### PR TITLE
Fix mini-ToC in the summary of changes article

### DIFF
--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -1,18 +1,17 @@
 # Release notes
 
-Learn about what is new, changed, removed, and known issues in Zowe. 
+Learn about what is new, changed, removed, and known issues in Zowe.
 
 Zowe Version 1.5.0 and later releases include the following enhancements, release by release.
 
-- [Release notes](#release-notes)
-  - [Version 1.5.0 (September 2019)](#version-150-september-2019)
-  - [Zowe SMP/E Alpha (August 2019)](#zowe-smpe-alpha-august-2019)
-  - [Version 1.4.0 (August 2019)](#version-140-august-2019)
-  - [Version 1.3.0 (June 2019)](#version-130-june-2019)
-  - [Version 1.2.0 (May 2019)](#version-120-may-2019)
-  - [Version 1.1.0 (April 2019)](#version-110-april-2019)
-  - [Version 1.0.1 (March 2019)](#version-101-march-2019)
-  - [Version 1.0.0 (February 2019)](#version-100-february-2019)
+- [Version 1.5.0 (September 2019)](#version-1-5-0-september-2019)
+- [Zowe SMP/E Alpha (August 2019)](#zowe-smp-e-alpha-august-2019)
+- [Version 1.4.0 (August 2019)](#version-1-4-0-august-2019)
+- [Version 1.3.0 (June 2019)](#version-1-3-0-june-2019)
+- [Version 1.2.0 (May 2019)](#version-1-2-0-may-2019)
+- [Version 1.1.0 (April 2019)](#version-1-1-0-april-2019)
+- [Version 1.0.1 (March 2019)](#version-1-0-1-march-2019)
+- [Version 1.0.0 (February 2019)](#version-1-0-0-february-2019)
 
 ## Version 1.5.0 (September 2019)
 

--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -4,14 +4,14 @@ Learn about what is new, changed, removed, and known issues in Zowe.
 
 Zowe Version 1.5.0 and later releases include the following enhancements, release by release.
 
-- [Version 1.5.0 (September 2019)](#version-1-5-0-september-2019)
-- [Zowe SMP/E Alpha (August 2019)](#zowe-smp-e-alpha-august-2019)
-- [Version 1.4.0 (August 2019)](#version-1-4-0-august-2019)
-- [Version 1.3.0 (June 2019)](#version-1-3-0-june-2019)
-- [Version 1.2.0 (May 2019)](#version-1-2-0-may-2019)
-- [Version 1.1.0 (April 2019)](#version-1-1-0-april-2019)
-- [Version 1.0.1 (March 2019)](#version-1-0-1-march-2019)
-- [Version 1.0.0 (February 2019)](#version-1-0-0-february-2019)
+- [Version 1.5.0 (September 2019)](#version-150-september-2019)
+- [Zowe SMP/E Alpha (August 2019)](#zowe-smpe-alpha-august-2019)
+- [Version 1.4.0 (August 2019)](#version-140-august-2019)
+- [Version 1.3.0 (June 2019)](#version-130-june-2019)
+- [Version 1.2.0 (May 2019)](#version-120-may-2019)
+- [Version 1.1.0 (April 2019)](#version-110-april-2019)
+- [Version 1.0.1 (March 2019)](#version-101-march-2019)
+- [Version 1.0.0 (February 2019)](#version-100-february-2019)
 
 ## Version 1.5.0 (September 2019)
 


### PR DESCRIPTION
summary of changes contained a link to the title of the article... removed