### PR TITLE
clarify prereqs not for CLI

### DIFF
--- a/docs/user-guide/systemrequirements.md
+++ b/docs/user-guide/systemrequirements.md
@@ -6,12 +6,10 @@ Before installing Zowe, ensure that your environment meets the prerequisites.
 - [Zowe Desktop requirements](#zowe-desktop-requirements)
 - [Zowe CLI requirements](#zowe-cli-requirements)
 
-## z/OS host requirements
-
-The following software is required for all Zowe components:
+## Common system requirements
 
 - z/OS Version 2.2 or later.
-- IBM z/OS Management Facility (z/OSMF) Version 2.2 or Version 2.3.
+- IBM z/OS Management Facility (z/OSMF) Version 2.2 or Version 2.3
 
   z/OSMF is a prerequisite for the Zowe microservices, Zowe Desktop applications, and Zowe CLI. z/OSMF must be installed and running before you use Zowe.
 
@@ -20,15 +18,14 @@ The following software is required for all Zowe components:
   - For production use of Zowe, see [Configuring z/OSMF](systemrequirements-zosmf.md). 
   :::
 
-- **(Not required for Zowe CLI)** Node.js Version 6.14.4.1 or later *on the z/OS host* where you install the Zowe Application Server. 
+## Zowe Application Framework requirements
+
+- Node.js Version 6.14.4.1 or later *on the z/OS host* where you install the Zowe Application Server
 
    To install Node.js on z/OS, follow the instructions in [Installing IBM SDK for Node.js - z-OS](install-nodejs-zos.md).
 
-- **(Not required for Zowe CLI)** IBM SDK for Java Technology Edition V8 or later
-
-## Zowe Desktop requirements
-
-- 833 MB of HFS file space.
+- IBM SDK for Java Technology Edition V8 or later
+- 833 MB of HFS file space
 
 - Supported browsers:
     -   Google Chrome V54 or later
@@ -38,25 +35,16 @@ The following software is required for all Zowe components:
 
 ## Zowe CLI requirements
 
-Install the following software on your computer:
+Zowe CLI is supported on platforms where Node.js 8.0 or 10 is available, including Windows, Linux, and Mac operating systems.
 
-- [**Node.js V8.0 or later**](https://nodejs.org/en/download/)
+- [**Node.js V8.0 or later**](https://nodejs.org/en/download/) on your computer
 
     **Tip:** You might need to restart the command prompt after installing Node.js. Issue the command `node --version` to verify that Node.js is installed. As a best practice, we recommend that you update Node.js regularly to the latest Long Term Support (LTS) version.
 
-- **Node Package Manager V5.0 or later**
+- **Node Package Manager V5.0 or later** on your computer.
 
     npm is included with the Node.js installation. Issue the command `npm --version` to verify that npm is installed.
 
-### Supported platforms
-
-Zowe CLI is supported on platforms where Node.js 8.0 or 10 is available, including Windows, Linux, and Mac operating systems.
-
-Zowe CLI integrates with z/OSMF running on IBM z/OS v2.2 or later.
-
-**Important!**
-
-- Oracle Linux 6 is not supported.
 
 ### Free disk space
 

--- a/docs/user-guide/systemrequirements.md
+++ b/docs/user-guide/systemrequirements.md
@@ -2,23 +2,29 @@
 
 Before installing Zowe, ensure that your environment meets the prerequisites.
 
+- [z/OS host requirements](#z-os-host-requirements)
+- [Zowe Desktop requirements](#zowe-desktop-requirements)
+- [Zowe CLI requirements](#zowe-cli-requirements)
+
 ## z/OS host requirements
+
+The following software is required for all Zowe components:
 
 - z/OS Version 2.2 or later.
 - IBM z/OS Management Facility (z/OSMF) Version 2.2 or Version 2.3.
 
-  z/OSMF is a prerequisite for the Zowe microservices. z/OSMF must be installed and running before you use Zowe.
+  z/OSMF is a prerequisite for the Zowe microservices, Zowe Desktop applications, and Zowe CLI. z/OSMF must be installed and running before you use Zowe.
 
   ::: tip 
    - For non-production use of Zowe (such as development, proof-of-concept, demo),  you can customize the configuration of z/OSMF to create what is known as "z/OS MF Lite" that simplifies the setup of z/OSMF. As z/OS MF Lite only supports selected REST services (JES, DataSet/File, TSO and Workflow), you will observe considerable improvements in start up time as well as a reduction in the efforts involved in setting up z/OSMF. For information about how to set up z/OSMF Lite, see [Configuring z/OSMF Lite (non-production environment)](systemrequirements-zosmf-lite.md)
   - For production use of Zowe, see [Configuring z/OSMF](systemrequirements-zosmf.md). 
   :::
 
-- Node.js Version 6.14.4.1 or later **on the z/OS host** where you install the Zowe Application Server. 
+- **(Not required for Zowe CLI)** Node.js Version 6.14.4.1 or later *on the z/OS host* where you install the Zowe Application Server. 
 
    To install Node.js on z/OS, follow the instructions in [Installing IBM SDK for Node.js - z-OS](install-nodejs-zos.md).
 
-- IBM SDK for Java Technology Edition V8 or later
+- **(Not required for Zowe CLI)** IBM SDK for Java Technology Edition V8 or later
 
 ## Zowe Desktop requirements
 

--- a/docs/user-guide/systemrequirements.md
+++ b/docs/user-guide/systemrequirements.md
@@ -2,8 +2,8 @@
 
 Before installing Zowe, ensure that your environment meets the prerequisites.
 
-- [z/OS host requirements](#z-os-host-requirements)
-- [Zowe Desktop requirements](#zowe-desktop-requirements)
+- [Common sytem requirements](#common-system-requirements)
+- [Zowe Application Framework requirements](#zowe-application-framework-requirements)
 - [Zowe CLI requirements](#zowe-cli-requirements)
 
 ## Common system requirements
@@ -22,7 +22,7 @@ Before installing Zowe, ensure that your environment meets the prerequisites.
 
 - Node.js Version 6.14.4.1 or later *on the z/OS host* where you install the Zowe Application Server
 
-   To install Node.js on z/OS, follow the instructions in [Installing IBM SDK for Node.js - z-OS](install-nodejs-zos.md).
+   To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
 
 - IBM SDK for Java Technology Edition V8 or later
 - 833 MB of HFS file space

--- a/docs/user-guide/systemrequirements.md
+++ b/docs/user-guide/systemrequirements.md
@@ -2,7 +2,7 @@
 
 Before installing Zowe, ensure that your environment meets the prerequisites.
 
-## z/OS host requirements (for all components)
+## z/OS host requirements
 
 - z/OS Version 2.2 or later.
 - IBM z/OS Management Facility (z/OSMF) Version 2.2 or Version 2.3.
@@ -14,13 +14,13 @@ Before installing Zowe, ensure that your environment meets the prerequisites.
   - For production use of Zowe, see [Configuring z/OSMF](systemrequirements-zosmf.md). 
   :::
 
-- Node.js Version 6.14.4.1 or later on the z/OS host where you install the Zowe Application Server. 
+- Node.js Version 6.14.4.1 or later **on the z/OS host** where you install the Zowe Application Server. 
 
    To install Node.js on z/OS, follow the instructions in [Installing IBM SDK for Node.js - z-OS](install-nodejs-zos.md).
 
 - IBM SDK for Java Technology Edition V8 or later
 
-## Disk and browser requirements (for Zowe Desktop)
+## Zowe Desktop requirements
 
 - 833 MB of HFS file space.
 
@@ -30,21 +30,13 @@ Before installing Zowe, ensure that your environment meets the prerequisites.
     -   Safari V11 or later
     -   Microsoft Edge (Windows 10)
 
-## System requirements for Zowe CLI
+## Zowe CLI requirements
 
-Before you install Zowe CLI, make sure your system meets the following requirements:
-
-### Prerequisite software
-
-The following prerequisites for Windows, Mac, and Linux are required if you are installing Zowe CLI from a local package. If you are installing Zowe CLI from Bintray registry, you only require Node.js and npm.
-
-**Note:** As a best practice, we recommend that you update Node.js regularly to the latest Long Term Support (LTS) version.
-
-Ensure that the following prerequisite software is installed on your computer:
+Install the following software on your computer:
 
 - [**Node.js V8.0 or later**](https://nodejs.org/en/download/)
 
-    **Tip:** You might need to restart the command prompt after installing Node.js. Issue the command `node --version` to verify that Node.js is installed.
+    **Tip:** You might need to restart the command prompt after installing Node.js. Issue the command `node --version` to verify that Node.js is installed. As a best practice, we recommend that you update Node.js regularly to the latest Long Term Support (LTS) version.
 
 - **Node Package Manager V5.0 or later**
 
@@ -52,9 +44,9 @@ Ensure that the following prerequisite software is installed on your computer:
 
 ### Supported platforms
 
-Zowe CLI is supported on any platform where Node.js 8.0 or 10 is available, including Windows, Linux, and Mac operating systems. For information about known issues and workarounds, see [Troubleshooting Zowe CLI](../troubleshoot/troubleshoot-cli.md).
+Zowe CLI is supported on platforms where Node.js 8.0 or 10 is available, including Windows, Linux, and Mac operating systems.
 
-Zowe CLI is designed and tested to integrate with z/OSMF running on IBM z/OS Version 2.2 or later. Before you can use Zowe CLI to interact with the mainframe, system programmers must install and configure IBM z/OSMF in your environment.
+Zowe CLI integrates with z/OSMF running on IBM z/OS v2.2 or later.
 
 **Important!**
 


### PR DESCRIPTION

- Cleaned up some extra text in the CLI section to make the page easier to consume. 
- added "not required for CLI" to certain prereqs. Users are getting confused and thinking that they need Node on z/OS in order to use the CLI alone. 


Signed-off-by: BrandonJenkins14 <brandon.jenkins@broadcom.com>