### PR TITLE
Fixed typos in two links in Installing Zowe

### DIFF
--- a/docs/user-guide/install-zos.md
+++ b/docs/user-guide/install-zos.md
@@ -779,7 +779,7 @@ The script writes its messages to your terminal window.  The results are marked 
 Follow the instructions in the following sections to verify that the components are installed correctly and are functional.
 
 - [Verifying Zowe Application Framework installation](#verifying-zowe-application-framework-installation)       
-- [Verifying z/OS Services installation](#verifying-z-os-services-installationn) 
+- [Verifying z/OS Services installation](#verifying-z-os-services-installation) 
 - [Verifying API Mediation installation](#verifying-api-mediation-installation) 
 
 ### Verifying Zowe Application Framework installation
@@ -794,7 +794,7 @@ where:
 - _httpPort_ is the port number that is assigned to _node.http.port_ in `zluxserver.json`.
 - _httpsPort_ is the port number that is assigned to _node.https.port_ in `zluxserver.json`.
   
-  For example, if the Zowe Application Server runs on host _myhost_ and the port number that is assigned to _node.https.port_ is 12345, you specify `https://myhost:12345/ZLUX/plugins/org.zowe.zlux.bootstrap/web/index.htm`.
+  For example, if the Zowe Application Server runs on host _myhost_ and the port number that is assigned to _node.https.port_ is 12345, you specify `https://myhost:12345/ZLUX/plugins/org.zowe.zlux.bootstrap/web/index.html`.
 
 ### Verifying z/OS Services installation
 

--- a/docs/user-guide/install-zos.md
+++ b/docs/user-guide/install-zos.md
@@ -779,7 +779,7 @@ The script writes its messages to your terminal window.  The results are marked 
 Follow the instructions in the following sections to verify that the components are installed correctly and are functional.
 
 - [Verifying Zowe Application Framework installation](#verifying-zowe-application-framework-installation)       
-- [Verifying z/OS Services installation](#verifying-zos-services-installation) 
+- [Verifying z/OS Services installation](#verifying-z-os-services-installation) 
 - [Verifying API Mediation installation](#verifying-api-mediation-installation) 
 
 ### Verifying Zowe Application Framework installation

--- a/docs/user-guide/install-zos.md
+++ b/docs/user-guide/install-zos.md
@@ -779,7 +779,7 @@ The script writes its messages to your terminal window.  The results are marked 
 Follow the instructions in the following sections to verify that the components are installed correctly and are functional.
 
 - [Verifying Zowe Application Framework installation](#verifying-zowe-application-framework-installation)       
-- [Verifying z/OS Services installation](#verifying-z-os-services-installation) 
+- [Verifying z/OS Services installation](#verifying-zos-services-installation) 
 - [Verifying API Mediation installation](#verifying-api-mediation-installation) 
 
 ### Verifying Zowe Application Framework installation


### PR DESCRIPTION
2 commits to fix hyperlinks identified in #402 