### PR TITLE
fix incorrect syntax for cics and db2 validate command

### DIFF
--- a/docs/user-guide/cli-cicsplugin.md
+++ b/docs/user-guide/cli-cicsplugin.md
@@ -55,7 +55,7 @@ To install Zowe CLI from an online registry, complete the following steps:
 3. (Optional) After the command execution completes, issue the following command to validate that the installation completed successfully.
 
     ```
-    zowe plugins validate cics
+    zowe plugins validate @brightside/cics
     ```
 
     Successful validation of the IBM CICS plug-in returns the response: `Successfully validated`.

--- a/docs/user-guide/cli-db2plugin.md
+++ b/docs/user-guide/cli-db2plugin.md
@@ -41,7 +41,7 @@ If you installed Zowe CLI from **online registry**, complete the following steps
 2. After the command execution completes, issue the following command to validate that the installation completed successfully.
 
     ```
-    zowe plugins validate db2
+    zowe plugins validate @brightside/db2
     ```
 
     Successful validation of the IBM Db2 plug-in returns the response: `Successfully validated`.
@@ -101,7 +101,7 @@ Now that the Db2 ODBC CLI driver is downloaded, set the IBM_DB_INSTALLER_URL env
 4. (Optional) After the command execution completes, issue the following command to validate that the installation completed successfully.
 
     ```
-    zowe plugins validate db2
+    zowe plugins validate @brightside/db2
     ```
 
     Successful validation of the IBM Db2 plug-in returns the response: `Successfully validated`.


### PR DESCRIPTION
Fixed syntax problems for #508 

Signed-off-by: BrandonJenkins14 <brandon.jenkins@broadcom.com>