### PR TITLE
Renamed zlux-example-server and  zlux-proxy-server

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -107,7 +107,7 @@ const ALL_PAGES = [{
           'extend/extend-desktop/mvd-apptoappcommunication.md',
           'extend/extend-desktop/mvd-errorreportingui.md',
           'extend/extend-desktop/mvd-logutility.md',
-          'extend/extend-desktop/zlux-example-server.md',
+          'extend/extend-desktop/zlux-app-server.md',
           'extend/extend-desktop/zlux-workshop-user-browser.md',
           'extend/extend-desktop/zlux-tutorials.md',
           'extend/extend-desktop/starter-intro.md',

--- a/docs/extend/extend-desktop/mvd-configdataservice.md
+++ b/docs/extend/extend-desktop/mvd-configdataservice.md
@@ -4,7 +4,7 @@ The Configuration Dataservice is an essential component of the Zowe Application 
 
 The Configuration Dataservice allows for saving preferences of applications, management of defaults and privileges within a Zowe ecosystem, and bootstrapping configuration of the server's dataservices.
 
-The fundamental element of extensibility of the Zowe Application Framework is a plug-in. The Configuration Dataservice works with data for plug-ins. Every resource that is stored in the Configuration Service is stored for a particular plug-in, and valid resources to be accessed are determined by the definition of each plug-in in how it uses the Configuration Dataservice.
+The fundamental element of extensibility of the Zowe Application Framework is a *plug-in*. The Configuration Dataservice works with data for plug-ins. Every resource that is stored in the Configuration Service is stored for a particular plug-in, and valid resources to be accessed are determined by the definition of each plug-in in how it uses the Configuration Dataservice.
 
 The behavior of the Configuration Dataservice is dependent upon the Resource structure for a plug-in. Each plug-in lists the valid resources, and the administrators can set permissions for the users who can view or modify these resources.
 
@@ -24,21 +24,21 @@ Configuration defaults that come with the product. Cannot be modified.
 
 **Site**
 
-Data that can be used between multiple instances of the Zowe Application Server (zlux-proxy-server).
+Data that can be used between multiple instances of the Zowe Application Server.
 
 **Instance**
 
-Data within an individual Zowe Application Server (zlux-proxy-server).
+Data within an individual Zowe Application Server.
 
 **Group**
 
-Data that is shared between multiple users in a group.
+Data that is shared between multiple users in a group.(Pending)
 
 **User**
 
-Data for an individual user.
+Data for an individual user.(Pending)
 
-**Note:** While Authorization tuning can allow for settings such as GET from Instance to work without login, *User* and *Group* scope queries will be rejected if not logged in due to the requirement to pull resources from a specific user. Because of this, *User* and *Group* scopes will not be functional until the Security Framework is available.
+**Note:** While Authorization tuning can allow for settings such as GET from Instance to work without login, *User* and *Group* scope queries will be rejected if not logged in due to the requirement to pull resources from a specific user. Because of this, *User* and *Group* scopes will not be functional until the Security Framework is merged into the mainline.
 
 Where *Product* is the broadest scope and *User* is the narrowest scope.
 
@@ -72,8 +72,11 @@ Get or put a single element rather than a collection.
 
 **Recursive** (boolean) 
 
-When performing a DELETE, specifies whether to delete subresources.
+When performing a DELETE, specifies whether to delete subresources too.
 
+**Listing** (boolean) 
+
+When performing a GET against a resource with content subresources, `listing=true` will provide the names of the subresources rather than both the names and contents.
 
 ### REST HTTP methods
 
@@ -239,7 +242,7 @@ The JSON contents within these directories are provided as Objects to dataservic
 
 Because the Configuration Dataservices stores data on a per-plug-in basis, each plug-in must define their resource structure to make use of the Configuration Dataservice. The resource structure definition is included in the plug-in's `pluginDefinition.json` file.
 
-For each resource and subresource, you can define an `aggregationPolicy` to control how the data of a broader scope alters the resource data that is returned to a user when requesting a resource from a narrower scope.
+For each resource and subresource, you can define an `aggregationPolicy` to control how the data of a broader scope alters the resource data that is returned to a user when requesting a resource from a narrower Scope.
 
 For example:
 ```
@@ -273,4 +276,5 @@ The following policies are currently implemented:
 * **NONE**: If the Configuration Dataservice is called for *Scope User*, only user-saved settings are sent, unless there are no user-saved settings for the query, in which case the dataservice attempts to send data that is found at a broader scope.
 
 * **OVERRIDE**: The Configuration Dataservice obtains data for the resource that is requested at the broadest level found, and joins the resource's properties from narrower scopes, overriding broader attributes with narrower ones, when found.
+
 

--- a/docs/extend/extend-desktop/mvd-creatingappplugins.md
+++ b/docs/extend/extend-desktop/mvd-creatingappplugins.md
@@ -20,7 +20,7 @@ If nothing is returned from the command, you can set the PATH using the *NODE_HO
 export NODE_HOME=node_installation_directory
 ```
 
-Using this directory, the node will be included on the PATH in `nodeServer.sh`. (`nodeServer.sh` is located in `zlux-example-server/bin`). 
+Using this directory, the node will be included on the PATH in `nodeServer.sh`. (`nodeServer.sh` is located in `zlux-app-server/bin`). 
 
 ## Using the sample application plug-in
 

--- a/docs/extend/extend-desktop/mvd-dataservices.md
+++ b/docs/extend/extend-desktop/mvd-dataservices.md
@@ -78,7 +78,7 @@ Here, the express-ws package is used, which adds websockets through the ws packa
 
 See the ws and express-ws topics on [www.npmjs.com](https://www.npmjs.com) for more information about how they work, as the API for websocket router dataservices is primarily provided in these packages.
 
-An example is available in `zlux-proxy-server/plugins/terminal-proxy/lib/terminalProxy.js`
+An example is available in `zlux-server-framework/plugins/terminal-proxy/lib/terminalProxy.js`
 
 #### Router dataservice context
 

--- a/docs/extend/extend-desktop/mvd-plugindefandstruct.md
+++ b/docs/extend/extend-desktop/mvd-plugindefandstruct.md
@@ -1,6 +1,6 @@
 # Plug-ins definition and structure
 
-The Zowe Application Server (`zlux-proxy-server`) enables extensiblity with application plug-ins. Application plug-ins are a subcategory of the unit of extensibility in the server called a *plug-in*.
+The Zowe Application Server (`zlux-server-framework`) enables extensiblity with application plug-ins. Application plug-ins are a subcategory of the unit of extensibility in the server called a *plug-in*.
 
 The files that define a plug-in are located in the `pluginsDir` directory. 
 
@@ -35,7 +35,7 @@ At runtime, the following set of directories are used by the server and client.
 
 #### lib
 
-The `lib` directory is where router-type dataservices are loaded by use in the Zowe Application Server. If the JS files that are loaded from the `lib` directory require NodeJS modules, which are not provided by the server base (the modules `ZLUX-proxy-server` requires are added to `NODE_PATH` at runtime), then you must include these modules in `lib/node_modules` for local directory lookup or ensure that they are found on the `NODE_PATH` environment variable. `nodeServer/node_modules` is not automatically accessed at runtime because it is a dev and build directory.
+The `lib` directory is where router-type dataservices are loaded by use in the Zowe Application Server. If the JS files that are loaded from the `lib` directory require NodeJS modules, which are not provided by the server base (the modules `zlux-server-framework` requires are added to `NODE_PATH` at runtime), then you must include these modules in `lib/node_modules` for local directory lookup or ensure that they are found on the `NODE_PATH` environment variable. `nodeServer/node_modules` is not automatically accessed at runtime because it is a dev and build directory.
 
 #### web
 
@@ -51,7 +51,7 @@ At startup, the server reads from the `pluginsDir` directory. The server loads t
 
 Within the `pluginsDir` directory are a collection of JSON files. Each file has two attributes, which serve to locate a plug-in on disk:
 
-**location**: This is a directory path that is relative to the server's executable (such as `zlux-example-server/bin/nodeServer.sh`) at which a `pluginDefinition.json` file is expected to be found.
+**location**: This is a directory path that is relative to the server's executable (such as `zlux-app-server/bin/nodeServer.sh`) at which a `pluginDefinition.json` file is expected to be found.
 
 **identifier**: The unique string (commonly styled as a Java resource) of a plug-in, which must match what is in the `pluginDefinition.json` file.
 

--- a/docs/extend/extend-desktop/react-sample.md
+++ b/docs/extend/extend-desktop/react-sample.md
@@ -25,7 +25,7 @@ Make sure that you first expose an API to connect to before following the steps 
     - If you are using the sample, this is included within the project. Copy to `Desktop/<Your_Project_Name>/`
 6.  Copy the project from `/Desktop` to `<zowe_base>/`
     - Use `scp <userID>@<server> /Users/path/to/files <zowe_base>/`
-7.  Create a new file within the plugins folder (`<zowe_base>/zlux-example-server-plugins`) called `com.<Your_Project_Name>.json`
+7.  Create a new file within the plugins folder (`<zowe_base>/zlux-app-server-plugins`) called `com.<Your_Project_Name>.json`
     - `touch com.<Your_Project_Name>.json`
 8.  Edit this folder (using vi) to read:
 
@@ -42,11 +42,11 @@ Make sure that you first expose an API to connect to before following the steps 
 
 ## Verify the Install
 
-Upon restarting the server, navigate to the Zowe Application Server (zlux-proxy-server).
+Upon restarting the server, navigate to the Zowe Application Server.
 
-- This can be found at: `https://<base>:<port>/ZLUX/plugins/com.rs.mvd/web/`
+- This can be found at: `https://<base>:<port>/ZLUX/plugins/org.zowe.zlux.bootstrap/web/`
 
-Make sure that your new plugin was added and that it is able to interact with the server.
+Make sure that your new plug-in was added and that it can interact with the server.
 
 If it is not able to interact with the server and you are getting CORS errors, you might need to update the server to accept all connections.
 
@@ -57,7 +57,7 @@ Note: This is for development purposes only.
 To update the server:
 
 - Navigate to `<zowe-base>/explorer-server/wlp/usr/servers/Atlas/server.xml`
-- Open to the file with vi and paste the following code in.
+- Open to the file with vi and paste in the following code.
 
 ```javascript
 <!-- FOR TESTING ONLY -->

--- a/docs/extend/extend-desktop/zlux-app-server.md
+++ b/docs/extend/extend-desktop/zlux-app-server.md
@@ -1,10 +1,10 @@
 # Stand up a local version of the Example Zowe Application Server
 
-`zlux-example-server` is an example of a server built upon the application framework. Within the repository, you will find a collection of build, deploy, and run scripts and configuration files that will help you to configure a simple Zowe Application Server with a few applications included.
+The `zlux-app-server` repository is an example of a server built upon the application framework. Within the repository, you will find a collection of build, deploy, and run scripts and configuration files that will help you to configure a simple Zowe Application Server with a few applications included.
 
 ## Server layout
 
-At the core of the application infrastructure backend is an extensible server, written for nodeJS and utilizing expressJS for routing. It handles the backend components of an application, and can serve as a proxy for requests from applications to additional servers, as needed. One such proxy destination is the ZSS - the Zowe Application Framework backend component for **Z Secure Services**. If you want to set up a Zowe Application Framework installation, contact Rocket to obtain the ZSS binary to use in the installation process.
+At the core of the application infrastructure backend is an extensible server, written for nodeJS and utilizing expressJS for routing. It handles the backend components of an application, and can serve as a proxy for requests from applications to additional servers, as needed. One such proxy destination is the ZSS, the Zowe Application Framework backend component for **Z Secure Services**, a so called agent for the Zowe Application Server. If you want to set up a Zowe Application Framework installation, contact Rocket to obtain the ZSS binary to use in the installation process.
 
 ### ZSS and Zowe Application Server overlap
 
@@ -46,11 +46,11 @@ cd zlux-build
 ```
 
 At this point, you have the latest code from each repository on your system.
-Continue from within `zlux-example-server`.
+Continue from within `zlux-app-server`.
 
 ### 2. Acquire external components
 
-Application plug-ins and external servers can require contents that are not in the Zowe github repositories. In the case of the `zlux-example-server`, there is a a ZSS binary component which cannot be found in the repositories. To obtain the ZSS binary component, contact Rocket.
+Applications and external servers can require contents that are not in the Zowe github repositories. In the case of the `zlux-app-server`, there is a a ZSS binary component which cannot be found in the repositories. To obtain the ZSS binary component, contact the Zowe project.
 
 After you obtain the ZSS binary component, you should receive _zssServer_.
 This must be placed within _zlux-build/externals/Rocket_, on the z/OS host.
@@ -66,7 +66,7 @@ mv zssServer externals/Rocket
 
 ### 3. Set the server configuration
 
-Read the [Configuration](https://github.com/zowe/zlux/wiki/Configuration-for-zLUX-Proxy-Server-&-ZSS) wiki page for a detailed explanation of the primary items that you will want to configure for your first server.
+Read the [Configuration](https://github.com/zowe/zlux/wiki/Configuration-for-zLUX-App-Server-&-ZSS) wiki page for a detailed explanation of the primary items that you will want to configure for your first server.
 
 In short, ensure that within the `config/zluxserver.json` file, **node.http.port** or **node.https.port** and the other HTTPS parameters are set to your liking on the LUW host, and that **zssPort** is set on the z/OS host.
 
@@ -82,8 +82,7 @@ Application plug-ins can contain server and web components. The web components m
 
 This example server only needs transpilation and packaging of web components, and therefore we do not need any special build steps for the host running ZSS.
 
-Instead, on the host running the Zowe Application Server, run the script that will automatically build all included application plug-ins.
-Under `zlux-build` run,
+Instead, on the host that runs the Zowe Application Server, run the script that will automatically build all included application plug-ins. Simply,
 
 ```
 //Windows
@@ -99,7 +98,7 @@ _Note: You will need to have `ant` and `ant-contrib` installed_
 
 ### 5. Deploy server configuration files
 
-If you are running the Zowe Application Server separate from ZSS, ensure the ZSS installation configuration is deployed. You can accomplish this by navigating to `zlux-build` and running the following:
+If you are running the Zowe Application Server separate from ZSS, ensure the ZSS installation configuration is deployed. You can accomplish this through:
 
 ```
 ant deploy
@@ -115,19 +114,19 @@ At this point, all server files have been configured and the application plug-in
 First, from the z/OS system, start ZSS.
 
 ```
-cd ../zlux-example-server/bin
+cd ../zlux-app-server/bin
 ./zssServer.sh
 ```
 
 If the zssServer server did not start, two common sources of error are:
 
 1. The _zssPort_ chosen is already occupied. To fix this, edit _config/zluxserver.json_ to choose a new one, and re-run _build/deploy.sh_ to make the change take effect.
-2. The zssServer binary does not have the APF bit set. Because this server is meant for secure services, it is required. To fix this, execute `extattr +a zssServer`. Note that you might need to alter the execute permissions of `zssServer.sh` in the event that the previous command is not satisfactory (for example: chmod +x zssServer.sh)
+2. The zssServer binary does not have the APF bit set. Because this server is meant for secure services, it is required. To fix this, execute `extattr +a zssServer`. Note that you might need to alter the execute permissions of `zssServer.sh` in the event that the previous command is not satisfactory (for example: `chmod +x zssServer.sh`)
 
 Second, from the system with the Zowe Application Server, start it with a few parameters to hook it to ZSS.
 
 ```
-cd ../zlux-example-server/bin
+cd ../zlux-app-server/bin
 
 // Windows:
 nodeServer.bat <parameters>
@@ -162,20 +161,23 @@ When the Zowe Application Server has started, one of the last messages you will 
 ### 7. Connect in a browser
 
 Now that ZSS and the Zowe Application Server are both started, you can access this instance by pointing your web browser to the Zowe Application Server.
-In this example, the address you will want to go to first is the location of the window management application - Zowe Desktop. The URL is:
+In this example, the address you will want to go to first is the location of the window management application: the Zowe Desktop. The URL is:
 
-`http(s)://\<zLUX Proxy Server\>:\<node.http(s).port\>/ZLUX/plugins/com.rs.mvd/web/index.html`
+`http(s)://<zLUX App Server>:<node.http(s).port>/ZLUX/plugins/org.zowe.zlux.bootstrap/web/index.html`
 
-Once here, a Login window is presented with a few example application plug-ins in the taskbar at the bottom of the window. To try the application plug-ins to see how they interact with the framework, can login with your mainframe credentials.
+Once here, a Login window opens with a few example application plug-ins in the taskbar at the bottom of the window. To try the application plug-ins to see how they interact with the framework, can login with your mainframe credentials.
 
 - tn3270-ng2: This application communicates with the Zowe Application Server to enable a TN3270 connection in the browser.
-- subsystems: This application shows various z/OS subsystems installed on the host the ZSS runs on. This is accomplished through discovery of these services by the application's portion running in the ZSS context.
-- sample-app: A simple app that shows how a Zowe Application Framework application frontend (Angular) component can communicate with an application backend (REST) component.
+- z/OS Subsystems: This application shows various z/OS subsystems installed on the host the ZSS runs on. This is accomplished through discovery of these services by the application's portion running in the ZSS context.
+- sample-angular-app: A simple app that show how a zLUX application frontend (here, Angular) component can communicate with an App backend (REST) component.
+- sample-react-app: Similar to the Angular application, but using React instead to show how you have the flexibility to use a framework of your choice.
+- sample-iframe-app: Similar in functionality to the Angular and React sample application, but presented by means of inclusion of an iframe, to show that pre-existing pages can be included.
+
 
 #### Deploy example
 
 ```
-// All paths relative to zlux-example-server/js or zlux-example-server/bin
+// All paths relative to zlux-app-server/js or zlux-app-server/bin
 // In real installations, these values will be configured during the install.
   "rootDir":"../deploy",
   "productDir":"../deploy/product",
@@ -192,12 +194,12 @@ In the configuration file, a directory can be specified which contains JSON file
 
 To include application plug-ins, be sure to define the location of the `Plugins` directory in the configuration file, through the top-level attribute _pluginsDir_
 
-**NOTE:** In this repository, the directory for these JSON files is `/plugins`. To separate configuration files from runtime files, the `zlux-example-server` repository copies the contents of this folder into `/deploy/instance/ZLUX/plugins`. So, the example configuration file uses the latter directory.
+**NOTE:** In this repository, the directory for these JSON files is `/plugins`. To separate configuration files from runtime files, the `zlux-app-server` repository copies the contents of this folder into `/deploy/instance/ZLUX/plugins`. So, the example configuration file uses the latter directory.
 
 #### Plugins directory example
 
 ```
-// All paths relative to zlux-example-server/js or zlux-example-server/bin
+// All paths relative to zlux-app-server/js or zlux-app-server/bin
 // In real installations, these values will be configured during the install.
 //...
   "pluginsDir":"../deploy/instance/ZLUX/plugins",
@@ -205,7 +207,7 @@ To include application plug-ins, be sure to define the location of the `Plugins`
 
 ### ZSS Configuration
 
-Running ZSS requires a JSON configuration file that is similar (or the same as) the one used for the Zowe Application Server. The attributes that are needed for ZSS, at minimum, are:_rootDir_, _productDir_, _siteDir_, _instanceDir_, _groupsDir_, _usersDir_, _pluginsDir_ and **zssPort**. All of these attributes have the same meaning as described above for the Zowe Application Server, but if the Zowe Application Server and ZSS are not run from the same location, then these directories can be different.
+Running ZSS requires a JSON configuration file that is similar or the same as the one used for the Zowe Application Server. The attributes that are needed for ZSS, at minimum, are:_rootDir_, _productDir_, _siteDir_, _instanceDir_, _groupsDir_, _usersDir_, _pluginsDir_ and **zssPort**. All of these attributes have the same meaning as described above for the Zowe Application Server, but if the Zowe Application Server and ZSS are not run from the same location, then these directories can be different.
 
 The **zssPort** attribute is specific to ZSS. This is the TCP port on which ZSS will listen to be contacted by the Zowe Application Server. Define this port in the configuration file as a value between 1024-65535.
 

--- a/docs/extend/extend-desktop/zlux-workshop-user-browser.md
+++ b/docs/extend/extend-desktop/zlux-workshop-user-browser.md
@@ -1,6 +1,6 @@
 # Create a User Database Browser application on the Zowe Application Framework
 
-This tutorial contains code snippets and descriptions that you can combine to build a complete app. It builds off the project skeleton code found at the [github project repo](https://github.com/zowe/workshop-user-browser-app).
+This tutorial contains code snippets and descriptions that you can combine to build a complete application. It builds off the project skeleton code found at the [github project repo](https://github.com/zowe/workshop-user-browser-app).
 
 By the end of this tutorial, you will:
 
@@ -14,7 +14,7 @@ By the end of this tutorial, you will:
 :::warning
 Before continuing, make sure you have completed the prerequisites for this tutorial:
 
-- Setup up the [zlux-example-server locally](./zlux-example-server.md).
+- Setup up the [zlux-app-server locally](./zlux-app-server.md).
   :::
 
 So, let's get started!
@@ -71,7 +71,7 @@ The file should contain the following:
 }
 ```
 
-A description of the particular values that are placed into this file can be found [on the wiki](https://github.com/zowe/zlux/wiki/Zlux-Plugin-Definition-&-Structure).
+A description of the values that are placed into this file can be found [on the wiki](https://github.com/zowe/zlux/wiki/Zlux-Plugin-Definition-&-Structure).
 
 Note the following attributes:
 
@@ -85,7 +85,7 @@ Note the following attributes:
 
 ### Constructing a Simple Angular UI
 
-Angular application plug-ins for Zowe are structured such that the source code exists within `webClient/src/app`. In here, you can create modules, components, templates and services in whatever hierarchy desired. For the application plug-in we are making here however, we will add three files:
+Angular application plug-ins for Zowe are structured such that the source code exists within `webClient/src/app`. In here, you can create modules, components, templates and services in any hierarchy. For the application plug-in we are creating however, we will add three files:
 
 - userbrowser.module.ts
 - userbrowser-component.html
@@ -187,7 +187,7 @@ At this time, we've made the source for a Zowe application plug-in that should o
 Before we're ready to use it however, we must transpile the typescript and package the application plug-in. This will require a few build tools first. We'll make an NPM package in order to facilitate this.
 
 Let's create a `package.json` file within `workshop-user-browser-app/webClient`.
-While a package.json can be created through other means such as `npm init` and packages can be added through commands such as `npm install --save-dev typescript@2.9.0`, we'll opt to save time by just pasting these contents in:
+While a `package.json` can be created through other means such as `npm init` and packages can be added through commands such as `npm install --save-dev typescript@2.9.0`, we'll opt to save time by just pasting these contents in:
 
 ```json
 {
@@ -233,32 +233,24 @@ While a package.json can be created through other means such as `npm init` and p
 }
 ```
 
-Before we can build, we first need to tell our system where our example server is located. While we could provide the explicit path to our server in our project, creating an environmental variable with this location will speed up future projects.
-
-To add an environmental variable on a Unix based machine:
-
-1. `cd ~`
-2. `nano .bash_profile`
-3. Add `export MVD_DESKTOP_DIR=/Users/<user-name>/path/to/zlux/zlux-app-manager/virtual-desktop/`
-4. Save and exit
-5. `source ~/.bash_profile`
-
 Now we are ready to build.
+
 Let's set up our system to automatically perform these steps every time we make updates to the application plug-in.
 
-1. Open a command prompt to `workshop-user-browser-app/webClient`
-1. Execute `npm install`
-1. Execute `npm run-script start`
+1. Open a command prompt to `workshop-user-browser-app/webClient`.
+2. Set the environment variable `MVD_DESKTOP_DIR` to the location of zlux-app-manager/virtual-desktop. For example, set `MVD_DESKTOP_DIR=../../zlux-app-manager/virtual-desktop`. This is needed whenever building individual application web code due to the core configuration files being located in virtual-desktop.
+1. Execute `npm install`.
+1. Execute `npm run-script start`.
 
 After the first execution of the transpilation and packaging concludes, you should have `workshop-user-browser-app/web` populated with files that can be served by the Zowe Application Server.
 
 ### Adding Your application plug-in to the Zowe Desktop
 
-At this point, your workshop-user-browser-app folder contains files for an application plug-in that could be added to a Zowe instance. We will add this to our own Zowe instance. First, ensure that the Zowe Application Server is not running. Then, navigate to the instance's root folder, `/zlux-example-server`.
+At this point, your workshop-user-browser-app folder contains files for an application plug-in that could be added to a Zowe instance. We will add this to our own Zowe instance. First, ensure that the Zowe Application Server is not running. Then, navigate to the instance's root folder, `/zlux-app-server`.
 
-Within, you'll see a folder, `plugins`. Take a look at one of the files within the folder. You can see that these are JSON files with the attributes **identifier** and **pluginLocation**. These files are what we call **Plugin Locators**, since they point to a plug-in to be included into the server.
+Within, you'll see a folder, `plugins`. Take a look at one of the files in the folder. You can see that these are JSON files with the attributes **identifier** and **pluginLocation**. These files are what we call **Plugin Locators**, since they point to a plug-in to be included into the server.
 
-Let's make one ourselves. Make a file `/zlux-example-server/plugins/org.openmainframe.zowe.workshop-user-browser.json`, with these contents:
+Let's make one ourselves. Make a file `/zlux-example-server/plugins/org.openmainframe.zowe.workshop-user-browser.json`, with the following contents:
 
 ```json
 {
@@ -267,7 +259,7 @@ Let's make one ourselves. Make a file `/zlux-example-server/plugins/org.openmain
 }
 ```
 
-When the server runs, it will check for these types of files in its `pluginsDir`, a location known to the server through its specification in the [server configuration file](https://github.com/zowe/zlux/wiki/Configuration-for-zLUX-Proxy-Server-&-ZSS#app-configuration). In our case, this is `/zlux-example-server/deploy/instance/ZLUX/plugins/`.
+When the server runs, it will check for these types of files in its `pluginsDir`, a location known to the server through its specification in the server configuration file. In our case, this is `/zlux-app-server/deploy/instance/ZLUX/plugins/`.
 
 You could place the JSON directly into that location, but the recommended way to place content into the deploy area is through running the server deployment process.
 Simply:
@@ -277,10 +269,10 @@ Simply:
 
 Now you're ready to run the server and see your application plug-in.
 
-1. `cd /zlux-example-server/bin`
-1. `./nodeServer.sh`
-1. Open your browser to `https://hostname:port`
-1. Login with your credentials
+1. `cd /zlux-example-server/bin`.
+1. `./nodeServer.sh`.
+1. Open your browser to `https://hostname:port`.
+1. Login with your credentials.
 1. Open the application plug-in on the bottom of the page with the green 'U' icon.
 
 Do you see the Hello World message from [this earlier step?](#constructing-a-simple-angular-ui). If so, you're in good shape! Now, let's add some content to the application plug-in.
@@ -289,7 +281,7 @@ Do you see the Hello World message from [this earlier step?](#constructing-a-sim
 
 An application plug-in can have one or more [Dataservices](https://github.com/zowe/zlux/wiki/ZLUX-Dataservices). A Dataservice is a REST or Websocket endpoint that can be added to the Zowe Application Server.
 
-To demonstrate the use of a Dataservice, we'll add one to this application plug-in. The application plug-in needs to display a list of users, filtered by some value. Ordinarily, this sort of data would be contained within a database, where you can obtain rows in bulk and filter them in some manner. Retrieval of database contents, likewise, is a task that is easily representable through a REST API, so let's make one.
+To demonstrate the use of a Dataservice, we'll add one to this application plug-in. The application plug-in needs to display a list of users, filtered by some value. Ordinarily, this sort of data would be contained within a database, where you can get rows in bulk and filter them in some manner. Retrieval of database contents, likewise, is a task that is easily representable through a REST API, so let's make one.
 
 1. Create a file, `workshop-user-browser-app/nodeServer/ts/tablehandler.ts`
    Add the following contents:
@@ -372,7 +364,7 @@ function respondWithRows(rows: Array<Array<string>>, res: Response): void {
 Because we reference the usertable file through import, we are able to refer to its **metadata** and **columns** attributes here.
 This **`respondWithRows`** function expects an array of rows, so we'll improve the Router to call this function with some rows so that we can present them back to the user.
 
-2. Update the **UserTableDataservice** constructor, modifying and expanding upon the Router
+2. Update the **UserTableDataservice** constructor, modifying and expanding upon the Router.
 
 ```typescript
   constructor(context: any){
@@ -408,10 +400,10 @@ This REST API now allows for two GET calls to be made: one to root /, and the ot
 
 Now that the Dataservice is made, add it to our Plugin's definition so that the server is aware of it, and then build it so that the server can run it.
 
-1. Open a (third) command prompt to `workshop-user-browser-app/nodeServer`
-1. Install dependencies, `npm install`
-1. Invoke the NPM build process, `npm run-script start`
-   1. If there are errors, go back to [building the dataservice](#building-your-first-dataservice) and make sure the files look correct.
+1. Open a (third) command prompt to `workshop-user-browser-app/nodeServer`.
+1. Install dependencies, `npm install`.
+1. Invoke the NPM build process, `npm run-script start`.
+   1. If there are errors, go back to [building the dataservice].(#building-your-first-dataservice) and make sure the files look correct.
 1. Edit `workshop-user-browser-app/pluginDefinition.json`, adding a new attribute which declares Dataservices.
 
 ```json
@@ -423,6 +415,7 @@ Now that the Dataservice is made, add it to our Plugin's definition so that the 
       "fileName": "tablehandler.js",
       "routerFactory": "tableRouter",
       "dependenciesIncluded": true
+      "version": "1.0.0"
     }
 ],
 ```
@@ -443,6 +436,7 @@ Your full pluginDefinition.json should now be:
       "fileName": "tablehandler.js",
       "routerFactory": "tableRouter",
       "dependenciesIncluded": true
+      "version": "1.0.0"
     }
   ],
   "webContent": {
@@ -465,7 +459,7 @@ Your full pluginDefinition.json should now be:
 
 There's a few interesting attributes about the Dataservice we have specified here. First is that it is listed as `type: router`, which is because there are different types of Dataservices that can be made to suit the need. Second, the **name** is **table**, which determines both the name seen in logs but also the URL this can be accessed at. Finally, **fileName** and **routerFactory** point to the file within `workshop-user-browser-app/lib` where the code can be invoked, and the function that returns the ExpressJS Router, respectively.
 
-4. [Restart the server](#adding-your-app-to-the-desktop) (as was done when adding the App initially) to load this new Dataservice. This is not always needed but done here for educational purposes.
+4. [Restart the server](#adding-your-app-to-the-desktop) (as was done when adding the application initially) to load this new Dataservice. This is not always needed but done here for educational purposes.
 5. Access `https://host:port/ZLUX/plugins/org.openmainframe.zowe.workshop-user-browser/services/table/` to see the Dataservice in action. It should return all of the rows in the user table, as you did a GET to the root / URL that we just coded.
 
 ## Adding your first Widget
@@ -536,7 +530,7 @@ Hopefully you are still running the command in the first command prompt, `npm ru
 
 ### Introducing ZLUX Grid
 
-When **ngOnInit** runs, it will call out to the REST Dataservice and put the table row results into our cache, but we haven't yet visualized this in any way. We need to improve our HTML a bit to do that, and rather than reinvent the wheel, we have a table visualization library we can rely on - **ZLUX Grid**.
+When **ngOnInit** runs, it will call out to the REST Dataservice and put the table row results into our cache, but we haven't yet visualized this in any way. We need to improve our HTML a bit to do that, and rather than reinvent the wheel, we have a table visualization library we can rely on: **ZLUX Grid**.
 
 If you inspect `package.json` in the **webClient** folder, you'll see that we've already included @zlux/grid as a dependency (as a link to one of the Zowe github repositories) so it should have been pulled into the **node_modules** folder during the `npm install` operation. We just need to include it in the Angular code to make use of it. To do so, complete these steps:
 
@@ -612,9 +606,9 @@ export class UserBrowserModule { }
 
 Note the key functions of this template:
 
-- There's a button which when clicked will submit selected users (from the grid). We will implement this ability later.
-- We show or hide the grid based on a variable `ngIf="showGrid"` so that we can wait to show the grid until there is data to present
-- The zlux-grid tag pulls the Zowe Application Framework Grid widget into our application, and it has many variables that can be set for visualization, as well as functions and modes.
+- There is a button which when clicked will submit selected users (from the grid). We will implement this ability later.
+- We show or hide the grid based on a variable `ngIf="showGrid"` so that we can wait to show the grid until there is data to present.
+- The zlux-grid tag pulls the ZLUX Grid widget into our application, and it has many variables that can be set for visualization, as well as functions and modes.
   - We allow the columns, rows, and metadata to be set dynamically by using the square bracket [ ] template syntax, and allow our code to be informed when the user selection of rows changes through `(selectionChange)="onTableSelectionChange($event)"`
 
 3. Small modification to **userbrowser-component.ts** to add the grid variable, and set up the aforementioned table selection event listener, both within the **UserBrowserComponent** Class:
@@ -627,7 +621,7 @@ onTableSelectionChange(rows: any[]):void{
 }
 ```
 
-The previous section, [Adding your Dataservice to the application](#adding-your-dataservice-to-the-app) set the variables that are fed into the Zowe Application Framework Grid widget, so at this point the application should be updated with the ability to present a list of users in a grid.
+The previous section, [Adding your Dataservice to the application](#adding-your-dataservice-to-the-app) set the variables that are fed into the ZLUX Grid widget, so at this point the application should be updated with the ability to present a list of users in a grid.
 
 If you are still running `npm run-script start` in a command prompt, it should now show that the application has been successfully built, and that means we are ready to see the results. Reload your browser's webpage and open the user browser application once more. Do you see the list of users in columns and rows that can be sorted and selected? If so, great, you've built a simple yet useful application within Zowe! Let's move on to the last portion of the application tutorial where we hook the Starter application and the User Browser application together to accomplish a task.
 
@@ -635,39 +629,39 @@ If you are still running `npm run-script start` in a command prompt, it should n
 
 Applications in Zowe can be useful and provide insight all by themselves, but a big advantage to using the Zowe Desktop is that applications can track and share context by user interaction. By having the foreground application request the application best suited for a task, the requested application can perform the task with context regarding the task data and purpose and you can accomplish a complex task by simple and intuitive means.
 
-In the case of this tutorial, we're not only trying find a list of employees in a company (as was shown in the last step where the Grid was added and populated with the REST API), but to filter that list to find those employees who are best suited to the task we need to accomplish. So, our user browser application needs to be enhanced with two new abilities:
+In the case of this tutorial, we are not only trying find a list of employees in a company (as was shown in the last step where the Grid was added and populated with the REST API), but to filter that list to find those employees who are best suited to the task we need to accomplish. So, our user browser application needs to be enhanced with two new abilities:
 
 - Filter the user list to show only those users that meet the filter
-- Send the subset of users selected in the list back to the App that requested a user list.
+- Send the subset of users selected in the list back to the application that requested a user list.
 
 How do we do either task? Application-to-application communication! Applications can communicate with other applications in a few ways, but can be categorized into two interaction groups:
 
-1. Launching an App with a context of what it should do
-1. Messaging an App that's already open to a request or alert it of something
+1. Launching an application with a context of what it should do
+1. Messaging an application that is already open to a request or alert it of something
 
-In either case, the application framework provides Actions as the objects to perform the communication. Actions not only define what form of communication should happen, but between which Apps. Actions are issued from one application, and are fulfilled by a target application. But, because there might be more than one instance or window of an application open, there are Target Modes:
+In either case, the application framework provides Actions as the objects to perform the communication. Actions not only define what form of communication should happen, but between which applications. Actions are issued from one application, and are fulfilled by a target application. But, because there might be more than one instance or window of an application open, there are Target Modes:
 
-- Open a new App window, where the message context is delivered in the form of a Launch Context
-- Message a particular, or any of the currently open instances of the target App
+- Open a new application window, where the message context is delivered in the form of a Launch Context
+- Message a particular, or any of the currently open instances of the target application
 
 ### Adding the Starter application
 
 In order to facilitate app-to-app communication, we need another application with which to communicate. A 'starter' application is provided which can be [found on github](https://github.com/zowe/workshop-starter-app).
 
-As we did previously in the [Adding Your application to the Desktop](#adding-your-app-to-the-desktop) section, we need to move the application files to a location where they can be included in our `zlux-example-server`. We then need to add to the `plugins` folder in the example server and re-deploy.
+As we did previously in the [Adding Your application to the Desktop](#adding-your-app-to-the-desktop) section, we need to move the application files to a location where they can be included in our `zlux-app-server`. We then need to add to the `plugins` folder in the example server and re-deploy.
 
-1. Clone or download the starter app under the `zlux` folder
+1. Clone or download the starter application under the `zlux` folder
 
 - `git clone https://github.com/zowe/workshop-starter-app.git`
 
-2. Navigate to starter app and build it as before
+2. Navigate to starter application and build it as before.
 
 - Install packages with `cd webClient` and then `npm install`
 - Build the project using `npm start`
 
-2. Next navigate to the `zlux-example-server`:
+2. Next navigate to the `zlux-app-server`:
 
-- create a new file under `/zlux-example-server/plugins/org.openmainframe.zowe.workshop-starter.json`
+- create a new file under `/zlux-app-server/plugins/org.openmainframe.zowe.workshop-starter.json`
 - Edit the file to contain:
 
 ```json
@@ -678,7 +672,7 @@ As we did previously in the [Adding Your application to the Desktop](#adding-you
 ```
 
 3. Make sure the ./nodeServer is stopped before running `ant deploy` under `zlux-build`
-4. Restart the ./nodeServer under `zlux-example-server/bin` with the appropriate parameters passed in.
+4. Restart the ./nodeServer under `zlux-app-server/bin` with the appropriate parameters passed in.
 5. Refresh the browser and verify that the app with a **Green S** is present in zLUX.
 
 ### Enabling Communication
@@ -774,17 +768,17 @@ We can also see that once this application has been opened, the Starter applicat
 
 ### Calling back to the Starter application
 
-We're almost finished. The application can visualize data from a REST API, and can be instructed by other applications to filter that data according to the situation. But, to complete this tutorial, we need the application communication to go in the other direction - inform the Starter application which employees you have chosen in the table!
+We are almost finished. The application can visualize data from a REST API, and can be instructed by other applications to filter that data according to the situation. But, to complete this tutorial, we need the application communication to go in the other direction - inform the Starter application which employees you have chosen in the table!
 
 This time, we will edit **provideZLUXDispatcherCallbacks** to issue Actions rather than to listen for them. We need to target the Starter application, since it is the application that expects to receive a message about which employees should be assigned a task. If that application is given an employee listing that contains employees with the wrong job titles, the operation will be rejected as invalid, so we can ensure that we get the correct result through a combination of filtering and sending a subset of the filtered users back to the starter application.
 
-Add a private instance variable to the **UserBrowserComponent** Class.
+Add a private instance variable to the **UserBrowserComponent** Class:
 
 ```typescript
  private submitSelectionAction: ZLUX.Action;
 ```
 
-Then, create the Action template within the constructor
+Then, create the Action template within the constructor:
 
 ```typescript
 this.submitSelectionAction = ZoweZLUX.dispatcher.makeAction(
@@ -797,8 +791,8 @@ this.submitSelectionAction = ZoweZLUX.dispatcher.makeAction(
 )
 ```
 
-So, we've made an Action which targets an open window of the Starter application, and provides it with an Object with a data attribute.
-We'll populate this object for the message to send to the application by getting the results from Zowe Application Framework Grid (`this.selectedRows` will be populated from `this.onTableSelectionChange`).
+So, we created an Action which targets an open window of the Starter application, and provides it with an Object with a data attribute.
+We'll populate this object for the message to send to the application by getting the results from ZLUX Grid (`this.selectedRows` will be populated from `this.onTableSelectionChange`).
 
 For the final change to this file, add a new method to the Class:
 
@@ -819,7 +813,7 @@ For the final change to this file, add a new method to the Class:
 }
 ```
 
-And we'll invoke this through a button click action, which we will add into the Angular template, **userbrowser-component.html**, by changing the button tag for "Submit Selected Users" to:
+And we'll invoke this through a button click action, which we will add into the Angular template, `userbrowser-component.html`, by changing the button tag for "Submit Selected Users" to:
 
 ```html
 <button type="button" class="wide-button btn btn-default" (click)="submitSelectedUsers()" value="Send">

--- a/docs/user-guide/mvd-configuration.md
+++ b/docs/user-guide/mvd-configuration.md
@@ -1,5 +1,5 @@
 # Zowe Application Framework configuration
-After you install Zowe, you can optionally configure the terminal application plug-ins or modify the Zowe Application Server and ZSS configuration, if needed.
+After you install Zowe, you can optionally configure the terminal application plug-ins or modify the Zowe Application Server and Zowe System Services (ZSS) configuration, if needed.
 
 ## Setting up terminal application plug-ins
 

--- a/docs/user-guide/mvd-configuration.md
+++ b/docs/user-guide/mvd-configuration.md
@@ -30,11 +30,11 @@ Follow these optional steps to configure the default connection to open for the 
 ### Configuration file
 The Zowe Application Server and ZSS rely on many parameters to run, which includes setting up networking, deployment directories, plug-in locations, and more. 
 
-For convenience, the Zowe Application Server and ZSS read from a JSON file with a common structure. ZSS reads this file directly as a startup argument, while the Zowe Application Server (as defined in the `zlux-proxy-server` repository) accepts several parameters, which are intended to be read from a JSON file through an implementer of the server, such as the example in the `zlux-example-server` repository, the `js/zluxServer.js` file. This file accepts a JSON file that specifies most, if not all, of the parameters needed. Other parameters can be provided through flags, if needed. 
+For convenience, the Zowe Application Server and ZSS read from a JSON file with a common structure. ZSS reads this file directly as a startup argument, while the Zowe Application Server (as defined in the `zlux-server-framework` repository) accepts several parameters, which are intended to be read from a JSON file through an implementer of the server, such as the example in the `zlux-app-server` repository, the `js/zluxServer.js` file. This file accepts a JSON file that specifies most, if not all, of the parameters needed. Other parameters can be provided through flags, if needed. 
 
-An example of a JSON file (`zluxserver.json`) can be found in the `zlux-example-server` repository, in the `config` directory. 
+An example of a JSON file (`zluxserver.json`) can be found in the `zlux-app-server` repository, in the `config` directory. 
 
-**Note:** All examples are based on the *zlux-example-server* repository.
+**Note:** All examples are based on the *zlux-app-server* repository.
 
 ### Network configuration
 
@@ -98,7 +98,7 @@ These directories dictate where the [Configuration Dataservice](../extend/extend
 
 #### Deploy example
 ```
-// All paths relative to zlux-example-server/js or zlux-example-server/bin
+// All paths relative to zlux-app-server/js or zlux-app-server/bin
 // In real installations, these values will be configured during the installation process.
   "rootDir":"../deploy",
   "productDir":"../deploy/product",
@@ -117,11 +117,11 @@ In the configuration file, you can specify a directory that contains JSON files,
 
 To include application plug-ins, define the location of the plug-ins directory in the configuration file, through the top-level attribute **pluginsDir**.
 
-**Note:** In this example, the directory for these JSON files is `/plugins`. Yet, to separate configuration files from runtime files, the `zlux-example-server` repository copies the contents of this folder into `/deploy/instance/ZLUX/plugins`. So, the example configuration file uses the latter directory.
+**Note:** In this example, the directory for these JSON files is `/plugins`. Yet, to separate configuration files from runtime files, the `zlux-app-server` repository copies the contents of this folder into `/deploy/instance/ZLUX/plugins`. So, the example configuration file uses the latter directory.
 
 #### Plug-ins directory example
 ```
-// All paths relative to zlux-example-server/js or zlux-example-server/bin
+// All paths relative to zlux-app-server/js or zlux-app-server/bin
 // In real installations, these values will be configured during the install process.
 //...
   "pluginsDir":"../deploy/instance/ZLUX/plugins",
@@ -148,8 +148,8 @@ When you run the Zowe Application Server, specify the following flags to declare
 
 The Zowe Application Framework log files contain processing messages and statistics. The log files are generated in the following default locations:
 
-- Zowe Proxy Server: `zlux-example-server/log/nodeServer-yyyy-mm-dd-hh-mm.log`
-- ZSS: `zlux-example-server/log/zssServer-yyyy-mm-dd-hh-mm.log`
+- Zowe Proxy Server: `zlux-app-server/log/nodeServer-yyyy-mm-dd-hh-mm.log`
+- ZSS: `zlux-app-server/log/zssServer-yyyy-mm-dd-hh-mm.log`
  
 The logs are timestamped in the format yyyy-mm-dd-hh-mm and older logs are deleted when a new log is created at server startup.
 


### PR DESCRIPTION
Renamed zlux-example-server to zlux-app-server (includes one file name change and a change to the config.js) Also renamed zlux-proxy-server to zlux-server-framework