### PR TITLE
Add Feedback link to doc site

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -343,6 +343,7 @@ module.exports = {
       { tags: ['versions'] },
       {
         text: 'Feedback',
+        canHideFirst: true,
         link: 'https://forms.gle/Ztu9AjgV6HRr1kEs9'
       },
       {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -326,7 +326,7 @@ module.exports = {
     rootBaseUrl: ROOT_BASE_URL,
     repo: `https://github.com/zowe${ROOT_BASE_URL}`,
     editLinks: true,
-    editLinkText: 'Propose content change in GitHub.',
+    editLinkText: 'Propose content change in GitHub',
     lastUpdated: 'Last Updated', // string | boolean
     sidebarDepth: 2,
     algolia: {
@@ -341,6 +341,10 @@ module.exports = {
       ...navbarLinks,
       // MODIFICATION_FROM_THEME versions dropdown placeholder, it will be converted when rendering
       { tags: ['versions'] },
+      {
+        text: 'Feedback',
+        link: 'https://forms.gle/Ztu9AjgV6HRr1kEs9'
+      },
       {
         text: 'Zowe.org',
         link: 'https://zowe.org',

--- a/docs/.vuepress/theme/styles/config.styl
+++ b/docs/.vuepress/theme/styles/config.styl
@@ -13,11 +13,11 @@ $contentWidth = 4096px
 
 // responsive breakpoints
 // MODIFICATION_FROM_THEME, original value 959px
-$MQNarrow = 1089px
+$MQNarrow = 1263px
 // MODIFICATION_FROM_THEME, newly added
-$MQMobileMiddle = 965px
+$MQMobileMiddle = 1222px
 // MODIFICATION_FROM_THEME, original value 719px
-$MQMobile = 860px
+$MQMobile = 1030px
 $MQMobileNarrow = 419px
 
 // code


### PR DESCRIPTION
Added the Feedback link to the nav bar to collect user feedback. 

Hi Jack @jackjia-ibm , wondering if you know a way to add this link to each page, right after the Propose content change in GitHub link?  This link goes to a documentation survey form. Thanks in advance!