### PR TITLE
Add "Active Development" to v1.0 versions drop-down

### DIFF
--- a/docs/.vuepress/versions.json
+++ b/docs/.vuepress/versions.json
@@ -1,4 +1,8 @@
 [{
+  "text": "Active Development",
+  "link": "active-development/"
+},
+  {
   "text": "Stable",
   "link": "stable/"
 },


### PR DESCRIPTION
Updated versions.jason. Adding a link to the Versions drop that lets users open the newly created Active Development documentation.

Signed-off-by: jamesbauman <james.bauman@broadcom.com>