### PR TITLE
Propagate the Node v8.16.1 warning change to 1.4.x

### DIFF
--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -4,11 +4,13 @@ Installing Zowe requires Node.js version 6.14.4.1 or later to be installed on th
 
 ## How to obtain IBM SDK for Node.js - z/OS
 
-IBM SDK for Node.js - z/OS, V6.0 (5655-SDK) is available at no license charge, as [announced in October 2018](https://www-01.ibm.com/common/ssi/cgi-bin/ssialias?infotype=AN&subtype=CA&htmlfid=897/ENUS918-171&appname=USN). You can obtain the free SDK for IBM Z Mainframe in one of several ways, depending on your requirements. For details, see the blog ["How to obtain IBM SDK for Node.js - z/OS, at no charge"](https://developer.ibm.com/mainframe/2019/04/17/ibm-sdk-for-node-js-z-os-at-no-charge/).
-
-To satisfy Zowe's prerequisite for Node.js - z/OS, you can choose one of the following ways: 
+You can obtain IBM SDK for Node.js - z/OS for free in one of the following ways:
 - Order the SMP/E version through your IBM representative for production use
 - Use the pax evaluation for non-production deployments
+
+**Known issue:** There is a known issue with node v8.16.1 and Zowe desktop encoding. See [https://github.com/ibmruntimes/node/issues/142](https://github.com/ibmruntimes/node/issues/142) for details.
+
+**Workaround:** Use node v8.16.0 which is available at [https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos). Download the `ibm-trial-node-v8.16.0-os390-s390x.pax.Z` file.
 
 ## Hardware and software requirements
 


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com>

Fixes: #774

In v1.4.x doc, we stated support of node V8.