### PR TITLE
add vsc name change

### DIFF
--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -53,7 +53,9 @@ The following features and enhancements were added.
 - Allow override of configuration attributes using a -D argument syntax. [#154](https://github.com/zowe/zlux-server-framework/pull/154)
 - Allow specifying environment variables that can be interpreted as JSON structures. [#156](https://github.com/zowe/zlux-server-framework/pull/156) 
 
-#### Zowe CLI
+#### Zowe Explorer (Extension for VSCode)
+
+- The name of the extension was changed from "VSCode Extension for Zowe" to "Zowe Explorer".
 - The VSCode Extention for Zowe contains various changes in this this release. For more information, see the [VSCode Change Log](https://github.com/zowe/vscode-extension-for-zowe/blob/master/CHANGELOG.md#0270).  
 
 ### Bug fixes


### PR DESCRIPTION
The name of the VSC extension was changed. Reflecting this in release notes. 
Signed-off-by: BrandonJenkins14 <36675406+BrandonJenkins14@users.noreply.github.com>

