### PR TITLE
Acf2 tss iss670

### DIFF
--- a/docs/user-guide/systemrequirements-zosmf.md
+++ b/docs/user-guide/systemrequirements-zosmf.md
@@ -96,9 +96,9 @@ User IDs   | User IDs require a TSO segment (access) and an OMVS segment. During
 
 **Note:** If your implementation uses an external security manager other than RACF (for example, CA Top Secret for z/OS or CA ACF2 for z/OS), you provide equivalent commands for your environment. For more information, see the following product documentation:
 
-- [Configure z/OS Management Facility for CA Top Secret](https://docops.ca.com/ca-top-secret-for-z-os/16-0/en/installing/configure-z-os-management-facility-for-ca-top-secret)
+- [Configure z/OS Management Facility for CA Top Secret](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/security/ca-top-secret-for-z-os/16-0/installing/configure-z-os-management-facility-for-ca-top-secret.html)
 
-- [Configure z/OS Management Facility for CA ACF2](https://docops.ca.com/ca-acf2-for-z-os/16-0/en/installing-and-implementing/configure-z-os-management-facility-for-ca-acf2)
+- [Configure z/OS Management Facility for CA ACF2](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/security/ca-acf2-for-z-os/16-0/installing-and-implementing/configure-z-os-management-facility-for-ca-acf2.html)
 
 ## z/OSMF REST services for the Zowe CLI
 The Zowe CLI uses z/OSMF Representational State Transfer (REST) APIs to work with system resources and extract system data. Ensure that the following REST services are configured and available.

--- a/docs/user-guide/systemrequirements-zosmf.md
+++ b/docs/user-guide/systemrequirements-zosmf.md
@@ -94,11 +94,11 @@ User IDs   | User IDs require a TSO segment (access) and an OMVS segment. During
 
     Point your browser at the nominated z/OSMF STANDALONE Server home page and you should see its Welcome Page where you can log in.
 
-**Note:** If your implementation uses an external security manager other than RACF (for example, CA Technologies, a Broadcom Company, Top Secret or CA Technologies ACF2), you provide equivalent commands for your environment. For more information, see the following product documentation:
+**Note:** If your implementation uses an external security manager other than RACF (for example, CA Top Secret for z/OS or CA ACF2 for z/OS), you provide equivalent commands for your environment. For more information, see the following product documentation:
 
-- [Configure z/OS Management Facility for CA Technologies Top Secret](https://docops.ca.com/ca-top-secret-for-z-os/16-0/en/installing/configure-z-os-management-facility-for-ca-top-secret)
+- [Configure z/OS Management Facility for CA Top Secret](https://docops.ca.com/ca-top-secret-for-z-os/16-0/en/installing/configure-z-os-management-facility-for-ca-top-secret)
 
-- [Configure z/OS Management Facility for CA Technologies ACF2](https://docops.ca.com/ca-acf2-for-z-os/16-0/en/installing-and-implementing/configure-z-os-management-facility-for-ca-acf2)
+- [Configure z/OS Management Facility for CA ACF2](https://docops.ca.com/ca-acf2-for-z-os/16-0/en/installing-and-implementing/configure-z-os-management-facility-for-ca-acf2)
 
 ## z/OSMF REST services for the Zowe CLI
 The Zowe CLI uses z/OSMF Representational State Transfer (REST) APIs to work with system resources and extract system data. Ensure that the following REST services are configured and available.


### PR DESCRIPTION
Removed "Technologies"  from the names of the CA security products reverenced in the article.
Updated the target URLs to point to the techdocs versions of the URLs. 


Resolves issue #670 