### PR TITLE
doc: Updated out-of-date STC naming scheme

### DIFF
--- a/docs/user-guide/configure-zowe-runtime.md
+++ b/docs/user-guide/configure-zowe-runtime.md
@@ -89,11 +89,11 @@ STC names have certain components and use the following format:
 
 where:
 
-- `pfx` - prefix that contains up to four characters, for example, `ZOWE`.
+- `pfx` - Prefix that contains up to four characters, for example, `ZOWE`.
 
-- `n` - instance number
+- `n` - Instance number
 
-- `SS` - a subcomponent that consists of 1 or 2 characters:
+- `SS` - A subcomponent. `SS` can be one of the following values:
    - **AG** - API ML Gateway
    - **AD** - API ML Discovery Service
    - **AC** - API ML Catalog
@@ -104,7 +104,7 @@ where:
    - **UU** - Explorer UI USS
    - **DT** - Zowe Desktop Application Server
 
-You should use the prefix for the main started task (+ number).
+The STC name of the main started task is `pfxnSV`. To view all the STCs for your instance of ZOWE in SDSF, you can use the PREFIX `pfxn*`.
 
 **Example:**
 

--- a/docs/user-guide/configure-zowe-runtime.md
+++ b/docs/user-guide/configure-zowe-runtime.md
@@ -91,6 +91,8 @@ where:
 
 - `pfx` - prefix that contains up to four characters, for example, `ZOWE`.
 
+- `n` - instance number
+
 - `SS` - a subcomponent that consists of 1 or 2 characters:
    - **AG** - API ML Gateway
    - **AD** - API ML Discovery Service
@@ -101,8 +103,6 @@ where:
    - **UJ** - Explorer UI Jobs
    - **UU** - Explorer UI USS
    - **DT** - Zowe Desktop Application Server
-
-- `N` - instance number
 
 You should use the prefix for the main started task (+ number).
 
@@ -116,7 +116,7 @@ You should use the prefix for the main started task (+ number).
   in the `zowe-install.yaml` file defines a prefix of ZOWE for the STC, so the first instance of Zowe API ML Gateway identifier will be as follows:
 
   ```
-  ZOWEAG1
+  ZOWE1AG
   ```
 #### Port allocations
 

--- a/docs/user-guide/configure-zowe-runtime.md
+++ b/docs/user-guide/configure-zowe-runtime.md
@@ -85,7 +85,7 @@ The file `scripts/configure/zowe-install.yaml` contains `key:value` pairs that c
 
 STC names have certain components and use the following format:
 
-```pfxSSn```
+```pfxnSS```
 
 where:
 


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com> 

The fix applies to V1.5.0 and later releases.

Fixes: https://github.com/zowe/docs-site/issues/725 