### PR TITLE
fix link on home page 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ footer: Except where otherwise noted, content on this site is licensed under a C
     <p>Find out how to install, configure, and use Zowe Application Framework, explorer server, API Mediation Layer, and Zowe CLI.</p>
   </div>
   <div class="feature">
-    <h2><a href="./extend/extender-architecture.html">Extending</a></h2>
+    <h2><a href="./extend/extend-api/libertyAPI.html">Extending</a></h2>
     <p>Learn about onboarding your products. Developers can follow tutorials that teach how to build and extend Zowe components.</p>
   </div>
   <div class="feature">


### PR DESCRIPTION
"Extending" button on home page pointed to incomplete article. For now, I pointed it to the first topic under Extending. 