### PR TITLE
fix outdated information about profiles

### DIFF
--- a/docs/user-guide/cli-configuringcli.md
+++ b/docs/user-guide/cli-configuringcli.md
@@ -33,7 +33,7 @@ The affect of the order is that if you omit an argument/option from the command 
 
 ### Creating Zowe CLI profiles
 
-Profiles are a Zowe CLI function that lets you store configuration information for use on multiple commands. You can create a profile that contains your username, password, and connection details for a particular mainframe system, then reuse that profile to avoid typing it again on every command. You can switch between profiles to quickly target different mainframe subsystems. 
+Profiles are a Zowe CLI function that let you store configuration information for use on multiple commands. You can create a profile that contains your username, password, and connection details for a particular mainframe system, then reuse that profile to avoid typing it again on every command. You can switch between profiles to quickly target different mainframe subsystems. 
 
 Profiles are **not** required to use the CLI. You can choose to specify all connection details in options on every command.
 
@@ -184,7 +184,7 @@ zowe zosmf check status -H <myhost> -P <myport> -u <myuser> --pw <mypass> --base
 
 ## Testing Zowe CLI connection to z/OSMF
 
-You can issue a command at any time to receive diagnostic information from the server and confirm that Zowe CLI can communicate with z/OSMF or other mainframe APIs. 
+You can issue a command at any time to receive diagnostic information from the server and confirm that Zowe CLI can communicate with z/OSMF or other mainframe APIs.
 
 **Tip:** Append `--help` to the end of commands in the product to see the complete set of commands and options available to you. For example, issue `zowe profiles --help` to learn more about how to list profiles, switch your default profile, or create different profile types.
 

--- a/docs/user-guide/cli-usingcli.md
+++ b/docs/user-guide/cli-usingcli.md
@@ -3,11 +3,10 @@
 This section contains information about using Zowe CLI.
 
 ## Displaying Zowe CLI help
-Zowe CLI contains a help system that is embedded directly into the command-line interface. When you want help with Zowe CLI, you issue help commands that provide you with information about the product, syntax, and usage.
 
-### Displaying top-level help
+Zowe CLI contains a help system that is embedded directly into the command-line interface. Issue help commands that provide you with information about the product, syntax, and usage.
 
-<!---your comment-->
+### Displaying top-level help 
 
 To begin using the product, open a command line window and issue the following command to view the top-level help descriptions:
 
@@ -194,7 +193,7 @@ The zosmf command group lets you work with Zowe CLI profiles and get general inf
 
 With the zosmf command group, you can perform the following tasks:
 
-- Create and manage your Zowe CLI zosmf profiles. You must have at least one zosmf profile to issue most commands. Issue the `zowe help explain profiles` command in Zowe CLI to learn more about using profiles.
+- Create and manage your Zowe CLI `zosmf` profiles. Profiles let you store configuration information for use on multiple commands. You can create a profile that contains your username, password, and connection details for a particular mainframe system, then reuse that profile to avoid typing it again on every command. You can switch between profiles to quickly target different mainframe subsystems. For more information, see [Creating profiles](cli-configuringcli.md#creating-zowe-cli-profiles).
 - Verify that your profiles are set up correctly to communicate with z/OSMF on your system. For more information, see [Test Connection to z/OSMF](cli-configuringcli.md#testing-zowe-cli-connection-to-z-osmf).
 - Get information about the current z/OSMF version, host, port, and plug-ins installed on your system.
 


### PR DESCRIPTION
1. There is no longer a `zowe help explain profiles` command. Removed references in doc. 
2. Profiles are no longer required - they are optional. Removed outdated language about this. 

Signed-off-by: BrandonJenkins14 <brandon.jenkins@broadcom.com>