### PR TITLE
Db2 slight rebrand

### DIFF
--- a/docs/user-guide/cli-db2plugin.md
+++ b/docs/user-guide/cli-db2plugin.md
@@ -1,4 +1,4 @@
-# IBM Db2 Database Plug-in for Zowe CLI 
+# IBM® Db2® Database Plug-in for Zowe CLI 
 
 The IBM® Db2® Database Plug-in for Zowe&trade; CLI lets you interact with Db2 for z/OS to perform tasks through Zowe CLI and integrate with modern development tools. The plug-in also lets you interact with Db2 to advance continuous integration and to validate product quality and stability.
 

--- a/docs/user-guide/cli-extending.md
+++ b/docs/user-guide/cli-extending.md
@@ -5,6 +5,6 @@ You can install plug-ins to extend the capabilities of Zowe&trade; CLI. Plug-ins
 **Important!** Plug-ins can gain control of your CLI application legitimately during the execution of every command. Install third-party plug-ins at your own risk. We make no warranties regarding the use of third-party plug-ins.
 
 - [Install plug-ins](cli-installplugins.md)
-- [Zowe plug-in for IBM® CICS](cli-cicsplugin.md)
-- [Zowe plug-in for IBM® Db2® Database](cli-db2plugin.md)
+- [IBM® CICS Plug-in for Zowe CLI](cli-cicsplugin.md)
+- [IBM® Db2® Database Plug-in for Zowe CLI](cli-db2plugin.md)
 - [Visual Studio Code (VSCode) Extension for Zowe](cli-vscodeplugin.md)


### PR DESCRIPTION
- Added "Database" to "IBM Db2 Plug-in for Zowe CLI" 
- Added copyright symbols