### PR TITLE
Vs code plugin

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -120,7 +120,8 @@ module.exports = {
             'mvd-using',
             'usingapis',
             'api-mediation-api-catalog',
-            'cli-usingcli'
+            'cli-usingcli',
+            'cli-vscodeplugin'
           ]
         },
         {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -120,8 +120,7 @@ module.exports = {
             'mvd-using',
             'usingapis',
             'api-mediation-api-catalog',
-            'cli-usingcli',
-            'cli-vscodeplugin'
+            'cli-usingcli'
           ]
         },
         {
@@ -146,7 +145,8 @@ module.exports = {
           children: [
             'cli-extending',
             'cli-installplugins',
-            'cli-cicsplugin'
+            'cli-cicsplugin',
+            'cli-vscodeplugin'
           ]
         }
       ],

--- a/docs/user-guide/Zowe_User_Guide.ditamap
+++ b/docs/user-guide/Zowe_User_Guide.ditamap
@@ -48,6 +48,7 @@ scope="local"/>
 <topicref format="md" href="usingapis.md" navtitle="Using APIs" scope="local"/>
 <topicref format="md" href="api-mediation-api-catalog.md" navtitle="Using API Catalog" scope="local"/>
 <topicref format="md" href="cli-usingcli.md" navtitle="Using Zowe CLI" scope="local"/>
+<topicref format="md" href="cli-vscode-plugin.md" navtitle="Using Visual Studio Code Extension for Zowe" scope="local"/>
 </chapter>
 <chapter format="md" href="mvd-extendingzlux.md" navtitle="Extending the Zowe Application Framework"
 scope="local">

--- a/docs/user-guide/Zowe_User_Guide.ditamap
+++ b/docs/user-guide/Zowe_User_Guide.ditamap
@@ -48,7 +48,7 @@ scope="local"/>
 <topicref format="md" href="usingapis.md" navtitle="Using APIs" scope="local"/>
 <topicref format="md" href="api-mediation-api-catalog.md" navtitle="Using API Catalog" scope="local"/>
 <topicref format="md" href="cli-usingcli.md" navtitle="Using Zowe CLI" scope="local"/>
-<topicref format="md" href="cli-vscode-plugin.md" navtitle="Using Visual Studio Code Extension for Zowe" scope="local"/>
+<topicref format="md" href="cli-vscodeplugin.md" navtitle="Using Visual Studio Code Extension for Zowe" scope="local"/>
 </chapter>
 <chapter format="md" href="mvd-extendingzlux.md" navtitle="Extending the Zowe Application Framework"
 scope="local">

--- a/docs/user-guide/cli-extending.md
+++ b/docs/user-guide/cli-extending.md
@@ -1,6 +1,10 @@
 # Extending Zowe CLI
 
-You can install plug-ins to extend the capabilities of Zowe CLI. Plug-ins add functionality to the product in the form of new command groups, actions, objects, and options. 
+You can install plug-ins to extend the capabilities of Zowe CLI. 
+
+Plug-ins CLI to third-party applications are also available, such as Visual Studio Code Extension for Zowe (powered by Zowe CLI).
+
+lug-ins add functionality to the product in the form of new command groups, actions, objects, and options. 
 
 **Important!** Plug-ins can gain control of your CLI application legitimately during the execution of every command. Install third-party plug-ins at your own risk. We make no warranties regarding the use of third-party plug-ins.
 
@@ -13,3 +17,9 @@ The following plug-ins are available:
 The Zowe CLI Plug-in for IBM CICS lets you extend Zowe CLI to interact with CICS programs and transactions. The plug-in uses the IBM CICS® Management Client Interface (CMCI) API to achieve the interaction with CICS. For more information, see CICS management client interface on the IBM Knowledge Center.
 
 For more information, see [CA Brightside Plug-in for IBM CICS](cli-cicsplugin.md).
