### PR TITLE
fixed code samples and a broken link

### DIFF
--- a/docs/user-guide/introduction.md
+++ b/docs/user-guide/introduction.md
@@ -38,7 +38,7 @@ zLUX consists of the following components:
 
 - **Application plug-ins**
 
-    Several application-type plug-ins are provided. For more information, see [Using zLUX application plug-ins](usingmvd.html#using-zlux-application-plug-ins).
+    Several application-type plug-ins are provided. For more information, see [Using zLUX application plug-ins](usingzlux.html#using-zlux-application-plug-ins).
 
 ## Explorer server
 

--- a/docs/user-guide/mvd-errorreportingui.md
+++ b/docs/user-guide/mvd-errorreportingui.md
@@ -9,7 +9,7 @@ Ideally, a program should have little to no logic errors. Once in a while a few 
 ## ZluxPopupManagerService
 
 The `ZluxPopupManagerService` is a standard popup widget that can, through its `reportError()` method, be used to display errors with attributes that specify the title (or error code), severity, text, whether it should block the user from proceeding, whether it should output to the logger, and other options you want to add to the error dialog. `ZluxPopupManagerService` uses both `ZluxErrorSeverity` and `ErrorReportStruct`.
-
+```
 `export declare class ZluxPopupManagerService {`
 
     eventsSubject: any;
@@ -26,22 +26,22 @@ The `ZluxPopupManagerService` is a standard popup widget that can, through its `
     getLoggerSeverity(severity: ZluxErrorSeverity): any;
     reportError(severity: ZluxErrorSeverity, title: string, text: string, options?: any): Rx.Observable<any>;
 `}`
-
+```
 ## ZluxErrorSeverity
 
 `ZluxErrorSeverity` classifies the type of report. Under the popup-manager, there are the following types: error, warning, and information. Each type has its own visual style and the desired error or pop-up should be classified accordingly to accurately indicate the type of issue to the user.
-
+```
 `export declare enum ZluxErrorSeverity {`
 
     ERROR = "error",
     WARNING = "warning",
     INFO = "info",
 `}`
-
+```
 ## ErrorReportStruct
 
 `ErrorReportStruct` contains the main interface that brings the specified parameters of `reportError()` together.
-
+```
 `export interface ErrorReportStruct {`
 
     severity: string;
@@ -50,7 +50,7 @@ The `ZluxPopupManagerService` is a standard popup widget that can, through its `
     title: string;
     buttons: string[];
 `}`
-
+```
 ## Implementation
 
 Import `ZluxPopupManagerService` and `ZluxErrorSeverity` from widgets. If you are using additional services with your error prompt, import those too (for example, `LoggerService` to print to the logger or `GlobalVeilService` to create a visible semi-transparent gray veil over the program and pause background tasks). Here, widgets is imported from `node_modules\@zlux\` so you must ensure zLUX widgets is used in your `package-lock.json` or `package.json` and you have run `npm install`.
@@ -60,18 +60,18 @@ Import `ZluxPopupManagerService` and `ZluxErrorSeverity` from widgets. If you ar
 ### Declaration
 
 Create a member variable within the constructor of the class you want to use it for. For example, in the Workflow application plug-in under `\zlux-workflow\src\app\app\zosmf-server-config.component.ts` is a `ZosmfServerConfigComponent` class with the pop-up manager service variable. If you want to automatically report the error to the console, you must set a logger.
-
+```
 `export class ZosmfServerConfigComponent {`
 
     constructor(
     private popupManager: ZluxPopupManagerService, )
     {  popupManager.setLogger(logger); } //Optional
 `}`
-
+```
 ### Usage
 
 Now that you have declared your variable within the scope of your program's class, you are ready to use the method. The following example describes an instance of the `reload()` method in Workflow that catches an error when the program attempts to retrieve a configuration from a `configService` and set it to the program's `this.config`. This method fails when the user has a faulty zss-Server configuration and the error is caught and then sent to the class' `popupManager` variable from the constructor above.
-
+```
 `reload(): void {`
 
     this.globalVeilService.showVeil();
@@ -90,7 +90,7 @@ Now that you have declared your variable within the scope of your program's clas
           this.popupManager.reportError(ZluxErrorSeverity.ERROR, errorTitle.toString()+": "+err.status.toString(), errorMessage+"\n"+err.toString(), options);  
         });
 `}`
