### PR TITLE
Some fixes to the Zowe CLI troubleshooting

### DIFF
--- a/docs/troubleshoot/cli/cli-issue.md
+++ b/docs/troubleshoot/cli/cli-issue.md
@@ -1,6 +1,6 @@
 # Raising a CLI issue on GitHub
 
-When necessary, you can raise GitHub Issues against the CLI repository [here](https://github.com/zowe/zowe-cli/issues). We suggest using either the bug or enhancement template.
+When necessary, you can raise GitHub issues against the Zowe CLI repository [here](https://github.com/zowe/zowe-cli/issues). It is suggested that you use either the bug or enhancement template.
 
 ## Raising a bug report
 

--- a/docs/troubleshoot/cli/mustgather-cli.md
+++ b/docs/troubleshoot/cli/mustgather-cli.md
@@ -1,6 +1,8 @@
 # Gathering information to troubleshoot Zowe CLI
 
-Follow these instructions to gather specific pieces of information to help troubleshoot CLI issues.
+Follow these instructions to gather specific pieces of information to help troubleshoot Zowe CLI issues.
+
+[[toc]]
 
 ## Identify the currently installed CLI version
 
@@ -24,7 +26,7 @@ For the `@lts-incremental` version:
 npm list -g @brightside/core
 ```
 
-More information regarding versioning conventions for Zowe CLI and plug-ins is located in [Versioning Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/MaintainerVersioning.md) 
+More information regarding versioning conventions for Zowe CLI and plug-ins is located in [Versioning Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/MaintainerVersioning.md). 
 
 ## Identify the currently installed versions of plug-ins
 
@@ -42,7 +44,8 @@ The following settings are configurable via environment variables:
 
 ### Log levels
 
-Environment variables are available to specify logging level and the CLI home directory
+Environment variables are available to specify logging level and the CLI home directory.
+
 **Important\!** Setting the log level to TRACE or ALL might result in "sensitive" data being logged. For example, command line arguments will be logged when TRACE is set.
 
 | Environment Variable | Description | Values | Default |
@@ -58,7 +61,7 @@ You can set the location on your computer where Zowe CLI creates the *.zowe* dir
 | ---------------------- | ----------- | ------ | ------- |
 | `ZOWE_CLI_HOME`  | Zowe CLI home directory location | Any valid path on your computer | Your computer default home directory |
 
-The values for these can be **echo**ed
+The values for these can be **echo**ed.
 
 ## Home directory structure
 
@@ -68,17 +71,17 @@ The values for these can be **echo**ed
 
 There are two sets of logs to be aware of:
 
-    - Imperative CLI Framework log, which generally contains installation and configuration information. 
+- Imperative CLI Framework log, which generally contains installation and configuration information. 
     
-    - Zowe CLI log, which contains information about interaction between CLI and the server endpoints. 
+- Zowe CLI log, which contains information about interaction between CLI and the server endpoints. 
     
-Analyzed these logs for any information relevant to your issue.
+Analyze these logs for any information relevant to your issue.
 
 ### Profile configuration
 
 The `profiles` folder stores connnection information. 
 
-**Important\!** The profile directory might contain "sensitive" information, such as the users mainframe password. Users should obfuscate aby sensitive references before providing configuration files.
+**Important\!** The profile directory might contain "sensitive" information, such as your mainframe password. You should obfuscate any sensitive references before providing configuration files.
 
 ## Node.js and npm
 Zowe CLI should be compatible with Node.js v8 and greater. 
@@ -91,28 +94,28 @@ npm --version
 ```
 
 ### npm configuration 
-If the user is having trouble installing Zowe CLI from an npm registry, gather their npm configuration to help identify issues with registry settings, global install paths, proxy settings, etc...
+If you are having trouble installing Zowe CLI from an npm registry, gather your npm configuration to help identify issues with registry settings, global install paths, proxy settings, etc...
 
 ```
 npm config ls -l
 ```
 
 ### npm log files
-In case of errors, npm creates log files in the `npm_cache\_logs` location. To get the `npm_cache` location for a specific OS, run:
+In case of errors, npm creates log files in the `npm_cache\_logs` location. To get the `npm_cache` location for a specific OS, run the following command:
 
 ```
 npm config get cache
 ```
 
-By default, npm keeps only 10 log files, but sometimes more are needed. You can instruct the user to increase the log count. Issue:
+By default, npm keeps only 10 log files, but sometimes more are needed. Increase the log count by issuing the following command:
 
 ```
 npm config set logs-max 50
 ```
 
-- This command increases the log count to 50, so that more log files will be stored on the system. Now the user can run tests multiple times and not lose the log files. The logs can be passed to Support for analysis. 
+This command increases the log count to 50, so that more log files will be stored on the system. Now you can run tests multiple times and not lose the log files. The logs can be passed to Support for analysis. 
 
-As the log files are created only when an npm conmmand fails, but you are interested to see what is executed, you can increase the loglevel of npm. Issue:
+As the log files are created only when an npm conmmand fails, but you are interested to see what is executed, you can increase the log level of npm. Issue the following command:
 
 ```
 npm config set loglevel verbose
@@ -122,4 +125,6 @@ npm config set loglevel verbose
 
 - The available log levels are:
 "silent", "error", "warn", "notice", "http", "timing", "info", "verbose", "silly", and "notice". "Notice" is the default.
-- Alternatively, you can pass `--loglevel verbose` on the command line, but this only works with npm related commands. By setting log level in the config, it also works when you issue some `zowe` commands that use npm (for ex. `zowe plugins install @zowe/cics`).
+<!--Explain what each log level means-->
+
+- Alternatively, you can pass `--loglevel verbose` on the command line, but this only works with npm related commands. By setting log level in the config, it also works when you issue some `zowe` commands that use npm (for example, `zowe plugins install @zowe/cics`).

--- a/docs/troubleshoot/cli/troubleshoot-cli.md
+++ b/docs/troubleshoot/cli/troubleshoot-cli.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-The CLI is experiencing a problem. You need to collect information that will help you resolve the issue. 
+Zowe CLI is experiencing a problem. You need to collect information that will help you resolve the issue. 
 
 ### Environment
 
@@ -10,7 +10,7 @@ These instructions apply to Zowe CLI installed on Windows, Mac OS X, and Linux s
 
 ## Before reaching out for support
 
-1. Is there already a GitHub Issue (open or closed) that covers the problem? Check [CLI Issues](https://github.com/zowe/zowe-cli/issues).
+1. Is there already a GitHub issue (open or closed) that covers the problem? Check [CLI Issues](https://github.com/zowe/zowe-cli/issues).
 2. Review the current list of [Known issues](known-cli.md) in documentation. Also try searching using the Zowe Docs search bar.
 
 ## Resolving the problem 

--- a/docs/troubleshoot/cli/zosmf-cli.md
+++ b/docs/troubleshoot/cli/zosmf-cli.md
@@ -1,11 +1,11 @@
 # z/OSMF troubleshooting
 The core command groups use the z/OSMF REST APIs which can experience any number of problems.
 
-If the user is experiencing HTTP 500 errors with the CLI, consider gathering the following:
+If you encounter HTTP 500 errors with the CLI, consider gathering the following information:
 1. The IZU* (IZUSVR and IZUANG) joblogs (z/OSMF server)
 2. z/OSMF USS logs (default location: /global/zosmf/data/logs - but may change depending on installation)
 
-If the user is experiencing HTTP 401 errors with the CLI, consider gathering the following:
+If you encounter HTTP 401 errors with the CLI, consider gathering the following information:
 1. Any security violations for the TSO user in SYSLOG
 
 ## Alternate methods


### PR DESCRIPTION
- Fixed a list that is displayed in blank on the doc site. Removed the extra spaces.
- Changed to second person for some descriptions. It targets at users so used "you".
- Some other small enhancements.

Signed-off-by: nannanli <nannanli@cn.ibm.com>