### PR TITLE
Add pre- and post-install verify script descriptions

### DIFF
--- a/docs/user-guide/install-zos.md
+++ b/docs/user-guide/install-zos.md
@@ -76,8 +76,17 @@ To install API Mediation Layer, the Zowe Application Framework, and explorer ser
         sshPort=22
         telnetPort=23
     ```
+3. Execute the `zowe-verify-pre-install.sh` script.
 
-3. Execute the `zowe-install.sh` script.
+    With the current directory being the `/install` directory, execute the script `zowe-verify-pre-install.sh` by issuing the following command:
+
+    ```
+    zowe-verify-pre-install.sh
+    ```
+
+    This script checks the basic pre-requisites for Zowe on your z/OS system before you install the Zowe runtime.  The script writes its messages to your terminal window.  The results will be marked `OK`, `Info`, `Warning` or `Error`.  Correct any reported errors and re-run the `zowe-verify-pre-install.sh` script before you run the `zowe-install.sh` script.  The `zowe-verify-pre-install.sh` script does not change any settings, so you can run it as often as required.
+
+4. Execute the `zowe-install.sh` script.
 
     With the current directory being the `/install` directory, execute the script `zowe-install.sh` by issuing the following command:
 
@@ -97,7 +106,7 @@ To install API Mediation Layer, the Zowe Application Framework, and explorer ser
     chmod u+x zowe-install.sh.
     ```
 
-4. Configure Zowe as a started task.
+5. Configure Zowe as a started task.
 
      The ZOWESVR must be configured as a started task (STC) under the IZUSVR user ID.
 
@@ -122,7 +131,7 @@ To install API Mediation Layer, the Zowe Application Framework, and explorer ser
         TSS ADDTO(STC) PROCNAME(ZOWESVR) ACID(IZUSVR)
         ```
 
-5. Add the users to the required groups, IZUADMIN for administrators and IZUUSER for standard users.
+6. Add the users to the required groups, IZUADMIN for administrators and IZUUSER for standard users.
 
      - If you use RACF, issue the following command:
 
@@ -217,6 +226,18 @@ You can obtain the _asid_ from the value of `A=asid` when you issue the followin
 ## Verifying installation
 
 After you complete the installation of API Mediation, Zowe Application Framework, and explorer server, use the following procedures to verify that the components are installed correctly and are functional.
+
+### Verifying Zowe configuration
+
+Once Zowe is running and the startup sequence is complete, navigate to the runtime `$ZOWE_ROOT_DIR/scripts` directory, where $ZOWE_ROOT_DIR is the location of the Zowe runtime directory that contains the explorer server.  
+
+Now run the `zowe-verify-post-install.sh` script by issuing the command
+
+```
+zowe-verify-post-install.sh
+```
+
+This script checks the configuration files and jobs for Zowe on your z/OS system.  The script writes its messages to your terminal window.  The results will be marked `OK`, `Info`, `Warning` or `Error`.  Correct any reported errors and re-start the Zowe server.  The `zowe-verify-post-install.sh` script does not change any settings, so you can run it as often as required.
 
 ### Verifying Zowe Application Framework installation
 

--- a/docs/user-guide/troubleshootinstall.md
+++ b/docs/user-guide/troubleshootinstall.md
@@ -26,7 +26,7 @@ Review the following troubleshooting tips if you have problems with Zowe install
 
 3. Changing Unix permissions
 
-    After the install script lay down the contents of the Zowe runtime into the `rootDir`, the next step is to set the file and directory permissions correctly to allow the Zowe runtime servers to start and operate successfully.
+    After the install script lays down the contents of the Zowe runtime into the `rootDir`, the next step is to set the file and directory permissions correctly to allow the Zowe runtime servers to start and operate successfully.
 
     The install process will execute the file `scripts/zowe-runtime-authorize.sh` in the Zowe runtime directory.  If the script is successful, the result is reported.  If for any reason the script fails to run because of insufficient authority by the user running the install, the install process reports the errors.  A user with sufficient authority should then run the `zowe-runtime-authorize.sh`.  If you attempt to start the Zowe runtime servers without the `zowe-runtime-authorize.sh` having successfully completed, the results are unpredictable and Zowe runtime startup or runtime errors will occur.  
 


### PR DESCRIPTION
1.  I added descriptions of the pre- and post-install verification scripts and how to use them.
2.  I fixed a typo in `troubleshootinstall.md`