### PR TITLE
Miscellaneous changes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,3 +47,7 @@ You can download the Version 1.1.x Zowe documentation on this website in PDF for
 A Zowe overview deck in PDF format is available for download. The information in this deck provides an introduction to Zowe, its vision and value statements, a deeper dive into the technology, how to get involved in the community, and more. 
 
 [Download PDF](./Zowe_Overview.pdf)
+
+### Zowe CLI command reference guide 
+
+View the [CLI Command Reference Guide](https://zowe.github.io/docs-site/latest/CLIReference_Zowe.pdf) for a detailed documentation on commands, actions, and options in Zowe CLI. The reference document is based on the `@lts-incremental` version of the CLI.

--- a/docs/extend/extend-cli/cli-devTutorials.md
+++ b/docs/extend/extend-cli/cli-devTutorials.md
@@ -2,31 +2,22 @@
 
 You can extend Zowe CLI by developing plug-ins and contributing code to the base Zowe CLI or existing plug-ins.
 
-**Note:** You can also [install existing plug-ins to Zowe CLI](../../user-guide/cli-extending.md).
-
-* [How can I contribute?](#how-can-i-contribute)
-* [Getting started](#getting-started)
-
 ## How can I contribute?
 You can contribute to Zowe CLI in the following ways:
 1. Add new commands, options, or other improvements to the base CLI.
 2. Develop a plug-in that users can install to Zowe CLI.
-
-See [Getting Started](#getting-started) to get started with development today!
 
 You might want to contribute to Zowe CLI to accomplish the following:
 * Provide new scriptable functionality for yourself, your organization, or to a broader community.
 * Make use of Zowe CLI infrastructure (profiles and programmatic APIs).
 * Participate in the Zowe CLI community space.
 
-The following plug-in projects have been developed:
+The following plug-ins have been developed:
 * [Zowe CLI Plug-in for IBM Db2](https://github.com/zowe/zowe-cli-db2-plugin)
 * [Zowe CLI Plug-in for IBM CICS](https://github.com/zowe/zowe-cli-cics-plugin)
 
 ## Getting started
-If you want to start working with the code immediately, check out the [Zowe CLI core repository](https://github.com/zowe/zowe-cli) and the [contribution guidelines](https://github.com/zowe/zowe-cli/master/blob/CONTRIBUTING.md).
-
-The [zowe-cli-sample-plugin GitHub repository](https://github.com/zowe/zowe-cli-sample-plugin) contains a sample plug-in that adheres to the guidelines for contributing to Zowe CLI projects. Follow the associated [developer tutorials](#tutorials) to learn about how to work with our sample plug-in, build new commands, or build a new Zowe CLI plug-in.
+If you want to start working with the code immediately, check out the [Zowe CLI core repository](https://github.com/zowe/zowe-cli) and the [contribution guidelines](https://github.com/zowe/zowe-cli/master/blob/CONTRIBUTING.md). The [zowe-cli-sample-plugin GitHub repository](https://github.com/zowe/zowe-cli-sample-plugin) is a sample plug-in that adheres to the guidelines for contributing to Zowe CLI projects.
 
 ### Tutorials
 Follow these tutorials to get started working with the sample plug-in:
@@ -39,13 +30,12 @@ Follow these tutorials to get started working with the sample plug-in:
 ### Plug-in Development Overview
 At a high level, a plug-in must have `imperative-framework` configuration [(sample here)](https://github.com/zowe/zowe-cli-sample-plugin/src/imperative.ts).  This configuration is discovered by  `imperative-framework` through the [package.json](https://github.com/zowe/zowe-cli-sample-plugin/package.json) `imperative` key.
 
-In addition to the configuration, a Zowe CLI plug-in will minimally contain the following:
+A Zowe CLI plug-in will minimally contain the following:
 1. **Programmatic API** - Node.js programmatic APIs to be called by your handler or other Node.js applications.
 2. **Command definition** - The syntax definition for your command.
 3. **Handler implementation** - To invoke your programmatic API to display information in the format that you defined in the definition.
 
-## Developer Documentation and Guidelines
-In addition to the [tutorials](#tutorials), the following guidelines and documentation will assist you during development:
+The following guidelines and documentation will assist you during development:
 
 ### Imperative CLI Framework Documentation
 [Imperative CLI Framework documentation](https://github.com/zowe/imperative/wiki) is a key source of information to learn about the features of Imperative CLI Framework (the code framework that you use to build plug-ins for Zowe CLI). Refer to these supplementary documents during development to learn about specific features such as:

--- a/docs/user-guide/cli-configuringcli.md
+++ b/docs/user-guide/cli-configuringcli.md
@@ -3,42 +3,11 @@ This section explains how to define and verify your connection to the mainframe 
 
 **Note** The configuration for the CLI is stored on your computer in a directory such as C:\Users\user01\.zowe. The configuration includes log files, your profile information, and CLI plug-ins that are installed. When you troubleshoot an issue with the CLI, the log files in the imperative and zowe folders contain valuable information.
 
-- [Testing Zowe CLI connection to z/OSMF](#testing-zowe-cli-connection-to-zosmf) 
 - [Defining Zowe CLI connection details](#defining-zowe-cli-connection-details)
+- [Testing Zowe CLI connection to z/OSMF](#testing-zowe-cli-connection-to-zosmf) 
 - [Setting CLI log levels](#setting-zowe-cli-log-levels)
 - [Setting the CLI home directory](#setting-the-zowe-cli-home-directory)
 
-## Testing Zowe CLI connection to z/OSMF
-
-You can issue a command at any time to receive diagnostic information from the server and confirm that Zowe CLI can communicate with z/OSMF or other mainframe APIs. 
-
-**Tip:** We recommend that you append `--help` to the end of commands in the product to see the complete set of commands and options available to you. For example, issue `zowe profiles --help` to learn more about how to list profiles, switch your default profile, or create different profile types.
-
-**Without a Profile**
-
-Verify that your CLI can communicate with z/OSMF by issuing the following command:
-
-```
-zowe zosmf check status --host <host> --port <port> --user <username> --pass <password> 
-```
-
-**Default profile**
-
-Verify that you can use your default profile to communicate with z/OSMF by issuing the following command:
-
-```
-zowe zosmf check status
-```
-
-**Specific profile**
-
-Verify that you can use a specific profile to communicate with z/OSMF by issuing the following command: 
-
-```
-zowe zosmf check status --zosmf-profile <profile_name>
-```
-
-The commands return a success or failure message and display information about your z/OSMF server. For example, the z/OSMF version number and a list of installed plug-ins. Report any failure to your systems administrator and use the information for diagnostic purposes.
 
 ## Defining Zowe CLI connection details
 
@@ -210,6 +179,39 @@ zowe zosmf check status -H <myhost> -P <myport> -u <myuser> --pw <mypass> --base
 **More Information:**
 - [API Mediation Layer](../getting-started/overview.md)
 - [Creating a profile to access API Mediation Layer](#creating-a-profile-to-access-an-api-mediation-layer)
+
+## Testing Zowe CLI connection to z/OSMF
+
+You can issue a command at any time to receive diagnostic information from the server and confirm that Zowe CLI can communicate with z/OSMF or other mainframe APIs. 
+
+**Tip:** We recommend that you append `--help` to the end of commands in the product to see the complete set of commands and options available to you. For example, issue `zowe profiles --help` to learn more about how to list profiles, switch your default profile, or create different profile types.
+
+**Without a Profile**
+
+Verify that your CLI can communicate with z/OSMF by issuing the following command:
+
+```
+zowe zosmf check status --host <host> --port <port> --user <username> --pass <password> 
+```
+
+**Default profile**
+
+Verify that you can use your default profile to communicate with z/OSMF by issuing the following command:
+
+```
+zowe zosmf check status
+```
+
+**Specific profile**
+
+Verify that you can use a specific profile to communicate with z/OSMF by issuing the following command: 
+
+```
+zowe zosmf check status --zosmf-profile <profile_name>
+```
+
+The commands return a success or failure message and display information about your z/OSMF server. For example, the z/OSMF version number and a list of installed plug-ins. Report any failure to your systems administrator and use the information for diagnostic purposes.
+
 
 ## Setting Zowe CLI log levels
 

--- a/docs/user-guide/cli-extending.md
+++ b/docs/user-guide/cli-extending.md
@@ -1,16 +1,8 @@
 # Extending Zowe CLI
 
-You can install plug-ins to extend the capabilities of Zowe CLI.
-
-Plug-ins CLI to third-party applications are also available, such as Visual Studio Code Extension for Zowe (powered by Zowe CLI).
-
-Plug-ins add functionality to the product in the form of new command groups, actions, objects, and options. 
+You can install plug-ins to extend the capabilities of Zowe CLI. Plug-ins CLI to third-party applications are also available, such as Visual Studio Code Extension for Zowe (powered by Zowe CLI). Plug-ins add functionality to the product in the form of new command groups, actions, objects, and options. 
 
 **Important!** Plug-ins can gain control of your CLI application legitimately during the execution of every command. Install third-party plug-ins at your own risk. We make no warranties regarding the use of third-party plug-ins.
-
-**Note:** For information about how to install, update, and validate a plug-in, see [Installing Plug-ins](cli-installplugins.md).
-
-The following plug-ins are available:
 
 **CA Brightside Plug-in for IBM® CICS®**
 

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -62,7 +62,7 @@ If you do not have internet access at your site, use the following method to ins
 
    **Tip:** Profiles are a Zowe CLI feature that let you store configuration information for use on multiple commands. You can create a profile that contains your username, password, and connection details for a particular mainframe system, then reuse that profile to avoid typing it again on every command.
 
-After you install and configure Zowe CLI, you can issue the `zowe --help` command to view a list of available commands. For information about how to connect the CLI to the mainframe, see [Defining CLI connection details](cli-configuringcli.md#defining-zowe-cli-connection-details).
+After you install and configure Zowe CLI, you can issue the `zowe --help` command to view a list of available commands. For information about how to connect the CLI to the mainframe (using command-line options, profiles, or environment variables), see [Defining CLI connection details](cli-configuringcli.md#defining-zowe-cli-connection-details).
 
 ### Installing Zowe CLI from an online registry
 

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -1,8 +1,8 @@
 # Installing Zowe CLI
 
-As an application developer, install Zowe CLI on your computer.
+Install Zowe CLI on your computer. You can learn about new CLI features in the [Release notes](../getting-started/summaryofchanges.md) or read about overall CLI functionality in the [Zowe overview](../getting-started/overview.md). 
 
-**Tip:** If you are familiar with command-line tools and want to get started with Zowe CLI quickly, see [Zowe CLI quick start](../getting-started/cli-getting-started.md)
+**Tip:** If you are familiar with command-line tools and want to get started using Zowe CLI quickly, see [Zowe CLI quick start](../getting-started/cli-getting-started.md)
 
 ## Methods to install Zowe CLI
 
@@ -70,7 +70,7 @@ If your computer is connected to the Internet, you can use the following method 
 
 **Follow these steps:**
 
-1.  Ensure that the following prerequisite software is installed on your computer:
+1.  Ensure that the following required software is installed on your computer:
 
     - [**Node.js V8.0 or later**](https://nodejs.org/en/download/)
 
@@ -100,10 +100,7 @@ If your computer is connected to the Internet, you can use the following method 
 
     **Note:** The IBM Db2 plug-in requires additional configuration. For more information about how to install multiple plug-ins, update to a specific version of a plug-in, and install from specific registries, see [Installing plug-ins](cli-installplugins.md).
 
-5.  (Optional) Create a `zosmf` profile so that you can issue commands that communicate with z/OSMF. For information about how to create a profile, see [Creating Zowe CLI profiles](cli-configuringcli.md#creating-zowe-cli-profiles).
+After you install and configure Zowe CLI, you can issue the `zowe --help` command to view a list of available commands. For information about how to connect the CLI to the mainframe (using command-line options, profiles, or environment variables), see [Defining CLI connection details](cli-configuringcli.md#defining-zowe-cli-connection-details).
 
-   **Tip:** Profiles are a Zowe CLI feature that let you store configuration information for use on multiple commands. You can create a profile that contains your username, password, and connection details for a particular mainframe system, then reuse that profile to avoid typing it again on every command.
-
-After you install and configure Zowe CLI, you can issue the `zowe --help` command to view a list of available commands. For information about how to connect the CLI to the mainframe, see [Defining CLI connection details](cli-configuringcli.md#defining-zowe-cli-connection-details).
 
 

--- a/docs/user-guide/cli-usingcli.md
+++ b/docs/user-guide/cli-usingcli.md
@@ -24,6 +24,10 @@ zowe <group, action, or object name> --help
 zowe zos-files create --help
 ```
 
+## Zowe CLI command reference guide 
+
+View the [CLI Command Reference Guide](../CLIReference_Zowe.pdf) for a detailed documentation on commands, actions, and options in Zowe CLI. The reference document is based on the `@lts-incremental` version of the CLI.
+
 ## Zowe CLI command groups
 Zowe CLI contains command groups that focus on specific business processes. For example, the `zos-files` command group
 provides the ability to interact with mainframe data sets. This article provides you with a brief synopsis of the tasks that you can perform with each group. For more information, see [Display Zowe CLI Help](#displaying-zowe-cli-help). 
@@ -181,9 +185,6 @@ With the zosmf command group, you can perform the following tasks:
 ```
 zowe zosmf -h
 ```
-## CLI Command Reference 
-
-See the [CLI Reference document](../CLIReference_Zowe.pdf) to review a list of all commands, actions, and options in Zowe CLI. The reference document is based on the @lts-incremental version of the CLI.
 
 ## Writing scripts to automate mainframe actions
 


### PR DESCRIPTION
- link to release notes from install topics
- clean up some text in Developing for Zowe CLI 
- Make command reference guide more prominent in TOC and add to Home page
- Move Test Connection to z/OSMF to AFTER creating profiles section
