### PR TITLE
Update TOC of docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -185,19 +185,20 @@ const ALL_PAGES = [{
   text: 'References',
   hideInPdf: true,
   canHideFirst: true,
-  baseuri: '/appendix/',
   items: [
     {
       text: 'Zowe CLI command reference', link: 'https://zowe.github.io/docs-site/latest/web_help/index.html'
     },
     {
     text: 'Bill of Materials',
+    baseuri: '/appendix/',
     items: [
       'appendix/bill-of-materials.md'
     ]
   },
   {
     text: 'Third-Party Software Requirements',
+    baseuri: '/appendix/',
     items: [
       'appendix/tpsr.md'
     ]

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -183,22 +183,22 @@ const ALL_PAGES = [{
 },
 {
   text: 'References',
+  baseuri: '/appendix/',
   hideInPdf: true,
   canHideFirst: true,
   items: [
     {
-      text: 'Zowe CLI command reference', link: 'https://zowe.github.io/docs-site/latest/web_help/index.html'
+      text: 'Zowe CLI command reference',
+      link: './web_help/index.html'
     },
     {
     text: 'Bill of Materials',
-    baseuri: '/appendix/',
     items: [
       'appendix/bill-of-materials.md'
     ]
   },
   {
     text: 'Third-Party Software Requirements',
-    baseuri: '/appendix/',
     items: [
       'appendix/tpsr.md'
     ]

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -182,11 +182,14 @@ const ALL_PAGES = [{
   ]
 },
 {
-  text: 'Appendix',
+  text: 'References',
   hideInPdf: true,
   canHideFirst: true,
   baseuri: '/appendix/',
   items: [
+    {
+      text: 'Zowe CLI command reference', link: 'https://zowe.github.io/docs-site/latest/web_help/index.html'
+    },
     {
     text: 'Bill of Materials',
     items: [
@@ -429,11 +432,6 @@ module.exports = {
       ...navbarLinks,
       // MODIFICATION_FROM_THEME versions dropdown placeholder, it will be converted when rendering
       { tags: ['versions'] },
-      {
-        text: 'Feedback',
-        canHideFirst: true,
-        link: 'https://forms.gle/Ztu9AjgV6HRr1kEs9'
-      },
       {
         text: 'Zowe.org',
         link: 'https://zowe.org',

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,3 +60,13 @@ Detailed documentation on commands, actions, and options in Zowe CLI. The refere
 A Zowe overview deck in PDF format is available for download. The information in this deck provides an introduction to Zowe, its vision and value statements, a deeper dive into the technology, how to get involved in the community, and more.
 
 [Download PDF](./Zowe_Overview.pdf)  |  [Download PowerPoint](https://ibm.box.com/s/1l34h38at1fgvmy1ghtu09owdhewx1sm)
+
+## Give Feedback
+
+Your feedback is important to us. Tell us what you think about the experience by taking the survey, creating an issue in GitHub, or leaving comments when a **How are we doing?** window pops up.
+
+[Take Survey](https://forms.gle/Ztu9AjgV6HRr1kEs9)  |  [Create Issue in GitHub](https://github.com/zowe/docs-site/issues)
+
+We review your feedback and make improvements to provide better content experience. Take a look at what we have been doing to address the feedback.
+
+[Progress Update](https://github.com/zowe/docs-site/wiki/User-feedback-and-content-update)


### PR DESCRIPTION
- Removed the `Feedback` link on the top navbar
- Moved the feedback section to the homepage
- Changed `Appendix` to `References` 
- Added the link to the CLI reference guide to the `References` drop down list