### PR TITLE
#606 Fix the directory name issue and some typos

### DIFF
--- a/docs/user-guide/install-zos.md
+++ b/docs/user-guide/install-zos.md
@@ -394,10 +394,11 @@ To install Zowe API Mediation Layer, Zowe Application Framework, and z/OS Servic
     
 8. Configure Zowe as a started task.
     <!-- TODO -->
-    The ZOWESVR must be configured as a started task (STC) under the IZUSVR user ID.  You can do this after the `zowe-install.sh` script has completed by running the script `zowe-config-stc.sh`.  To run this script, use the `cd` command to switch to the Zowe runtime directory that you specified in the `install:rootDir` in the `zowe-install.yaml` file, and execute the script from the `/install` directory that is created by the `pax` command.  For example:
+    The ZOWESVR must be configured as a started task (STC) under the IZUSVR user ID.  You can do this after the `zowe-install.sh` script has completed by running the script `zowe-config-stc.sh`.  To run this script, use the `cd` command to switch to the `scripts` directory that is created by the `pax` command. For example:
+
      ```
-     cd /var/zowe/1.3.0
-     /zowe/builds/install/zowe-config-stc.sh
+     cd /zowe/builds/scripts
+     zowe-config-stc.sh
      ```
     Alternatively, you can issue the commands manually:
     
@@ -608,7 +609,7 @@ Once the cross memory server is installed and started, there will be started tas
 
 ### Manually installing the Zowe Cross Memory Server
 <!-- TODO. Entire sub-section -->
-A number of files are included in the USS directory `zowe_install_dir/files/zss`.  If this directory is not present, you must create it by expanding the file `zowe_install_dir/files/zss.pax`.  To do this, first create the folder `zss` beneath `files` using the command `mkdir zss` and navigate into the `zss` folder using the command `cd zss`. Then, expand the `zss.pax` file using the command `pax -ppx -rf ../zss.pax`. 
+A number of files are included in the USS directory `$INSTALL_DIR/files/zss`.  If this directory is not present, you must create it by expanding the file `$INSTALL_DIR/files/zss.pax`.  To do this, first create the folder `zss` beneath `files` using the command `mkdir zss` and navigate into the `zss` folder using the command `cd zss`. Then, expand the `zss.pax` file using the command `pax -ppx -rf ../zss.pax`. 
 
 The manual installation consists of the following steps.
 
@@ -657,7 +658,7 @@ The manual installation consists of the following steps.
 
 1. PARMLIB member
 
-    The Zowe cross memory server started task requires a valid ZWESISPxx PARMLIB member to be found at startup. The file `zowe_install_dir/files/zss/SAMPLIB/ZWESIP00` contains the default configuration values.  You can copy this member to your system PARMLIB data set, or allocate the default PDS data set ZWES.SISAMP that is specified in the ZWESIS01 started task JCL.
+    The Zowe cross memory server started task requires a valid ZWESISPxx PARMLIB member to be found at startup. The file `$INSTALL_DIR/files/zss/SAMPLIB/ZWESIP00` contains the default configuration values.  You can copy this member to your system PARMLIB data set, or allocate the default PDS data set ZWES.SISAMP that is specified in the ZWESIS01 started task JCL.
 
 1. Security requirements for the cross memory server
 
@@ -832,13 +833,13 @@ The manual installation consists of the following steps.
 
 ### Scripted install of the Zowe Cross Memory Server 
 <!-- TODO. Entire sub-section -->
-For users who have sufficient authority under their user ID to the z/OS instance they are installing the Zowe cross memory server into, there is a convenience script provided in `/zowe_install_dir/install/zowe-install-apf-server.sh`.
+For users who have sufficient authority under their user ID on the z/OS instance where they are installing the Zowe cross memory server, a convenience script is provided in `$INSTALL_DIR/install/zowe-install-apf-server.sh`.
 
 - The script will create the APF authorized load library, copy the load module, create the PROCLIB, define the `ZWES.IS` FACILITY class and give READ access to the ZOWESVR user ID.  
 - The script will not create the PPT entry which must be done manually.  This is done using the steps described in step "5. Security requirements for the cross memory server" in [Manually installing the Zowe Cross Memory Server](#manually-installing-the-zowe-cross-memory-server). 
 - The script will not create anything for the ICSF cryptographic services.  These are described in step "6. ICSF cryptographic services" in [Manually installing the Zowe Cross Memory Server](#manually-installing-the-zowe-cross-memory-server).
 
-Because the parameters that are used to control the script are contained in the file `/zowe_install_dir/install/zowe-install-apf-server.yaml`, you must edit this file before running the `zowe-install-apf-server.sh` script with appropriate values.
+Because the parameters that are used to control the script are contained in the file `$INSTALL_DIR/install/zowe-install-apf-server.yaml`, you must edit this file before running the `zowe-install-apf-server.sh` script with appropriate values.
 
 ```
 # Datasets that APF server will be installed into
@@ -872,8 +873,8 @@ users:
 where, 
 
 - _users:zoweUser_ is the TSO user ID that the ZOWESVR started task runs under.  For the majority of installs, this will be IZUSVR, so enter IZUSVR as the value, and the script will give this user access to the `READ ZWES.IS FACILITY` class that allows Zowe to use the cross memory server.
-- _users:sctUser_ is the user ID that the ZWESIS01 started task will be run under.  Enter the same value as the user ID that is running ZOWESVR, so choose IZUSVR.
-- _users:stcUserUid_.  This is the Unix user ID of the TSO user ID used to run the ZWESIS01 started task. If the user ID is IZUSVR to see the Unix user ID enter the command `id IZUSVR` which will return the sctUserUid in the uid result.  In the example below IZUSVR has a uid of 210, so `users:stcUserUid=210` should be entered.  
+- _users:stcUser_ is the user ID that the ZWESIS01 started task will be run under.  Enter the same value as the user ID that is running ZOWESVR, so choose IZUSVR.
+- _users:stcUserUid_.  This is the Unix user ID of the TSO user ID used to run the ZWESIS01 started task. If the user ID is IZUSVR to see the Unix user ID enter the command `id IZUSVR` which will return the stcUserUid in the uid result.  In the example below IZUSVR has a uid of 210, so `users:stcUserUid=210` should be entered.  
 
     ```
    /:>id IZUSVR


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com>

- Fixed the install directory name. Now all uses `$INSTALL_DIR`
- Fixed two typos
- Reworded one sentence
- Updated the commands to locate the zowe-config-stc.sh script