### PR TITLE
Propagate the Node v8.16.1 warning change to 1.5.x

### DIFF
--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -10,6 +10,10 @@ You can obtain IBM SDK for Node.js - z/OS for free in one of the following ways:
 
 For details, see the blog ["How to obtain IBM SDK for Node.js - z/OS, at no charge"](https://developer.ibm.com/mainframe/2019/04/17/ibm-sdk-for-node-js-z-os-at-no-charge/).
 
+**Known issue:** There is a known issue with node v8.16.1 and Zowe desktop encoding. See [https://github.com/ibmruntimes/node/issues/142](https://github.com/ibmruntimes/node/issues/142) for details.
+
+**Workaround:** Use node v8.16.0 which is available at [https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos). Download the `ibm-trial-node-v8.16.0-os390-s390x.pax.Z` file.
+
 ## Hardware and software requirements
 
 **Hardware:**


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com>

Fixes: #774 

In v1.4.x doc, we stated support of node V8.