### PR TITLE
Move FAQ content from Zowe.org

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -30,7 +30,7 @@ const ALL_PAGES = [{
     link: 'getting-started/cli-getting-started.md'
   },
   {
-    text: 'Zowe CLI FAQs',
+    text: 'Zowe FAQs',
     link: 'getting-started/freqaskques.md'
   },
   ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ footer: Except where otherwise noted, content on this site is licensed under a C
 <div class="features">
   <div class="feature">
     <h2><a href="./getting-started/overview.html">Getting Started</a></h2>
-    <p>Learn about Zowe architecture and components; read about what's new and changed in the Release Notes.</p>
+    <p>Learn about Zowe architecture, components, and how to quickly get started with Zowe CLI. Read about what's new and changed in the Release Notes. Get answers to your frequently asked questions (FAQs).</p>
   </div>
   <div class="feature">
     <h2><a href="./user-guide/installandconfig.html">User Guide</a></h2>
@@ -20,11 +20,11 @@ footer: Except where otherwise noted, content on this site is licensed under a C
   </div>
   <div class="feature">
     <h2><a href="./troubleshoot/troubleshooting.html">Troubleshooting</a></h2>
-    <p>Get troubleshooting tips and answers to your most frequently asked questions.</p>
+    <p>Get troubleshooting tips to help you understand and effectively resolve problems with Zowe.</p>
   </div>
   <div class="feature">
     <h2><a href="./contributing.html">Contributing</a></h2>
-    <p>Learn about how you can contribute to this documentation.</p>
+    <p>Learn about how you can contribute to this documentation. Read about the Zowe UI and code guidelines to help you contribute to Zowe.</p>
   </div>
   <div class="feature">
     <h2><a href="https://zowe.org/home/">Getting Help</a></h2>

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -7,7 +7,7 @@ Check out the following FAQs to learn more about the purpose and function of Zow
 
 ## Zowe FAQ
 
-**What is Zowe?**
+### What is Zowe?
 
 <details>
 
@@ -17,7 +17,7 @@ Zowe is an open source project within the [Open Mainframe Project](https://www.o
 
 </details>
 
-**Who is the target audience for using Zowe?**
+### Who is the target audience for using Zowe?
 
 <details>
 
@@ -27,7 +27,7 @@ Zowe technology can be used by a variety of mainframe IT and non-IT professional
 
 </details>
 
-**What language is Zowe written in?**
+### What language is Zowe written in?
 
 <details>
 
@@ -37,7 +37,7 @@ Zowe consists of several components. The primary languages are Java and JavaScri
 
 </details>
 
-**What is the licensing for Zowe?**
+### What is the licensing for Zowe?
 
 <details>
 
@@ -49,8 +49,7 @@ In the simplest terms (taken from the FAQs above) - "...if you have modified EPL
 
 </details>
 
-
-**Why is Zowe licensed using EPL2.0?**
+### Why is Zowe licensed using EPL2.0?
 
 <details>
 
@@ -61,7 +60,7 @@ The Open Mainframe Project wants to encourage adoption and innovation, and also 
 </details>
 
 
-**What are some examples of how Zowe technology might be used by z/OS products and applications?**
+### What are some examples of how Zowe technology might be used by z/OS products and applications?
 
 <details>
 
@@ -76,7 +75,7 @@ The increased capabilities of RESTful APIs on z/OS allows APIs to be used in pro
 </details>
 
 
-**What is the best way to get started with Zowe?**
+### What is the best way to get started with Zowe?
 
 <details>
 
@@ -91,7 +90,7 @@ To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick s
 </details>
 
 
-**What are the prerequisites for Zowe?**
+### What are the prerequisites for Zowe?
 
 <details>
 
@@ -112,7 +111,7 @@ Zowe components use typical z/OS System authorization facility (SAF) calls for s
 </details>
 
 
-**How is access to the Zowe open source managed?**
+### How is access to the Zowe open source managed?
 
 <details>
 
@@ -123,7 +122,7 @@ The source code for Zowe is maintained on an Open Mainframe Project GitHub serve
 </details>
 
 
-**How do I get involved in the open source development?**
+### How do I get involved in the open source development?
 
 <details>
 
@@ -138,7 +137,7 @@ For information and tutorials about extending Zowe with a new plug-in or applica
 </details>
 
 
-**When will Zowe be completed?**
+### When will Zowe be completed?
 
 <details>
 
@@ -149,7 +148,7 @@ Zowe will continue to evolve in the coming years based on new ideas and new cont
 </details>
 
 
-**Can I try Zowe without a z/OS instance?**
+### Can I try Zowe without a z/OS instance?
 
 <details>
 
@@ -164,10 +163,7 @@ Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more in
 </details>
 
 
-
-
-
-### Zowe CLI FAQ
+## Zowe CLI FAQ
 
 **Why might I use Zowe CLI versus a traditional ISPF interface to perform mainframe tasks?**
 
@@ -180,7 +176,7 @@ For new developers, command line interfaces might be more familiar than an ISPF 
 </details>
 
 
-**With what tools is Zowe CLI compatible?**
+### With what tools is Zowe CLI compatible?
 
 <details>
 
@@ -191,7 +187,7 @@ Zowe CLI is very flexible! It can work in conjunction with popular build and tes
 </details>
 
 
-**Which method should I use to install Zowe CLI?**
+### Which method should I use to install Zowe CLI?
 
 <details>
 
@@ -206,7 +202,7 @@ You can install Zowe CLI using the following methods:
 </details>
 
 
-**How can I get help with using Zowe CLI?**
+### How can I get help with using Zowe CLI?
 
 <details>
 
@@ -218,7 +214,7 @@ You can install Zowe CLI using the following methods:
 
 </details>
 
-**How can I use Zowe CLI to automate mainframe actions?**
+### How can I use Zowe CLI to automate mainframe actions?
 
 <details>
 
@@ -230,7 +226,7 @@ You can install Zowe CLI using the following methods:
 </details>
 
 
-**How can I contribute to Zowe CLI?**
+### How can I contribute to Zowe CLI?
 
 <details>
 

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -158,14 +158,14 @@ IBM has contributed a free hands-on tutorial for Zowe. Visit the [Zowe Tutorial 
 
 The Zowe community is also currently working to provide a vendor-neutral site for an open z/OS build and sandbox environment.
 
-Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more information, see [Configuring z/OSMF Lite (../user-guide/systemrequirements-zosmf-lite.html) on Zowe Docs.
+Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more information, see [Configuring z/OSMF Lite](../user-guide/systemrequirements-zosmf-lite.html) on Zowe Docs.
 
 </details>
 
 
 ## Zowe CLI FAQ
 
-**Why might I use Zowe CLI versus a traditional ISPF interface to perform mainframe tasks?**
+### Why might I use Zowe CLI versus a traditional ISPF interface to perform mainframe tasks?
 
 <details>
 

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -84,9 +84,9 @@ The increased capabilities of RESTful APIs on z/OS allows APIs to be used in pro
 
 Zowe provides a convenience build that includes the components released-to-date, as well as IP being considered for contribution, in an easy to install package on [Zowe.org](https://zowe.org/home/). The convenience build can be easily installed and the Zowe capabilities seen in action. 
 
-To install the complete Zowe solution, see [Installing Zowe](https://zowe.github.io/docs-site/latest/user-guide/installandconfig.html).
+To install the complete Zowe solution, see [Installing Zowe](../user-guide/installandconfig.md).
 
-To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick start](https://zowe.github.io/docs-site/latest/getting-started/cli-getting-started.html).
+To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick start](cli-getting-started.md).
 
 </details>
 
@@ -97,10 +97,9 @@ To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick s
 
 <summary> Click to show answer </summary>
 
-The primary prerequisites is Java on z/OS and the z/OS Management Facility enabled and configured. For a complete list of software requirements listed by component, see [System requirements](https://zowe.github.io/docs-site/latest/user-guide/systemrequirements.html).
+The primary prerequisites is Java on z/OS and the z/OS Management Facility enabled and configured. For a complete list of software requirements listed by component, see [System requirements](../user-guide/systemrequirements.html).
 
 </details>
-
 
 **How is access security managed on z/OS?**
 
@@ -134,7 +133,7 @@ The best way to get started is to join a [Zowe Slack channel](https://slack.open
 
 For more information about emailing lists, community calendar, meeting minutes, and more, see [Contribute](https://zowe.org/contribute/) on Zowe.org.  
 
-For information and tutorials about extending Zowe with a new plug-in or application, see [Extending](https://zowe.github.io/docs-site/latest/extend/extend-apiml/api-mediation-onboard-overview.html) on Zowe Docs.
+For information and tutorials about extending Zowe with a new plug-in or application, see [Extending](../extend/extend-apiml/api-mediation-onboard-overview.html) on Zowe Docs.
 
 </details>
 
@@ -160,7 +159,7 @@ IBM has contributed a free hands-on tutorial for Zowe. Visit the [Zowe Tutorial 
 
 The Zowe community is also currently working to provide a vendor-neutral site for an open z/OS build and sandbox environment.
 
-Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more information, see [Configuring z/OSMF Lite (https://zowe.github.io/docs-site/latest/user-guide/systemrequirements-zosmf-lite.html) on Zowe Docs.
+Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more information, see [Configuring z/OSMF Lite (../user-guide/systemrequirements-zosmf-lite.html) on Zowe Docs.
 
 </details>
 

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -5,7 +5,6 @@ Check out the following FAQs to learn more about the purpose and function of Zow
 - [Zowe FAQ](#zowe-faq)
 - [Zowe CLI FAQ](#zowe-cli-faq)
 
-
 ## Zowe FAQ
 
 **What is Zowe?**
@@ -85,7 +84,7 @@ The increased capabilities of RESTful APIs on z/OS allows APIs to be used in pro
 
 Zowe provides a convenience build that includes the components released-to-date, as well as IP being considered for contribution, in an easy to install package on [Zowe.org](https://zowe.org/home/). The convenience build can be easily installed and the Zowe capabilities seen in action. 
 
-To get started installing the complete Zowe solution, see [Installing Zowe](https://zowe.github.io/docs-site/latest/user-guide/installandconfig.html).
+To install the complete Zowe solution, see [Installing Zowe](https://zowe.github.io/docs-site/latest/user-guide/installandconfig.html).
 
 To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick start](https://zowe.github.io/docs-site/latest/getting-started/cli-getting-started.html).
 
@@ -98,66 +97,72 @@ To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick s
 
 <summary> Click to show answer </summary>
 
-The primary prerequisites is Java on z/OS and the z/OS Management Facility enabled and configured. For more information, see [System requirements](https://zowe.github.io/docs-site/latest/user-guide/systemrequirements.html).
+The primary prerequisites is Java on z/OS and the z/OS Management Facility enabled and configured. For a complete list of software requirements listed by component, see [System requirements](https://zowe.github.io/docs-site/latest/user-guide/systemrequirements.html).
 
 </details>
 
 
-**xxxxxxxx**
+**How is access security managed on z/OS?**
 
 <details>
 
 <summary> Click to show answer </summary>
 
-The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+Zowe components use typical z/OS System authorization facility (SAF) calls for security.
 
 </details>
 
 
-**xxxxxxxx**
+**How is access to the Zowe open source managed?**
 
 <details>
 
 <summary> Click to show answer </summary>
 
-The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+The source code for Zowe is maintained on an Open Mainframe Project GitHub server. Everyone has read access. "Committers" on the project have authority to alter the source code to make fixes or enhancements. A list of Committers is documented in the [Zowe Charter](https://zowe.org/Zowe-Charter.pdf).
 
 </details>
 
 
-**xxxxxxxx**
+**How do I get involved in the open source development?**
 
 <details>
 
 <summary> Click to show answer </summary>
 
-The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+The best way to get started is to join a [Zowe Slack channel](https://slack.openmainframeproject.org/) and/or email distribution list and begin learning about the current capabilities, then contribute to future development. 
+
+For more information about emailing lists, community calendar, meeting minutes, and more, see [Contribute](https://zowe.org/contribute/) on Zowe.org.  
+
+For information and tutorials about extending Zowe with a new plug-in or application, see [Extending](https://zowe.github.io/docs-site/latest/extend/extend-apiml/api-mediation-onboard-overview.html) on Zowe Docs.
 
 </details>
 
 
-**xxxxxxxx**
+**When will Zowe be completed?**
 
 <details>
 
 <summary> Click to show answer </summary>
 
-The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+Zowe will continue to evolve in the coming years based on new ideas and new contributions from a growing community.
 
 </details>
 
 
+**Can I try Zowe without a z/OS instance?**
 
+<details>
 
+<summary> Click to show answer </summary>
 
+IBM has contributed a free hands-on tutorial for Zowe. Visit the [Zowe Tutorial page](https://developer.ibm.com/tutorials/zowe-step-by-step-tutorial/) to learn about adding new applications to the Zowe Desktop and and how to enable communication with other Zowe components.
 
+The Zowe community is also currently working to provide a vendor-neutral site for an open z/OS build and sandbox environment.
 
+Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more information, see [Configuring z/OSMF Lite (https://zowe.github.io/docs-site/latest/user-guide/systemrequirements-zosmf-lite.html) on Zowe Docs.
 
-
-
-
-
-
+</details>
 
 
 

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -96,7 +96,7 @@ To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick s
 
 <summary> Click to show answer </summary>
 
-The primary prerequisites is Java on z/OS and the z/OS Management Facility enabled and configured. For a complete list of software requirements listed by component, see [System requirements](../user-guide/systemrequirements.html).
+The primary prerequisites is Java on z/OS and the z/OS Management Facility enabled and configured. For a complete list of software requirements listed by component, see [System requirements](../user-guide/systemrequirements.md).
 
 </details>
 
@@ -132,7 +132,7 @@ The best way to get started is to join a [Zowe Slack channel](https://slack.open
 
 For more information about emailing lists, community calendar, meeting minutes, and more, see [Contribute](https://zowe.org/contribute/) on Zowe.org.  
 
-For information and tutorials about extending Zowe with a new plug-in or application, see [Extending](../extend/extend-apiml/api-mediation-onboard-overview.html) on Zowe Docs.
+For information and tutorials about extending Zowe with a new plug-in or application, see [Extending](../extend/extend-apiml/api-mediation-onboard-overview.md) on Zowe Docs.
 
 </details>
 
@@ -158,7 +158,7 @@ IBM has contributed a free hands-on tutorial for Zowe. Visit the [Zowe Tutorial 
 
 The Zowe community is also currently working to provide a vendor-neutral site for an open z/OS build and sandbox environment.
 
-Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more information, see [Configuring z/OSMF Lite](../user-guide/systemrequirements-zosmf-lite.html) on Zowe Docs.
+Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more information, see [Configuring z/OSMF Lite](../user-guide/systemrequirements-zosmf-lite.md) on Zowe Docs.
 
 </details>
 

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -1,42 +1,236 @@
 # Frequently Asked Questions
 
-## Zowe CLI
+Check out the following FAQs to learn more about the purpose and function of Zowe. 
 
-The following questions are frequently asked about Zowe CLI:
+- [Zowe FAQ](#zowe-faq)
+- [Zowe CLI FAQ](#zowe-cli-faq)
 
-- [Why might I use Zowe CLI versus a traditional ISPF interface to perform mainframe tasks?](#why-might-i-use-zowe-cli-versus-a-traditional-ispf-interface-to-perform-mainframe-tasks)
-- [With what tools is Zowe CLI compatible?](#with-what-tools-is-zowe-cli-compatible)
-- [Which method should I use to install Zowe CLI?](#which-method-should-i-use-to-install-zowe-cli)
-- [How can I get help with using Zowe CLI?](#how-can-i-get-help-with-using-zowe-cli)
-- [How can I use Zowe CLI to automate mainframe actions?](#how-can-i-use-zowe-cli-to-automate-mainframe-actions)
-- [How can I contribute to Zowe CLI?](#how-can-i-contribute-to-zowe-cli)
 
-### Why might I use Zowe CLI versus a traditional ISPF interface to perform mainframe tasks?
+## Zowe FAQ
+
+**What is Zowe?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+Zowe is an open source project within the [Open Mainframe Project](https://www.openmainframeproject.org/) that is part of [The Linux Foundation](https://www.linuxfoundation.org). The Zowe project provides modern software interfaces on IBM z/OS to address the needs of a variety of modern users. These interfaces include a new web graphical user interface, a script-able command-line interface, extensions to existing REST APIs, and new REST APIs on z/OS.
+
+</details>
+
+**Who is the target audience for using Zowe?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+Zowe technology can be used by a variety of mainframe IT and non-IT professionals. The target audience is primarily application developers and system programmers, but the Zowe Application Framework is the basis for developing web browser interactions with z/OS that can be used by anyone. 
+
+</details>
+
+**What language is Zowe written in?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+Zowe consists of several components. The primary languages are Java and JavaScript. Zowe CLI is written in TypeScript.
+
+</details>
+
+**What is the licensing for Zowe?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+Zowe source code is licensed under EPL2.0. For license text click [here](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt) and for additional information click [here](https://www.eclipse.org/legal/epl-2.0/faq.php). 
+
+In the simplest terms (taken from the FAQs above) - "...if you have modified EPL-2.0 licensed source code and you distribute that code or binaries built from that code outside your company, you must make the source code available under the EPL-2.0."
+
+</details>
+
+
+**Why is Zowe licensed using EPL2.0?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+The Open Mainframe Project wants to encourage adoption and innovation, and also let the community share new source code across the Zowe ecosystem. The open source code can be used by anyone, provided that they adhere to the licensing terms.
+
+</details>
+
+
+**What are some examples of how Zowe technology might be used by z/OS products and applications?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+The Zowe Desktop (web user interface) can be used in many ways, such as to provide custom graphical dashboards that monitor data for z/OS products and applications.
+
+Zowe CLI can also be used in many ways, such as for simple job submission, data set manipulation, or for writing complex scripts for use in mainframe-based DevOps pipelines. 
+
+The increased capabilities of RESTful APIs on z/OS allows APIs to be used in programmable ways to interact with z/OS services. 
+
+</details>
+
+
+**What is the best way to get started with Zowe?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+Zowe provides a convenience build that includes the components released-to-date, as well as IP being considered for contribution, in an easy to install package on [Zowe.org](https://zowe.org/home/). The convenience build can be easily installed and the Zowe capabilities seen in action. 
+
+To get started installing the complete Zowe solution, see [Installing Zowe](https://zowe.github.io/docs-site/latest/user-guide/installandconfig.html).
+
+To get up and running with the Zowe CLI component quickly, see [Zowe CLI quick start](https://zowe.github.io/docs-site/latest/getting-started/cli-getting-started.html).
+
+</details>
+
+
+**What are the prerequisites for Zowe?**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+The primary prerequisites is Java on z/OS and the z/OS Management Facility enabled and configured. For more information, see [System requirements](https://zowe.github.io/docs-site/latest/user-guide/systemrequirements.html).
+
+</details>
+
+
+**xxxxxxxx**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+
+</details>
+
+
+**xxxxxxxx**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+
+</details>
+
+
+**xxxxxxxx**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+
+</details>
+
+
+**xxxxxxxx**
+
+<details>
+
+<summary> Click to show answer </summary>
+
+The Open Mainframe Project wants to encourage adoption of the technology and foster innovation plus allow new source code to be shared across the Zowe ecosystem. The open source code can be used by anyone provided they adhere to the licensing terms. 
+
+</details>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Zowe CLI FAQ
+
+**Why might I use Zowe CLI versus a traditional ISPF interface to perform mainframe tasks?**
+
+<details>
+
+<summary> Click to show answer  </summary>
 
 For new developers, command line interfaces might be more familiar than an ISPF interface. Zowe CLI lets developers be productive from day-one by using familiar tools. Zowe CLI also lets developers write scripts that automate a sequence of mainframe actions. The scripts can then be executed from off-platform automation tools such as Jenkins automation server, or manually during development.
 
-### With what tools is Zowe CLI compatible?
+</details>
+
+
+**With what tools is Zowe CLI compatible?**
+
+<details>
+
+<summary> Click to show answer </summary>
 
 Zowe CLI is very flexible! It can work in conjunction with popular build and testing tools such as Gulp and Gradle, Mocha and Junit. Zowe CLI runs on a variety of operating systems, including Windows, macOS, and Linux. Zowe CLI scripts can be abstracted into automation tools such as Jenkins and TravisCI. This is a key advantage of the CLI - developers can integrate with modern tools that work best for them.
 
-### Which method should I use to install Zowe CLI?
+</details>
+
+
+**Which method should I use to install Zowe CLI?**
+
+<details>
+
+<summary> Click to show answer  </summary>
 
 You can install Zowe CLI using the following methods:
+
 - **Local package installation:** The local package method lets you install Zowe CLI from a zipped file that contains the core application and all plug-ins. When you use the local package method, you can install Zowe CLI in an offline environment. We recommend that you download the package and distribute it internally if your site does not have internet access.
+
 - **Online NPM registry:** The online NPM (Node Package Manager) registry method unpacks all of the files that are necessary to install Zowe CLI using the command line. When you use the online registry method, you need an internet connection to install Zowe CLI
 
-### How can I get help with using Zowe CLI?
+</details>
+
+
+**How can I get help with using Zowe CLI?**
+
+<details>
+
+<summary> Click to show answer  </summary>
 
 - You can get help for any command, action, or option in Zowe CLI by issuing the command 'zowe --help'.
 - For information about the available commands in Zowe CLI, see [Command Groups](../user-guide/cli-usingcli.md#zowe-cli-command-groups).
 - If you have questions, the [Zowe Slack space](https://openmainframeproject.slack.com/) is the place to ask our community!
 
-### How can I use Zowe CLI to automate mainframe actions?
+</details>
+
+**How can I use Zowe CLI to automate mainframe actions?**
+
+<details>
+
+<summary> Click to show answer  </summary>
 
 - You can automate a sequence of Zowe CLI commands by writing bash scripts. You can then run your scripts in an automation server such as Jenkins. For example, you might write a script that moves your Cobol code to a mainframe test system before another script runs the automated tests.
 - Zowe CLI lets you manipulate data sets, submit jobs, provision test environments, and interact with mainframe systems and source control management, all of which can help you develop robust continuous integration/delivery.
 
-### How can I contribute to Zowe CLI?
+</details>
+
+
+**How can I contribute to Zowe CLI?**
+
+<details>
+
+<summary> Click to show answer  </summary>
 
 As a developer, you can extend Zowe CLI in the following ways:
 
@@ -47,3 +241,5 @@ As a developer, you can extend Zowe CLI in the following ways:
 - Fix bugs in Zowe CLI or plug-in code, submit enhancement requests via GitHub issues, and raise your ideas with the community in Slack.
 
     **Note:** For more information, see [Developing for Zowe CLI](../extend/extend-cli/cli-devTutorials.md#how-can-i-contribute).
+
+</details>

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -100,7 +100,7 @@ The primary prerequisites is Java on z/OS and the z/OS Management Facility enabl
 
 </details>
 
-**How is access security managed on z/OS?**
+### How is access security managed on z/OS?
 
 <details>
 
@@ -171,7 +171,7 @@ Zowe is also compatible with IBM z/OSMF Lite for non-production use. For more in
 
 <summary> Click to show answer  </summary>
 
-For new developers, command line interfaces might be more familiar than an ISPF interface. Zowe CLI lets developers be productive from day-one by using familiar tools. Zowe CLI also lets developers write scripts that automate a sequence of mainframe actions. The scripts can then be executed from off-platform automation tools such as Jenkins automation server, or manually during development.
+For developers new to the mainframe, command-line interfaces might be more familiar than an ISPF interface. Zowe CLI lets developers be productive from day-one by using familiar tools. Zowe CLI also lets developers write scripts that automate a sequence of mainframe actions. The scripts can then be executed from off-platform automation tools such as Jenkins automation server, or manually during development.
 
 </details>
 
@@ -182,7 +182,7 @@ For new developers, command line interfaces might be more familiar than an ISPF 
 
 <summary> Click to show answer </summary>
 
-Zowe CLI is very flexible! It can work in conjunction with popular build and testing tools such as Gulp and Gradle, Mocha and Junit. Zowe CLI runs on a variety of operating systems, including Windows, macOS, and Linux. Zowe CLI scripts can be abstracted into automation tools such as Jenkins and TravisCI. This is a key advantage of the CLI - developers can integrate with modern tools that work best for them.
+Zowe CLI is very flexible; developers can integrate with modern tools that work best for them. It can work in conjunction with popular build and testing tools such as Gulp, Gradle, Mocha, and Junit. Zowe CLI runs on a variety of operating systems, including Windows, macOS, and Linux. Zowe CLI scripts can be abstracted into automation tools such as Jenkins and TravisCI. 
 
 </details>
 


### PR DESCRIPTION
Moved the FAQs content from [https://zowe.org/faq/](https://zowe.org/faq) to the Getting Started > Zowe FAQs section on docs-site. We already had CLI-specific FAQs in the doc site, so I generalized the name of the existing topic, added the general FAQs, and moved the CLI content to the bottom. 

**Notes:**
- @Tbr00ksy can you please confirm that the content is accurate and useful in your opinion? Feel free to tag others who might want to add or adjust the content.
- I made changes, such as removing some future-tense references to what Zowe "will do", as this content was written pre-GA, fixing grammar, and adding relevant links. 
- Doc Squad, please build this and see if the format/style is OK. Open to suggestions/improvement. 

Fixes #559 