### PR TITLE
Fix prereq

### DIFF
--- a/docs/user-guide/cli-configuringcli.md
+++ b/docs/user-guide/cli-configuringcli.md
@@ -12,12 +12,12 @@ You can set the log level to adjust the level of detail that is written to log f
 
 | Environment Variable | Description | Values | Default |
 | ---------------------- | ----------- |------- | ------- |
-| `BRIGHTSIDE\_APP\_LOG\_LEVEL`        | Zowe CLI logging level            | Log4JS log levels (OFF, TRACE, DEBUG, INFO, WARN, ERROR, FATAL) | DEBUG   |
-| `BRIGHTSIDE\_IMPERATIVE\_LOG\_LEVEL` | Imperative CLI Framework logging level | Log4JS log levels (OFF, TRACE, DEBUG, INFO, WARN, ERROR, FATAL) | DEBUG   |
+| `ZOWE\_APP\_LOG\_LEVEL`        | Zowe CLI logging level            | Log4JS log levels (OFF, TRACE, DEBUG, INFO, WARN, ERROR, FATAL) | DEBUG   |
+| `ZOWE\_IMPERATIVE\_LOG\_LEVEL` | Imperative CLI Framework logging level | Log4JS log levels (OFF, TRACE, DEBUG, INFO, WARN, ERROR, FATAL) | DEBUG   |
 
-### Setting the .brightside directory
-You can set the location on your PC where Zowe CLI creates the *.brightside* directory, which contains log files, profiles, and plug-ins for the product:
+### Setting the .zowe directory
+You can set the location on your PC where Zowe CLI creates the *.zowe* directory, which contains log files, profiles, and plug-ins for the product:
 
 | Environment Variable | Description | Values | Default |
 | ---------------------- | ----------- | ------ | ------- |
-| `BRIGHTSIDE\_CLI\_HOME`  | Zowe CLI home directory location | Any valid path on your PC | Your PC default home directory |
+| `ZOWE\_CLI\_HOME`  | Zowe CLI home directory location | Any valid path on your PC | Your PC default home directory |

--- a/docs/user-guide/systemrequirements.md
+++ b/docs/user-guide/systemrequirements.md
@@ -191,13 +191,12 @@ Before you install Zowe CLI, make sure your system meets the following requireme
 
 ### Supported platforms
 
-You can install Zowe CLI on any Windows or Linux operating system. For more information about known issues and workarounds, see [Troubleshooting installing Zowe CLI](troubleshootinstall.html#troubleshooting-installing-zowe-cli).
+CA Brightside Community Edition is supported on any platform where Node.js 8.0 or 10 is available, including Windows, Linux, and Mac operating systems. For information about known issues and workarounds, see [Troubleshooting installing Zowe CLI](troubleshootinstall.html#troubleshooting-installing-zowe-cli).
 
 Zowe CLI is designed and tested to integrate with z/OSMF running on IBM z/OS Version 2.2 or later. Before you can use Zowe CLI to interact with the mainframe, system programmers must install and configure IBM z/OSMF in your environment.
 
 **Important!**
 
-- Zowe CLI is not officially supported on Mac computers. However, Zowe CLI *might* run successfully on some Mac computers.
 - Oracle Linux 6 is not supported.
 
 ### Free disk space
@@ -206,7 +205,7 @@ Zowe CLI requires approximately **100 MB** of free disk space. The actual quanti
 
 ### Prerequisite software
 
-***Important!*** The following prerequisites for Windows, Mac, and Linux are required if you are installing Zowe CLI from a local package. If you are installing Zowe CLI from Bintray registry, you only require Node.js and npm.
+The following prerequisites for Windows, Mac, and Linux are required if you are installing Zowe CLI from a local package. If you are installing Zowe CLI from Bintray registry, you only require Node.js and npm.
 
 **Note:** As a best practice, we recommend that you update Node.js regularly to the latest Long Term Support (LTS) version.
 


### PR DESCRIPTION
Update supported platforms - we support any OS that runs Node.js 8 or 10. 

Also corrected the names of the Zowe CLI environment variables. 