+
+**VSCode Extension for Zowe** 
+
+The Visual Studio Code (VSCode) Extension for Zowe lets you interact with data sets that are stored on IBM z/OS mainframe. Install the extension directly to [VSCode](https://code.visualstudio.com/) to enable the extension within the GUI. You can explore data sets, view their contents, make changes, and upload the changes to the mainframe. For some users, it can be more convenient to interact with data sets through a GUI rather than using command-line interfaces or 3270 emulators. The extension is powered by Zowe CLI.
+
+For more information, see [VSCode Extension for Zowe](cli-vscodeplugin.md).

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -92,6 +92,7 @@ After you install and configure Zowe CLI, you can issue the `zowe --help` com
 **Note:** You might encounter problems when you attempt to install Zowe CLI depending on your operating system and environment. For more information and workarounds, see [Troubleshooting installing Zowe CLI](troubleshootinstall.html#troubleshooting-installing-zowe-cli).
 
 ## Creating a Zowe CLI profile
+
 Profiles are a Zowe CLI functionality that let you store configuration information for use on multiple commands. You can create a profile that contains your username, password, and connection details for a particular mainframe system, then reuse that profile to avoid typing it again on every command. You can switch between profiles to quickly target different mainframe subsystems.
 
 **Important\!** A `zosmf` profile is required to issue most Zowe CLI commands. The first profile that you create becomes your default profile. When you issue any command that requires

--- a/docs/user-guide/cli-vscodeplugin.md
+++ b/docs/user-guide/cli-vscodeplugin.md
@@ -16,7 +16,7 @@ Before you use the VSCode extension, meet the following prerequisites on your PC
 
   - [Install Zowe CLI](cli-installcli.md).
   
-  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with the mainframe. See [Creating a Zowe CLI Profile](cli-installcli#creating-a-zowe-cli-profile).
+  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with the mainframe. See [Creating a Zowe CLI Profile](cli-installcli.md#creating-a-zowe-cli-profile).
 
 ## Installing
 

--- a/docs/user-guide/cli-vscodeplugin.md
+++ b/docs/user-guide/cli-vscodeplugin.md
@@ -16,7 +16,7 @@ Before you use the VSCode extension, meet the following prerequisites on your PC
 
   - [Install Zowe CLI](cli-installcli.md).
   
-  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with the mainframe. See [Creating a Zowe CLI Profile](cli-installcli#).
+  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with the mainframe. See [Creating a Zowe CLI Profile](cli-installcli#creating-a-zowe-cli-profile).
 
 ## Installing
 

--- a/docs/user-guide/cli-vscodeplugin.md
+++ b/docs/user-guide/cli-vscodeplugin.md
@@ -1,4 +1,4 @@
-# Using VSCode Extension for Zowe
+# VSCode Extension for Zowe
 
 The Visual Studio Code (VSCode) Extension for Zowe lets you interact with data sets that are stored on IBM z/OS mainframe. Install the extension directly to [VSCode](https://code.visualstudio.com/) to enable the extension within the GUI. You can explore data sets, view their contents, make changes, and upload the changes to the mainframe. For some users, it can be more convenient to interact with data sets through a GUI rather than using command-line interfaces or 3270 emulators. The extension is powered by Zowe CLI.
 

--- a/docs/user-guide/cli-vscodeplugin.md
+++ b/docs/user-guide/cli-vscodeplugin.md
@@ -1,0 +1,39 @@
+# Using VSCode Extension for Zowe
+
+The Visual Studio Code (VSCode) Extension for Zowe lets you interact with data sets that are stored on IBM z/OS mainframe. Install the extension directly to [VSCode](https://code.visualstudio.com/) to enable the functionality within the GUI. You can explore data sets, view their contents, make changes, and upload the changes to the mainframe. For some users, it can be more convenient to interact with data sets through a GUI rather than using command-line interfaces or 3270 emulators. The extension is powered by Zowe CLI.
+
+**Note:** The primary documentation for this plug-in is available on the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe). This topic is intended to be an overview of the extension.
+
+  - [Prerequisites](#prerequisites)
+  - [Installing](#installing)
+  - [Use Cases](#use-cases)
+
+## Prerequisites
+
+Before you use the VSCode extension, meet the following prerequisites on your PC:
+
+  - Install [VSCode](https://code.visualstudio.com/).
+
+  - [Install Zowe CLI](cli-installcli.md).
+  
+  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with z/OSMF. See [Create a Profile](cli-create).
+
+## Installing
+
+1. Address [the prerequisites](#prerequisites)
+2. Open VSCode. Navigate to the **Extensions** tab on the left side of the UI.
+3. Click the green **Install** button to install the plug-in.
+4. Restart VSCode. The plug-in is now installed and available for use.
+
+**Tip:** For information about how to install the extension from a VSIX file and run system tests on the extension, see the Developer README file in the Zowe VSCode extension GitHub repository.
+
+## Use-Cases
+
+As an developer, you can use VSCode Extension for Zowe to perform the following tasks. 
+
+- View and filter mainframe data sets.
+- Create download, edit, upload, and delete PDS and PDS members.
+- Use "safe save" to compare changes and resolve conflicts when a data set is changed during your local editing. 
+- Switch between Zowe CLI profiles to 
+
+**Note:** For detailed step-by-step instructions for using the plug-in and more information about each feature, see [Zowe on the Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe).

--- a/docs/user-guide/cli-vscodeplugin.md
+++ b/docs/user-guide/cli-vscodeplugin.md
@@ -1,8 +1,8 @@
 # Using VSCode Extension for Zowe
 
-The Visual Studio Code (VSCode) Extension for Zowe lets you interact with data sets that are stored on IBM z/OS mainframe. Install the extension directly to [VSCode](https://code.visualstudio.com/) to enable the functionality within the GUI. You can explore data sets, view their contents, make changes, and upload the changes to the mainframe. For some users, it can be more convenient to interact with data sets through a GUI rather than using command-line interfaces or 3270 emulators. The extension is powered by Zowe CLI.
+The Visual Studio Code (VSCode) Extension for Zowe lets you interact with data sets that are stored on IBM z/OS mainframe. Install the extension directly to [VSCode](https://code.visualstudio.com/) to enable the extension within the GUI. You can explore data sets, view their contents, make changes, and upload the changes to the mainframe. For some users, it can be more convenient to interact with data sets through a GUI rather than using command-line interfaces or 3270 emulators. The extension is powered by Zowe CLI.
 
-**Note:** The primary documentation for this plug-in is available on the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe). This topic is intended to be an overview of the extension.
+**Note:** The primary documentation, for this plug-in is available on the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe). This topic is intended to be an overview of the extension.
 
   - [Prerequisites](#prerequisites)
   - [Installing](#installing)
@@ -16,11 +16,11 @@ Before you use the VSCode extension, meet the following prerequisites on your PC
 
   - [Install Zowe CLI](cli-installcli.md).
   
-  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with z/OSMF. See [Create a Profile](cli-installclil#creating-a-zowe-cli-profile).
+  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with the mainframe. See [Creating a Zowe CLI Profile](cli-installcli#).
 
 ## Installing
 
-1. Address [the prerequisites](#prerequisites)
+1. Address [the prerequisites](#prerequisites).
 2. Open VSCode. Navigate to the **Extensions** tab on the left side of the UI.
 3. Click the green **Install** button to install the plug-in.
 4. Restart VSCode. The plug-in is now installed and available for use.
@@ -33,7 +33,7 @@ As an developer, you can use VSCode Extension for Zowe to perform the following
 
 - View and filter mainframe data sets.
 - Create download, edit, upload, and delete PDS and PDS members.
-- Use "safe save" to compare changes and resolve conflicts when a data set is changed during your local editing. 
-- Switch between Zowe CLI profiles to 
+- Use "safe save" to safely resolve conflicts when a data set is changed during local editing. 
+- Switch between Zowe CLI profiles to quickly target different mainframe systems. 
 
 **Note:** For detailed step-by-step instructions for using the plug-in and more information about each feature, see [Zowe on the Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe).

--- a/docs/user-guide/cli-vscodeplugin.md
+++ b/docs/user-guide/cli-vscodeplugin.md
@@ -16,7 +16,7 @@ Before you use the VSCode extension, meet the following prerequisites on your PC
 
   - [Install Zowe CLI](cli-installcli.md).
   
-  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with z/OSMF. See [Create a Profile](cli-create).
+  - Create at least one Zowe CLI 'zosmf' profile so that the extension can communicate with z/OSMF. See [Create a Profile](cli-installclil#creating-a-zowe-cli-profile).
 
 ## Installing
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -82,7 +82,7 @@ With Zowe CLI, you can interact with z/OS remotely in the following ways:
   - **Produce responses as JSON documents:**    
     Return data in JSON format on request for consumption in other programming languages.
 
-For more information about the available functionality in Zowe CLI, see [Zowe CLI Command Groups](cli-usingcli.html#zowe-cli-command-groups).
+For detailed information about the available functionality in Zowe CLI, see [Zowe CLI Command Groups](cli-usingcli.html#zowe-cli-command-groups).
 
 For information about extending the functionality of Zowe CLI by installing plug-ins, see [Extending Zowe CLI](cli-extending.md).
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -10,7 +10,7 @@ Zowe consists of the following main components.
 
 - [**API Mediation Layer**](#api-mediation-layer): Provides an API abstraction layer through which APIs can be discovered, catalogued, and presented uniformly.
 
-- [**Zowe CLI**](#zowe-cli): Provides a command-line interface that lets you interact with the mainframe remotely and use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. It provides a set of utilities and services for application developers that want to become efficient in supporting and building z/OS applications quickly.
+- [**Zowe CLI**](#zowe-cli): Provides a command-line interface that lets you interact with the mainframe remotely and use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. It provides a set of utilities and services for application developers that want to become efficient in supporting and building z/OS applications quickly. Some Zowe extensions are powered by Zowe CLI, for example the [Visual Studio Code Extension for Zowe](cli-vscodeplugin.md).
 
 For details of each component, see the corresponding section.
 
@@ -63,8 +63,6 @@ Zowe CLI provides the following benefits:
   - Ensure that business critical applications running on z/OS can be maintained and supported by existing and generally available software development resources.
   - Provides a more streamlined way to build software that integrates with z/OS. 
 
-The following sections explain the key features and details for Zowe CLI:
-
 **Note:** For information about prerequisites, software requirements, installing and upgrading Zowe CLI, see
 [Installing Zowe](installandconfig.md).
 
@@ -85,6 +83,8 @@ With Zowe CLI, you can interact with z/OS remotely in the following ways:
     Return data in JSON format on request for consumption in other programming languages.
 
 For more information about the available functionality in Zowe CLI, see [Zowe CLI Command Groups](cli-usingcli.html#zowe-cli-command-groups).
+
+For information about extending the functionality of Zowe CLI by installing plug-ins, see [Extending Zowe CLI](cli-extending.md).
 
 ### Zowe CLI Third-Party software agreements
 

--- a/docs/user-guide/summaryofchanges.md
+++ b/docs/user-guide/summaryofchanges.md
@@ -72,6 +72,10 @@ Zowe CLI contains the following new features:
     - `zowe zos-jobs download output` command: Lets you download the complete spool output for a job to a local directory on your PC.
     - The `zowe zos-jobs submit data-set` command and the `zowe zos-jobs submit local-file` command now contain a `--view-all-spool-content` option. The option lets you submit a job and view its complete spool output in one command.
 
+- **Visual Studio Code Extension for Zowe**
+
+    The Visual Studio Code (VSCode) Extension for Zowe is now available. You can install the extension directly to Visual Studio Code to enable the extension within the UI. Using the extension you can data sets, view their contents, make changes, and upload the changes to the mainframe directly from the Visual Studio Code user interface. For more information, see [VSCode Extension for Zowe](cli-vscodeplugin.md). 
+
 #### New in API Mediation Layer
 
 API Mediation Layer Version 0.9.1 contains the following new functionality and features:

--- a/docs/user-guide/systemrequirements.md
+++ b/docs/user-guide/systemrequirements.md
@@ -195,9 +195,7 @@ CA Brightside Community Edition is supported on any platform where Node.js 8.0 o
 
 Zowe CLI is designed and tested to integrate with z/OSMF running on IBM z/OS Version 2.2 or later. Before you can use Zowe CLI to interact with the mainframe, system programmers must install and configure IBM z/OSMF in your environment.
 
-**Important!**
-
-- Oracle Linux 6 is not supported.
+**Important!** Oracle Linux 6 is not supported.
 
 ### Free disk space
 


### PR DESCRIPTION
- Introduce VSCode article cli-vscodeplugin.md
- Describe the extension in the parent topic cli-extending.md
- Parent topic now mentions that some extensions are not into the CLI, but built on the CLI
- Mention and links to topic in the Overview section, overview.md 
- Added to TOC in config.js, Extending Zowe CLI section
- Added to DITAMAP

Recommend a general content review. 