### PR TITLE
Update the Node.js version

### DIFF
--- a/docs/user-guide/systemrequirements.md
+++ b/docs/user-guide/systemrequirements.md
@@ -12,7 +12,7 @@ Before installing Zowe, ensure that your environment meets all of the prerequisi
 
 - z/OS® Version 2.2 or later.
 
-- Node.js Version 6.14.4 or later on the z/OS host where you install the Zowe Application Server.
+- Node.js Version 6.14.4.1 or later on the z/OS host where you install the Zowe Application Server.
 
     1. To install Node.js on z/OS, follow the procedures at [https://developer.ibm.com/node/sdk/ztp](https://developer.ibm.com/node/sdk/ztp).
 


### PR DESCRIPTION
Per issue #253 , updated the Node.js version to be 6.14.4.1 and later. 

@armstro Hi Bruce, the doc now still points users to https://developer.ibm.com/node/sdk/ztp/ but  updated the version number for Node.js. As it's some time since this issue was opened, any updates about this issue? Will this doc update suffice? Thanks! 