### PR TITLE
Add "Active Development" to v1.2 Versions drop-down

### DIFF
--- a/docs/.vuepress/versions.json
+++ b/docs/.vuepress/versions.json
@@ -1,6 +1,10 @@
 [{
-  "text": "Stable",
-  "link": "stable/"
+  "text": "Active Development",
+  "link": "active-development/"
+},
+{
+"text": "Stable",
+"link": "stable/"
 },
 {
   "text": "v1.3.x",


### PR DESCRIPTION
Updated versions.jason. Adding a link to the Versions drop that lets users open the newly created Active Development documentation.

Signed-off-by: jamesbauman <james.bauman@broadcom.com>