### PR TITLE
Fix the download link on master branch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ footer: Except where otherwise noted, content on this site is licensed under a C
     <p>Learn about how you can contribute to this documentation. Read about the Zowe UI and code guidelines to help you contribute to Zowe.</p>
   </div>
   <div class="feature">
-    <h2><a href="https://zowe.org/home/">Getting Help</a></h2>
+    <h2><a href="https://zowe.org/">Getting Help</a></h2>
     <p>Visit Zowe.org where you can experience our applications and join Zowe communities.</p>
   </div>
 </div>

--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -81,7 +81,7 @@ The increased capabilities of RESTful APIs on z/OS allows APIs to be used in pro
 
 <summary> Click to show answer </summary>
 
-Zowe provides a convenience build that includes the components released-to-date, as well as IP being considered for contribution, in an easy to install package on [Zowe.org](https://zowe.org/home/). The convenience build can be easily installed and the Zowe capabilities seen in action. 
+Zowe provides a convenience build that includes the components released-to-date, as well as IP being considered for contribution, in an easy to install package on [Zowe.org](https://zowe.org). The convenience build can be easily installed and the Zowe capabilities seen in action. 
 
 To install the complete Zowe solution, see [Installing Zowe](../user-guide/installandconfig.md).
 
@@ -117,7 +117,7 @@ Zowe components use typical z/OS System authorization facility (SAF) calls for s
 
 <summary> Click to show answer </summary>
 
-The source code for Zowe is maintained on an Open Mainframe Project GitHub server. Everyone has read access. "Committers" on the project have authority to alter the source code to make fixes or enhancements. A list of Committers is documented in the [Zowe Charter](https://zowe.org/Zowe-Charter.pdf).
+The source code for Zowe is maintained on an Open Mainframe Project GitHub server. Everyone has read access. "Committers" on the project have authority to alter the source code to make fixes or enhancements. A list of Committers is documented in [Committers to the Zowe project](https://github.com/zowe/community/blob/master/COMMITTERS.md).
 
 </details>
 
@@ -130,7 +130,7 @@ The source code for Zowe is maintained on an Open Mainframe Project GitHub serve
 
 The best way to get started is to join a [Zowe Slack channel](https://slack.openmainframeproject.org/) and/or email distribution list and begin learning about the current capabilities, then contribute to future development. 
 
-For more information about emailing lists, community calendar, meeting minutes, and more, see [Contribute](https://zowe.org/contribute/) on Zowe.org.  
+For more information about emailing lists, community calendar, meeting minutes, and more, see the [Zowe Community](https://github.com/zowe/community/blob/master/README.md) GitHub repo.  
 
 For information and tutorials about extending Zowe with a new plug-in or application, see [Extending](../extend/extend-apiml/api-mediation-onboard-overview.md) on Zowe Docs.
 

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -29,7 +29,7 @@ If you do not have internet access at your site, use the following method to ins
 
         npm is included with the Node.js installation. Issue the command `npm --version` to verify that npm is installed.
 
-2. Obtain the installation files. From the Zowe [Download](https://zowe.org/download/) website, click **Download Zowe Command Line Interface** to download the Zowe CLI installation package named `zowe-cli-package-*v*.*r*.*m*.zip` to your computer.
+2. Obtain the installation files. From the Zowe [Download](https://zowe.org/#download) website, click **Zowe Command Line Interface** to download the Zowe CLI installation package named `zowe-cli-package-*v*.*r*.*m*.zip` to your computer.
 
     **Note:**
     -  *v* indicates the version

--- a/docs/user-guide/install-zos.md
+++ b/docs/user-guide/install-zos.md
@@ -28,7 +28,7 @@ The Zowe installation file for Zowe z/OS components are distributed as a PAX fil
 
 The numbers are incremented each time a release is created so the higher the numbers, the later the release. 
 
-To download the PAX file, open your web browser and click the *DOWNLOAD Zowe z/OS Components* button on the [Zowe Download](https://zowe.org/download/) website to save it to a folder on your desktop. After you obtain the PAX file, follow the procedures below to verify the PAX file and prepare it to install the Zowe runtime.
+To download the PAX file, open your web browser and click the *Zowe z/OS Components* button on the [Zowe Download](https://zowe.org/#download) website to save it to a folder on your desktop. After you obtain the PAX file, follow the procedures below to verify the PAX file and prepare it to install the Zowe runtime.
 
 **Follow these steps:**
 

--- a/docs/user-guide/update-zos.md
+++ b/docs/user-guide/update-zos.md
@@ -7,7 +7,7 @@ In the past, to update Zowe on z/OS, you had to install a new version of Zowe on
 Ensure that you meet the following requirements before you run the update script:
 
   - Stop a running instance of Zowe.
-  - Download and unpaсk the [pax file](https://zowe.org/download/). Use the following command to unpack the file:
+  - Download and unpaсk the [pax file](https://zowe.org/#download). Use the following command to unpack the file:
     ```
      pax -ppx -rf <path/to/pax>
     ```


### PR DESCRIPTION
The download link has changed after zowe.org is refreshed.

Signed-off-by: nannanli <nannanli@cn.ibm.com>