-
+```
 Here, the `errorMessage` clearly describes the error with a small degree of ambiguity as to account for all types of errors that might occur from that method. The specifics of the error are then generated dynamically and are printed with the `err.toString()`, which contains the more specific information that is used to pinpoint the problem. The `this.popupManager.report()` method triggers the error prompt to display. The error severity is set with `ZluxErrorSeverity.ERROR` and the `err.status.toString()` describes the status of the error (often classified by a code for example: `404`). The optional parameters in `options` specify that this error will block the user from interacting with the application plug-in until the error is closed or it until goes away on its own. `globalVeilService` is optional and is used to create a gray veil on the outside of the program when the error is caused. You must import `globalVeilService` separately (see `zlux-workflow` for more information).
 
 ### HTML

--- a/docs/user-guide/mvd-uribroker.md
+++ b/docs/user-guide/mvd-uribroker.md
@@ -5,7 +5,7 @@ The URI Broker is an object in the application plug-in web framework, which faci
 
 ## Accessing the URI Broker
 
-The URI Broker is accessible independent of other frameworks involved such as Angular, and is also accessible through iframe. This is because it is attached to a global when within the MVD. For more information, see [Desktop and window management](mvd-desktopandwindowmgt.md).
+The URI Broker is accessible independent of other frameworks involved such as Angular, and is also accessible through iframe. This is because it is attached to a global when within the MVD. For more information, see [Virtual desktop and window management](mvd-desktopandwindowmgt.md).
 Access the URI Broker through one of two locations:
 
 Natively:

--- a/docs/user-guide/mvd-zluxconfiguration.md
+++ b/docs/user-guide/mvd-zluxconfiguration.md
@@ -8,23 +8,23 @@ Follow these optional steps to configure the default connection to open for the 
 ### Setting up the TN3270 mainframe terminal application plug-in
 
 `_defaultTN3270.json` is a file in `tn3270-ng2/`, which is deployed during setup. Within this file, you can specify the following parameters to configure the terminal connection:
-    
+```    
       "host": <hostname>
       "port": <port>
       “security”: {
       type: <”telnet” or “tls”>
     }
-    
+```    
 ### Setting up the VT Terminal application plug-in
 
 `_defaultVT.json` is a file in `vt-ng2/`, which is deployed during setup. Within this file, you can specify the following parameters to configure the terminal connection:
- 
+``` 
     “host”:<hostname>
     “port”:<port>
     “security”: {
       type: <”telnet” or “ssh”>
     }
-    
+```    
 ## Configuring the zLUX Proxy Server and ZSS
 
 ### Configuration file
@@ -115,9 +115,9 @@ This topic describes application plug-ins that are defined in advance.
 
 In the configuration file, you can specify a directory that contains JSON files, which tell the server what application plug-in to include and where to find it on disk. The backend of these application plug-ins use the server's plug-in structure, so much of the server-side references to application plug-ins use the term *plug-in*.
 
-To include application plug-ins, define the location of the plug-ins directory in the configuration file, through the top-level attribute **pluginsDir**
+To include application plug-ins, define the location of the plug-ins directory in the configuration file, through the top-level attribute **pluginsDir**.
 
-**Note:** In this example, the directory for these JSON files is [/plugins](https://github.com/gizafoundation/zlux-example-server/tree/master/plugins). Yet, to separate configuration files from runtime files, the *zlux-example-server* repository copies the contents of this folder into `/deploy/instance/ZLUX/plugins`. So, the example configuration file uses the latter directory.
+**Note:** In this example, the directory for these JSON files is `/plugins`. Yet, to separate configuration files from runtime files, the `zlux-example-server` repository copies the contents of this folder into `/deploy/instance/ZLUX/plugins`. So, the example configuration file uses the latter directory.
 
 #### Plug-ins directory example
 ```


### PR DESCRIPTION
Fixed broken link to point to "usingzlux" topic

Accessing the uri broker link should say "virtual..."

in zlux config topic, removed old link (should just be a folder name).

Fix code samples in terminal config and error reporting topics