### PR TITLE
allow to check https://docs.zowe.org/latest/ without following path

### DIFF
--- a/gh-pages-default/404.html
+++ b/gh-pages-default/404.html
@@ -95,7 +95,7 @@
         }, 10000);
       };
       if (url) {
-        var m = url.match(/^https?:\/\/([^\/]+\/)([^\/]+\/)(.+)$/);
+        var m = url.match(/^https?:\/\/([^\/]+\/)([^\/]+\/)(.*)$/);
         if (m) {
           need = false;
           if (m[1] !== 'docs.zowe.org/') {

--- a/gh-pages-default/404.html
+++ b/gh-pages-default/404.html
@@ -48,6 +48,10 @@
         font-size: 14px;
         margin: 0 10px;
       }
+      #legacy-url {
+        color: #393;
+        font-weight: bold;
+      }
 
     </style>
   </head>
@@ -63,9 +67,10 @@
       </p>
 
       <p id="legacy-url" style="display: none;">
-        We have added documentation version support, so this may be caused by
-        you are visiting a legacy link. Please click on this
-        <a id="new-doc-link">link</a>, or the page will redirect in 10 seconds.
+        We have migrated our documentation website URLs recently. This error may
+        be caused by you are visiting a legacy link.<br /><br />Please click
+        <a id="new-doc-link">here</a> to visit the updated link, or the page will
+        be redirected to the new link in 10 seconds.
       </p>
 
       <div id="suggestions">


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

https://docs.zowe.org/latest/ will show a 404 page without any redirecting help information. This change will fix it.