### PR TITLE
Draft - Secure Credential Store Plug-in for Zowe CLI 

### DIFF
--- a/docs/.vuepress/pages.json
+++ b/docs/.vuepress/pages.json
@@ -65,6 +65,7 @@
           "user-guide/cli-installplugins.md",
           "user-guide/cli-cicsplugin.md",
           "user-guide/cli-db2plugin.md",
+          "user-guide/cli-scsplugin.md",
           "user-guide/cli-vscodeplugin.md"
         ]
       }

--- a/docs/getting-started/cli-getting-started.md
+++ b/docs/getting-started/cli-getting-started.md
@@ -18,7 +18,7 @@ Get started with Zowe&trade; CLI quickly and easily.
      - [Example:](#example)
 - [Next Steps](#next-steps)
 
-## Installing 
+## Installing
 
 Before you install Zowe CLI, download and install [Node.js and npm.](https://nodejs.org/en/download/)
 
@@ -32,10 +32,12 @@ npm config set @brightside:registry https://api.bintray.com/npm/ca/brightside
 npm install @brightside/core@lts-incremental -g
 ```
 
-### Installing CLI plug-ins 
+### Installing CLI plug-ins
+
+<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 ```
-zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental
+zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@lts-zowe-2.x
 ```
 
 The command installs the IBM CICS plug-in, but the IBM Db2 plug-in requires [additional configuration to install](../user-guide/cli-db2plugin.md#installing).
@@ -64,13 +66,13 @@ See [Command Groups](../user-guide/cli-usingcli.md#zowe-cli-command-groups) for 
 
 ## Using profiles
 
-Zowe profiles let you store configuration details such as username, password, host, and port for a mainframe system. Switch between profiles to quickly target different subsystems and avoid typing connection details on every command. 
+Zowe profiles let you store configuration details such as username, password, host, and port for a mainframe system. Switch between profiles to quickly target different subsystems and avoid typing connection details on every command.
 
-### Profile types 
+### Profile types
 
 Most command groups require a `zosmf-profile`, but some plug-ins add their own profile types. For example, the CICS plug-in has a `cics-profile`. The profile type that a command requires is defined in the `PROFILE OPTIONS` section of the help response.
 
-**Tip:** The first `zosmf` profile that you create becomes your default profile. If you don't specify any options on a command, the default profile is used. Issue `zowe profiles -h` to learn about listing profiles and setting defaults. 
+**Tip:** The first `zosmf` profile that you create becomes your default profile. If you don't specify any options on a command, the default profile is used. Issue `zowe profiles -h` to learn about listing profiles and setting defaults.
 
 ### Creating a zosmf profile
 
@@ -101,7 +103,7 @@ You want to delete a list of temporary datasets. Use Zowe CLI to download the li
 
 set -e
 
-# Obtain the list of temporary project data sets 
+# Obtain the list of temporary project data sets
 dslist=$(zowe zos-files list dataset "my.project.ds*")
 
 # Delete each data set in the list

--- a/docs/getting-started/cli-getting-started.md
+++ b/docs/getting-started/cli-getting-started.md
@@ -37,7 +37,7 @@ npm install @brightside/core@lts-incremental -g
 <!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 ```
-zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@lts-zowe-2.x
+zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@zowe-v1-lts
 ```
 
 The command installs the IBM CICS plug-in, but the IBM Db2 plug-in requires [additional configuration to install](../user-guide/cli-db2plugin.md#installing).

--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -1,6 +1,6 @@
 # Release notes <!-- omit in toc -->
 
-Learn about what is new, changed, or removed in Zowe&trade;. 
+Learn about what is new, changed, or removed in Zowe&trade;.
 
 Zowe Version 1.7.1 and later releases include the following enhancements, release by release.
 
@@ -19,6 +19,10 @@ Zowe Version 1.7.1 and later releases include the following enhancements, releas
 ## Version 1.7.1 (December 2019)
 
 <!--If there is a corresponding GitHub issue, please also include the GitHub issue number. See v1.3.0 release notes as an example.-->
+
+
+<!-- NEW CLI PLUGIN ENTRY for 1.1.0LTS  -->
+<!-- The Secure Credential Store Plug-in for Zowe CLI is now available. The plug-in uses the credential manager of your OS to securely store mainframe credentials in your user profiles. For more information, see [Secure Credential Store Plug-in for Zowe CLI](../user-guide/cli-scsplugin.md) -->
 
 ### New features and enhancements
 
@@ -58,12 +62,12 @@ The following features and enhancements were added.
 - Cleanup Gateway - our code ([#417](https://github.com/zowe/api-layer/pull/417))
 - Cleanup Discovery Service dependency logs ([#403](https://github.com/zowe/api-layer/pull/403))
 - Cleanup Discovery Service - our code ([#407](https://github.com/zowe/api-layer/pull/407))
-- External option to activate DEBUG mode for APIML ([#410](https://github.com/zowe/api-layer/pull/410)) 
+- External option to activate DEBUG mode for APIML ([#410](https://github.com/zowe/api-layer/pull/410))
 
 #### Zowe App Server
 
-- Introduced the "SJ" feature to the JES Explorer application ([#282](https://github.com/zowe/zlux/issues/282))  
-  
+- Introduced the "SJ" feature to the JES Explorer application ([#282](https://github.com/zowe/zlux/issues/282))
+
   You can now right-click a job label and click "Get JCL" to retrieve the JCL used to submit the job.  This JCL can then be edited and resubmitted.
 
   <img src="../images/releasenotes/v17-sjdemo.gif" alt="SJ Demo" width="550px"/>
@@ -93,7 +97,7 @@ The following features and enhancements were added.
 The following bugs were fixed.
 
 #### API Mediation Layer
- 
+
 Fixed a typo in Gateway startup script. ([#427](https://github.com/zowe/api-layer/pull/427))
 
 #### Zowe App Server
@@ -102,10 +106,10 @@ Fixed notification click, time stamp, inconsistent notification manager pop up c
 
 #### Zowe CLI
 This version of Zowe CLI contains various bug fixes that address vulnerabilities.
-  
+
 ## Version 1.6.0 (October 2019)
 
-No changes were made to API ML or Zowe CLI in this release. 
+No changes were made to API ML or Zowe CLI in this release.
 
 ### What's new in the Zowe App Server
 
@@ -119,11 +123,11 @@ The following features and enhancements are added:
 
 ### What's new in Zowe CLI
 
-The following enhancement was added: 
+The following enhancement was added:
 
 - The `--wait-for-output` and the `--wait-for-active` options were added. You can append these options to a `zowe zos-jobs submit` command to either wait for the job to be active, or wait for the job to complete and enter OUTPUT status. If you do not specify `--vasc`, you can use these options to check job return codes without issuing `zowe zos-jobs view job-status-by-jobid <jobid>`.
 
-### What's new in the Visual Studio Code (VSC) Extension for Zowe 
+### What's new in the Visual Studio Code (VSC) Extension for Zowe
 
 The Visual Studio Code (VSC) Extension for Zowe lets you interact with data sets and USS files from a convenient graphical interface. Review the [Change Log](https://github.com/zowe/vscode-extension-for-zowe/blob/master/CHANGELOG.md) to learn about the latest improvements to the extension.
 
@@ -142,7 +146,7 @@ The following features and enhancements are added:
 
 The following bugs are fixed:
 
-- A defect has been resolved where previously an authentication message was thrown in the service detail page in the API Catalog when the swagger JSON document link was clicked. The message requires the user to provide mainframe credentials but did not link to an option to authenticate. Now, a link is included to provide the user with the option to authenticate. 
+- A defect has been resolved where previously an authentication message was thrown in the service detail page in the API Catalog when the swagger JSON document link was clicked. The message requires the user to provide mainframe credentials but did not link to an option to authenticate. Now, a link is included to provide the user with the option to authenticate.
 
 ### What's new in the Zowe App Server
 
@@ -178,7 +182,7 @@ The following features and enhancements are added:
 - Add keyboard shortcuts to open and close tabs ([#81](https://github.com/zowe/zlux-editor/pull/81))
 - Add loading indicator for dataset loading ([#34](https://github.com/zowe/zlux-file-explorer/pull/34))
 - Compress the terminals with gzip for improved initial load time, same as was done with the editor previously ([#22](https://github.com/zowe/tn3270-ng2/pull/22), [#23](https://github.com/zowe/vt-ng2/pull/23))
-- Made the following enhancements to the JES Explorer App 
+- Made the following enhancements to the JES Explorer App
   - Add ability to open and view multiple Spool files at once ([#99](https://github.com/zowe/explorer-jes/pull/99))
   - Migrate from V0 to V1 of Material UI ([#98](https://github.com/zowe/explorer-jes/pull/98))
   - Migrate from V15 to V16 of React ([#98](https://github.com/zowe/explorer-jes/pull/98))
@@ -199,12 +203,12 @@ The following bugs are fixed:
 The following commands and enhancements are added:
 
 - You can append `--help-web` to launch interactive command help in your Web browser. For more information, see [Interactive Web Help](../user-guide#interactive-web-help). [(#238)](https://github.com/zowe/imperative/issues/238)
-  
+
 
 ## Zowe SMP/E Alpha (August 2019)
 
-A pre-release of the Zowe SMP/E build is now available. This alpha release is based on Zowe Version 1.4.0. Do not use this alpha release in production environment. 
-- To obtain the SMP/E build, go to the [Zowe Download](https://www.zowe.org/#download) website. 
+A pre-release of the Zowe SMP/E build is now available. This alpha release is based on Zowe Version 1.4.0. Do not use this alpha release in production environment.
+- To obtain the SMP/E build, go to the [Zowe Download](https://www.zowe.org/#download) website.
 - For more information, see [Installing Zowe SMP/E Alpha](../user-guide/install-zowe-smpe.md).
 
 ## Version 1.4.0 (August 2019)
@@ -227,7 +231,7 @@ This release of Zowe API ML contains the following improvements:
     ```
     %d{yyyy-MM-dd HH:mm:ss.SSS,UTC} %clr(&lt;${logbackService:-${logbackServiceName}}:%thread:${PID:- }&gt;){magenta} %X{userid:-} %clr(%-5level) %clr(\(%logger{15},%file:%line\)){cyan} %msg%n
     ```
-    
+
 - Added an NPM command to register certificates on Windows. The following command installs the certificate to trusted root certification authorities:
     ```
     npm run register-certificates-win
@@ -302,14 +306,14 @@ The following bugs are fixed:
 <!-- TODO -->
 This release of Zowe API ML contains the following user experience improvements:
 
-- Added authentication endpoints (/login, /query) to the API Gateway 
+- Added authentication endpoints (/login, /query) to the API Gateway
 - Added the Gateway API Swagger document ([#305](https://github.com/zowe/api-layer/pull/305))
-    - Fixed the bug that causes JSON response to set incorrectly when unauthenticated 
-    - Fixed error messages shown when a home page cannot be modified 
-- Added a new e2e test for GW, and update the detail service tile ([#309](https://github.com/zowe/api-layer/pull/309)) 
+    - Fixed the bug that causes JSON response to set incorrectly when unauthenticated
+    - Fixed error messages shown when a home page cannot be modified
+- Added a new e2e test for GW, and update the detail service tile ([#309](https://github.com/zowe/api-layer/pull/309))
 - Removed a dependency of integration-enabler-java on the gateway-common ([#302](https://github.com/zowe/api-layer/pull/302))
 - Removed access to the Discovery service UI with basic authentication ([#313](https://github.com/zowe/api-layer/pull/313))  
-- Fixed the issue with the connection logic on headers to pass in the websocket ([#275](https://github.com/zowe/api-layer/pull/275)) 
+- Fixed the issue with the connection logic on headers to pass in the websocket ([#275](https://github.com/zowe/api-layer/pull/275))
 - Fixed the bug 264: Bypass the API Gateway when the server returns 302 ([#276](https://github.com/zowe/api-layer/pull/276))
 - Fixed the issue that causes the API ML Services display as UP, and makes the API doc available in the Catalog regardless whether the API ML Services stop ([#287](https://github.com/zowe/api-layer/pull/287))
 - Fixed the issue that prevents the API Catalog to load under zLux 9 ([314](https://github.com/zowe/api-layer/pull/314))
@@ -335,7 +339,7 @@ Made the following fixes and enhancements:
   - Fixed an issue with files shown without alphabetical sorting. ([#85](https://github.com/zowe/zlux/issues/85))
 - Made the following fixes and enhancements to the TN3270 application ([#96](https://github.com/zowe/zlux-server-framework/pull/96)):
   - Fixed an issue where the application could not be configured to default to a TLS connection.
-  - Fixed an issue where it could not handle a TN3270 connection, only TN3270E. 
+  - Fixed an issue where it could not handle a TN3270 connection, only TN3270E.
     Improved preference saving. Administrators can now store default values for terminal mod type, codepage, and screen dimensions.
 - Made the following fixes and enhancements for App2App for IFrames ([#24](https://github.com/zowe/zlux-platform/pull/24), [#107](https://github.com/zowe/zlux-app-manager/pull/107)):
   - Fixed an issue with an exception when handling App2App communication with IFrames.
@@ -372,7 +376,7 @@ The following bugs are fixed:
 <!-- ### What's changed -->
 <!-- TODO. Fix the link once the doc is ready -->
 <!-- - An update script for Zowe is introduced. Now you can update all Zowe applications with the update script. For more information, see [Zowe Update Script](../user-guide/update-zos.md). -->
-    
+
 
 ## Version 1.2.0 (May 2019)
 
@@ -383,33 +387,33 @@ Version 1.2.0 contains the following changes since Version 1.1.0.
 - Made the following installer improvements:
   - Check whether ICSF is configured before checking Node version to avoid runaway CPU.
   - Warn if the host name that is determined by the installer is not a valid IP address.
-  - Fixed a bug where a numeric value is specified in ZOWE_HOST_NAME causing errors generating the Zowe certificate. 
+  - Fixed a bug where a numeric value is specified in ZOWE_HOST_NAME causing errors generating the Zowe certificate.
 - Made the following improvements to the `zowe-check-prereqs.sh` script:
   - Improvements for checking and validating the telnet and ssh port required by the Zowe Desktop applications.
 
 ### What's new in API Mediation Layer
 This release of Zowe API ML contains the following user experience improvements:
 - Prevented the Swagger UI container on the service detail page from
-spilling.                                                                                                                             
-- Added a check for the availability of the z/OSMF URL contained in the  
-configuration. z/OSMF is used to verify users logging into the Catalog.  
+spilling.
+- Added a check for the availability of the z/OSMF URL contained in the
+configuration. z/OSMF is used to verify users logging into the Catalog.
 - Made _PageNotFound_ error visible only in the debug log level.
 - Added zD&T-compatible ciphers and the TLS protocol restricted to 1.2.
 - Introduced support for VSCode development.
 - Introduced a common cipher configuration property.
 - Fixed URL transformation defects.
-- Fixed reporting that the Catalog is down when it is started before the 
-Discovery Service.                                                       
-- Removed the bean overriding error message from the log.                
-- Fixed the state manipulation mechanism in the Catalog. As a result, no 
-restoring of the application state is performed.                         
-- Fixed the Catalog routing mechanism for a users who is already logged  
-in so that the user is not prompted to log in again.                     
+- Fixed reporting that the Catalog is down when it is started before the
+Discovery Service.
+- Removed the bean overriding error message from the log.
+- Fixed the state manipulation mechanism in the Catalog. As a result, no
+restoring of the application state is performed.
+- Fixed the Catalog routing mechanism for a users who is already logged
+in so that the user is not prompted to log in again.
 - A timeout has been set for Catalog login when z/OSMF is not responding.
-- A tile change in the Catalog is now propagated to the UI.              
+- A tile change in the Catalog is now propagated to the UI.
 - Fixed a problem with an incorrect service homepage link in the Catalog.
 - The Catalog Login button has been disabled when the login request is in
-progress.  
+progress.
 
 ### What's new in the Zowe App Server
 - Improved security by adding support for RBAC (Role Based Access Control) to enable Zowe to determine whether a user is authorized to access a dataservice.
@@ -429,13 +433,13 @@ The Zowe CLI core component contains the following improvements and fixes:
 - The zowe `zos-workflows` command group now contains the following `active-workflow-details` options:
 
     - `--steps-summary-only | --sso (boolean)`: An optional parameter that lets you list (only) the steps summary.
-    - `--skip-workflow-summary | --sws (boolean)`: An optional parameter that lets you skip the default workflow summary. 
+    - `--skip-workflow-summary | --sws (boolean)`: An optional parameter that lets you skip the default workflow summary.
 
 - Zowe CLI was updated to correct an issue where the `zowe zos-workflows start` command ignored the `-- workflow-name` argument.
 
 - Updated and clarified the description the `-- overwrite` option for the `zowe zos-workflows create workflow-from-data-set` command and the `Zowe zos-workflows create workflow-from-uss-file` command.
 
-- The [CLI Reference Guide](../CLIReference_Zowe.pdf) is featured on the Zowe Docs home page. The document is a comprehensive guide to commands and options in Zowe CLI. 
+- The [CLI Reference Guide](../CLIReference_Zowe.pdf) is featured on the Zowe Docs home page. The document is a comprehensive guide to commands and options in Zowe CLI.
 
 - You can now click the links on the Welcome to Zowe help section and open the URL in a browser window. Note that the shell application must support the capability to display and click hyperlinks.
 
@@ -544,7 +548,7 @@ Version 1.0.0 contains the following changes since the Open Beta release.
 
 ### What's new in API Mediation Layer
 
-- HTTPs is now supported on all Java enablers for onboarding API microservices with the API ML.  
+- HTTPs is now supported on all Java enablers for onboarding API microservices with the API ML.
 
 - SSO authentication using z/OSMF has been implemented for the API Catalog login.  Mainframe credentials are required for access.
 
@@ -552,7 +556,7 @@ Version 1.0.0 contains the following changes since the Open Beta release.
 
 -  **Breaking change to Zowe CLI**: The `--pass` command option is changed to `--password` for all core Zowe CLI commands for clarity and to be consistent with plug-ins. If you have zosmf profiles that you created prior to January 11, 2019, you must recreate them to use the `--password` option. The aliases `--pw` and `--pass` still function when you issue commands as they did prior to this breaking change. You do not need to modify scripts that use  `--pass`.
 
-- The `@next` npm tag used to install Zowe CLI is deprecated. Use the `@latest` npm tag to install the product with the online registry method. 
+- The `@next` npm tag used to install Zowe CLI is deprecated. Use the `@latest` npm tag to install the product with the online registry method.
 
 ### What's new in the Zowe Desktop
 

--- a/docs/user-guide/cli-cicsplugin.md
+++ b/docs/user-guide/cli-cicsplugin.md
@@ -1,4 +1,4 @@
-# IBM® CICS® Plug-in for Zowe CLI
+# IBM® CICS® Plug-in for Zowe&trade; CLI
 
 The IBM® CICS® Plug-in for Zowe&trade; CLI lets you extend Zowe CLI to interact with CICS programs and transactions. The plug-in uses the IBM CICS® Management Client Interface (CMCI) API to achieve the interaction with CICS. For more information, see [CICS management client interface](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.3.0/com.ibm.cics.ts.clientapi.doc/topics/clientapi_overview.html) on the IBM Knowledge Center.
 

--- a/docs/user-guide/cli-cicsplugin.md
+++ b/docs/user-guide/cli-cicsplugin.md
@@ -1,4 +1,4 @@
-# IBM® CICS® Plug-in for Zowe CLI 
+# IBM® CICS® Plug-in for Zowe CLI
 
 The IBM® CICS® Plug-in for Zowe&trade; CLI lets you extend Zowe CLI to interact with CICS programs and transactions. The plug-in uses the IBM CICS® Management Client Interface (CMCI) API to achieve the interaction with CICS. For more information, see [CICS management client interface](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.3.0/com.ibm.cics.ts.clientapi.doc/topics/clientapi_overview.html) on the IBM Knowledge Center.
 
@@ -13,15 +13,15 @@ The IBM® CICS® Plug-in for Zowe&trade; CLI lets you extend Zowe CLI to interac
 
 As an application developer, you can use the plug-in to perform the following tasks:
 
-  - Deploy code changes to CICS applications that were developed with COBOL. 
-  - Deploy changes to CICS regions for testing or delivery. See the [define command](#commands) for an example of how you can define programs to CICS to assist with testing and delivery. 
+  - Deploy code changes to CICS applications that were developed with COBOL.
+  - Deploy changes to CICS regions for testing or delivery. See the [define command](#commands) for an example of how you can define programs to CICS to assist with testing and delivery.
   - Automate CICS interaction steps in your CI/CD pipeline with Jenkins Automation Server or TravisCI.
   - Deploy build artifacts to CICS regions.
-  - Alter, copy, define, delete, discard, and install CICS resources and resource definitions. 
+  - Alter, copy, define, delete, discard, and install CICS resources and resource definitions.
 
-## Commands 
+## Commands
 
-For detailed documentation on commands, actions, and options available in this plug-in, see our Web Help. It is available for download in three formats: a PDF document, an interactive online version, and a ZIP file containing the HTML for the online version.
+For detailed command, actions, and option documentation for this plug-in, see our Web Help (available in three formats: interactive online, PDF, or ZIP):
 
 - <a href="../web_help/index.html" target="_blank">Browse Online</a>
 - <a href="../zowe_web_help.zip">Download (ZIP)</a>
@@ -38,10 +38,10 @@ Use one of the following methods to install or update the plug-in:
 - [Installing plug-ins from an online registry](cli-installplugins.md#installing-plug-ins-from-an-online-registry)
 
 - [Installing plug-ins from a local package](cli-installplugins.md#installing-plug-ins-from-a-local-package)
-      
+
 ## Creating a user profile
 
-You can set up a CICS profile to avoid typing your connection details on every command. The profile contains your host, port, username, and password for the CMCI instance of your choice. You can create multiple profiles and switch between them if necessary. Issue the following command to create a cics profile: 
+You can set up a CICS profile to avoid typing your connection details on every command. The profile contains your host, port, username, and password for the CMCI instance of your choice. You can create multiple profiles and switch between them if necessary. Issue the following command to create a cics profile:
 
 ```
 zowe profiles create cics <profile name> -H <host> -P <port> -u <user> -p <password>

--- a/docs/user-guide/cli-db2plugin.md
+++ b/docs/user-guide/cli-db2plugin.md
@@ -1,11 +1,11 @@
-# IBM® Db2® Database Plug-in for Zowe CLI 
+# IBM® Db2® Database Plug-in for Zowe&trade; CLI
 
 The IBM® Db2® Database Plug-in for Zowe&trade; CLI lets you interact with Db2 for z/OS to perform tasks through Zowe CLI and integrate with modern development tools. The plug-in also lets you interact with Db2 to advance continuous integration and to validate product quality and stability.
 
 Zowe CLI Plug-in for IBM Db2 Database lets you execute SQL statements against a Db2 region, export a Db2 table, and call a stored procedure. The plug-in also exposes its API so that the plug-in can be used directly in other products.
 
 [[toc]]
-  
+
 ## Use cases
 
 As an application developer, you can use Zowe CLI Plug-in for IBM DB2 Database to perform the following tasks:
@@ -15,9 +15,9 @@ As an application developer, you can use Zowe CLI Plug-in for IBM DB2 Database t
   - Export tables to a local file on your computer in SQL format.
   - Call a stored procedure and pass parameters.
 
-## Commands 
+## Commands
 
-For detailed documentation on commands, actions, and options available in this plug-in, see our Web Help. It is available for download in three formats: a PDF document, an interactive online version, and a ZIP file containing the HTML for the online version.
+For detailed command, actions, and option documentation for this plug-in, see our Web Help (available in three formats: interactive online, PDF, or ZIP):
 
 - <a href="../web_help/index.html" target="_blank">Browse Online</a>
 - <a href="../zowe_web_help.zip">Download (ZIP)</a>
@@ -60,9 +60,9 @@ Download the ODBC driver before you install the Db2 plug-in.
 
 2. Create a new directory named `odbc_cli`  on your computer. Remember the path to the new directory. You will need to provide the full path to this directory immediately before you install the Db2 plug-in.
 
-3. Place the ODBC driver in the `odbc_cli` folder. **Do not extract the ODBC driver**.  
+3. Place the ODBC driver in the `odbc_cli` folder. **Do not extract the ODBC driver**.
 
-You downloaded and prepared to use the ODBC driver successfully. Proceed to install the plug-in to Zowe CLI. 
+You downloaded and prepared to use the ODBC driver successfully. Proceed to install the plug-in to Zowe CLI.
 
 #### Installing the plug-in
 
@@ -100,9 +100,9 @@ Now that the Db2 ODBC CLI driver is downloaded, set the `IBM_DB_INSTALLER_URL` e
 
 ## Addressing the license requirement
 
-The following steps are required for both the registry and offline package installation methods: 
+The following steps are required for both the registry and offline package installation methods:
 
-1. Locate your client copy of the Db2 license. You must have a properly licensed and configured Db2 instance for the Db2 plugin to successfully connect to Db2 on z/OS. 
+1. Locate your client copy of the Db2 license. You must have a properly licensed and configured Db2 instance for the Db2 plugin to successfully connect to Db2 on z/OS.
 
     **Note:** The license must be of version 11.1 if the Db2 server is not `db2connectactivated`. You can buy a db2connect license from IBM. The connectivity can be enabled either on server using db2connectactivate utility or on client using client side license file.
     To know more about DB2 license and purchasing cost, please contact IBM Customer Support.
@@ -116,7 +116,7 @@ The following steps are required for both the registry and offline package insta
         ```
         <zowe_home>/plugins/installed/lib/node_modules/@brightside/db2/node_modules/ibm_db/installer/clidriver/license
         ```
-    **Tip:** By default, <zowe_home> is set to `~/.zowe` on \*NIX systems, and `C:\Users\<Your_User>\.zowe` on Windows systems. 
+    **Tip:** By default, <zowe_home> is set to `~/.zowe` on \*NIX systems, and `C:\Users\<Your_User>\.zowe` on Windows systems.
 
     After the license is copied, you can use the Db2 plugin functionality.
 
@@ -137,7 +137,7 @@ Issue the command `-DISPLAY DDF` in the SPUFI or ask your DBA for the following 
 To create a db2 profile in Zowe CLI, issue the following command with your connection details for the Db2 instance:
 
 ```
-zowe profiles create db2 <profile name> -H <host> -P <port> -d <database> -u <user> -p <password>  
+zowe profiles create db2 <profile name> -H <host> -P <port> -d <database> -u <user> -p <password>
 ```
 
 **Note** For more information, issue the command `zowe profiles create db2-profile --help`

--- a/docs/user-guide/cli-extending.md
+++ b/docs/user-guide/cli-extending.md
@@ -1,10 +1,11 @@
 # Extending Zowe CLI
 
-You can install plug-ins to extend the capabilities of Zowe&trade; CLI. Plug-ins CLI to third-party applications are also available, such as Visual Studio Code Extension for Zowe (powered by Zowe CLI). Plug-ins add functionality to the product in the form of new command groups, actions, objects, and options. 
+You can install plug-ins to extend the capabilities of Zowe&trade; CLI. Plug-ins CLI to third-party applications are also available, such as Visual Studio Code Extension for Zowe (powered by Zowe CLI). Plug-ins add functionality to the product in the form of new command groups, actions, objects, and options.
 
 **Important!** Plug-ins can gain control of your CLI application legitimately during the execution of every command. Install third-party plug-ins at your own risk. We make no warranties regarding the use of third-party plug-ins.
 
 - [Install plug-ins](cli-installplugins.md)
 - [IBM® CICS Plug-in for Zowe CLI](cli-cicsplugin.md)
 - [IBM® Db2® Database Plug-in for Zowe CLI](cli-db2plugin.md)
+- [Secure Credential Store Plug-in for Zowe CLI](cli-scsplugin.md)
 - [Visual Studio Code (VSCode) Extension for Zowe](cli-vscodeplugin.md)

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -84,6 +84,8 @@ If your computer is connected to the Internet, you can use the following method 
 
 2.  Issue the following command to set the registry to the Zowe CLI scoped package. In addition to setting the scoped registry, your default registry must be set to an npm registry that includes all of the dependencies for Zowe CLI, such as the global npm registry:
 
+<!-- in zowe-v1-lts the registry will become Public NPM and the scope becomes @zowe for core and plugins -->
+
     ```
     npm config set @brightside:registry https://api.bintray.com/npm/ca/brightside
     ```
@@ -99,7 +101,7 @@ If your computer is connected to the Internet, you can use the following method 
 <!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
     ```
-    zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@lts-zowe-2.x
+    zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@zowe-v1-lts
     ```
 
     **Note:** The IBM Db2 plug-in requires additional configuration. For more information about how to install multiple plug-ins, update to a specific version of a plug-in, and install from specific registries, see [Installing plug-ins](cli-installplugins.md).

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -1,6 +1,6 @@
 # Installing Zowe CLI
 
-Install Zowe&trade; CLI on your computer. You can learn about new CLI features in the [Release notes](../getting-started/summaryofchanges.md) or read about overall CLI functionality in the [Zowe overview](../getting-started/overview.md). 
+Install Zowe&trade; CLI on your computer. You can learn about new CLI features in the [Release notes](../getting-started/summaryofchanges.md) or read about overall CLI functionality in the [Zowe overview](../getting-started/overview.md).
 
 **Tip:** If you are familiar with command-line tools and want to get started using Zowe CLI quickly, see [Zowe CLI quick start](../getting-started/cli-getting-started.md)
 
@@ -53,7 +53,7 @@ If you do not have internet access at your site, use the following method to ins
 4. Issue the following command against the extracted directory to install Zowe CLI on your computer:
 
     ```
-    npm install -g zowe-cli.tgz 
+    npm install -g zowe-cli.tgz
     ```
 
     **Note:** On Linux, you might need to prepend `sudo` to your `npm` commands so that you can issue the install and uninstall commands. For more information, see [Troubleshooting Zowe CLI](../troubleshoot/cli/troubleshoot-cli.md).
@@ -96,8 +96,10 @@ If your computer is connected to the Internet, you can use the following method 
 
 4. (Optional) To install all available plug-ins to Zowe CLI, issue the following command:
 
+<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
+
     ```
-    zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental
+    zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@lts-zowe-2.x
     ```
 
     **Note:** The IBM Db2 plug-in requires additional configuration. For more information about how to install multiple plug-ins, update to a specific version of a plug-in, and install from specific registries, see [Installing plug-ins](cli-installplugins.md).

--- a/docs/user-guide/cli-installplugins.md
+++ b/docs/user-guide/cli-installplugins.md
@@ -7,11 +7,12 @@ Use commands in the `plugins` command group to install and manage Zowe&trade; CL
 You can install the following Zowe plug-ins:
 - IBM® CICS® Plug-in for Zowe CLI
 - IBM® Db2® Plug-in for Zowe CLI
+- Secure Credential Store Plug-in for Zowe CLI
 - [Third-party Zowe Conformant Plug-ins](https://www.openmainframeproject.org/projects/zowe/conformance)
 
 Use either of the following methods to install plug-ins:
 
-- Install from an online NPM registry. Use this method when your computer ***can*** access the Internet. 
+- Install from an online NPM registry. Use this method when your computer ***can*** access the Internet.
 
     For more information, see [Installing plug-ins from an online registry](#installing-plug-ins-from-an-online-registry).
 
@@ -28,13 +29,13 @@ Install Zowe CLI plug-ins using npm commands on Windows, Mac, and Linux. The pro
 1. Meet the [software requirements for each plug-in](cli-swreqplugins.md) that you install.
 
 2.  Set the proper target registry by issuing the following command:
-   
+
       ```
       npm config set @brightside:registry https://api.bintray.com/npm/ca/brightside
       ```
 
 3.  Issue the following command to install a plug-in:
-   
+
       ```
       zowe plugins install <my-plugin>
       ```
@@ -44,18 +45,20 @@ Install Zowe CLI plug-ins using npm commands on Windows, Mac, and Linux. The pro
     | Plug-in | Installation Command Syntax |
     |---------|-----------------------------|
     | IBM CICS Plug-in for Zowe CLI | `@brightside/cics@lts-incremental` |
-    | IBM Db2 Plug-in for Zowe CLI| `@brightside/db2@lts-incremental` |
-    |    |    |
+    | IBM Db2 Plug-in for Zowe CLI | `@brightside/db2@lts-incremental` |
+    | Secure Credential Store Plug-in for Zowe CLI  | `@zowe/secure-credential-store-for-zowe-cli@lts-zowe-2.x` | | | |
+
+<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 4.  (Optional) Issue the following command to install two or more plug-ins using one command. Separate the `<my-plugin>` names with one space.
-   
+
     ```
     zowe plugins install <@brightside/my-plugin1> <@brightside/my-plugin2> <@brightside/my-plugin3> ...
     ```
-    
+
     **Note:** The IBM Db2 Plug-in for Zowe CLI requires additional licensing and ODBC driver configurations. If you installed the DB2 plug-in, see [IBM Db2 Plug-in for Zowe CLI](cli-db2plugin.md).
 
-You installed Zowe CLI plug-ins. 
+You installed Zowe CLI plug-ins.
 
 ## Installing plug-ins from a local package
 
@@ -64,7 +67,7 @@ Install plug-ins from a local package on any computer that has limited or no acc
 **Follow these steps:**
 
 1.  Meet the [software requirements for each plug-in](cli-swreqplugins.md) that you want to install.
-   
+
 2.  Obtain the installation files.
 
     From the Zowe [Download](https://zowe.org/download/) website, click **Download Zowe CLI** to download the Zowe CLI installation package named `zowe-cli-package-*v*.*r*.*m*.zip` to your computer.
@@ -105,8 +108,12 @@ Install plug-ins from a local package on any computer that has limited or no acc
     |---------|-----------------|
     | IBM CICS Plug-in for Zowe CLI | `cics.tgz` |
     | IBM Db2 Plug-in for Zowe CLI | `db2.tgz` |
+    | Secure Credential Store Plug-in for Zowe CLI | `secure-credential-store-for-zowe-cli.tgz` |
+    |||
 
-You installed Zowe CLI plug-ins. 
+<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
+
+You installed Zowe CLI plug-ins.
 
 ## Validating plug-ins
 
@@ -118,7 +125,7 @@ The `validate` command has the following syntax:
 zowe plugins validate [plugin]
 ```
 
-  - **`[plugin]`**  
+  - **`[plugin]`**
     (Optional) Specifies the name of the plug-in that you want to
     validate. If you do not specify a plug-in name, the command
     validates all installed plug-ins. The name of the plug-in is not always the same as the name of the NPM package.
@@ -127,7 +134,10 @@ zowe plugins validate [plugin]
     |-|-|
     |IBM CICS Plug-in for Zowe CLI|`@brightside/cics`|
     |IBM Db2 Plug-in for Zowe CLI|`@brightside/db2`|
+    | Secure Credential Store Plug-in for Zowe CLI | `@zowe/secure-credential-store-for-zowe-cli` |
     |||
+
+<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 **Examples: Validate plug-ins**
 
@@ -203,7 +213,10 @@ The following table describes the uninstallation command synstax for each plug-i
  |---------|-----------------------------|
  | IBM CICS Plug-in for Zowe CLI | `@brightside/cics` |
  | IBM Db2 Plug-in for Zowe CLI| `@brightside/db2` |
+ | Secure Credential Store Plug-in for Zowe CLI | `@zowe/secure-credential-store-for-zowe-cli` |
  |    |    |
+
+<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 **Example:**
 

--- a/docs/user-guide/cli-installplugins.md
+++ b/docs/user-guide/cli-installplugins.md
@@ -46,9 +46,7 @@ Install Zowe CLI plug-ins using npm commands on Windows, Mac, and Linux. The pro
     |---------|-----------------------------|
     | IBM CICS Plug-in for Zowe CLI | `@brightside/cics@lts-incremental` |
     | IBM Db2 Plug-in for Zowe CLI | `@brightside/db2@lts-incremental` |
-    | Secure Credential Store Plug-in for Zowe CLI  | `@zowe/secure-credential-store-for-zowe-cli@lts-zowe-2.x` | | | |
-
-<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
+    | Secure Credential Store Plug-in for Zowe CLI  | `@zowe/secure-credential-store-for-zowe-cli@zowe-v1-lts` |
 
 4.  (Optional) Issue the following command to install two or more plug-ins using one command. Separate the `<my-plugin>` names with one space.
 
@@ -109,7 +107,7 @@ Install plug-ins from a local package on any computer that has limited or no acc
     | IBM CICS Plug-in for Zowe CLI | `cics.tgz` |
     | IBM Db2 Plug-in for Zowe CLI | `db2.tgz` |
     | Secure Credential Store Plug-in for Zowe CLI | `secure-credential-store-for-zowe-cli.tgz` |
-    |||
+
 
 <!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
@@ -135,9 +133,6 @@ zowe plugins validate [plugin]
     |IBM CICS Plug-in for Zowe CLI|`@brightside/cics`|
     |IBM Db2 Plug-in for Zowe CLI|`@brightside/db2`|
     | Secure Credential Store Plug-in for Zowe CLI | `@zowe/secure-credential-store-for-zowe-cli` |
-    |||
-
-<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 **Examples: Validate plug-ins**
 
@@ -214,9 +209,7 @@ The following table describes the uninstallation command synstax for each plug-i
  | IBM CICS Plug-in for Zowe CLI | `@brightside/cics` |
  | IBM Db2 Plug-in for Zowe CLI| `@brightside/db2` |
  | Secure Credential Store Plug-in for Zowe CLI | `@zowe/secure-credential-store-for-zowe-cli` |
- |    |    |
 
-<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 **Example:**
 

--- a/docs/user-guide/cli-scsplugin.md
+++ b/docs/user-guide/cli-scsplugin.md
@@ -32,18 +32,21 @@ Use one of the following methods to install or update the plug-in:
 
 - [Installing plug-ins from a local package](cli-installplugins.md#installing-plug-ins-from-a-local-package)
 
-**Note:** Profiles that you create *after* you install the plug-in are secured automatically. Update your existing profiles to be securely stored.
+**Note:** Profiles that you created *before* installing the SCS plug-in must be manually updated. See the following section for details.
 
 ## Using
 
 ### Securing your credentials
-The plug-in introduces a new command group named `zowe scs` that converts all existing plain-text profiles into securely-stored profiles. Issue the following command:
+
+New profiles that you create *after* installing the plug-in are stored securely by default.
+
+For existing profiles, the plug-in introduces a new command group named `zowe scs` that converts the profile into securely-stored profiles. Issue the following command:
 
 ```
 zowe scs update
 ```
 
-The following is an example of securely stored credentials in a user profile
+The following is an example of securely stored credentials in a user profile configuration file:
 
 **Example: Credentials Secured with CA Secure Credential Store Plug-in for Zowe CLI**
 
@@ -55,7 +58,8 @@ user: 'managed by @brightside/secure-credential-store'
 pass: 'managed by @brightside/secure-credential-store'
 rejectUnauthorized: false
 ```
-If you do not have or do not activate the plug-in, your credential appear to be visible and are stored in plain text. The following is an example of credentials that are stored with a default credential manager of your operating system.
+
+The following is an example of credentials that are stored with a *default *credential manager of your operating system.
 
 **Example: Credentials Secured with a Default Credential Manager**
 
@@ -69,3 +73,11 @@ rejectUnauthorized: false
 ```
 
 ### Deactivating the plug-in
+Deactivate the Plug-in
+If you do not want to use CA Secure Credential Store Plug-in for Zowe CLI, choose one of the following methods to deactivate the plug-in:
+Uninstall the Plug-in
+Issue the zowe plugins uninstall [plugin] command to delete the plug-in from your computer.
+When you uninstall the plug-in, existing profiles become invalid and you have to recreate them. For more information, see Create CLI Profiles.
+If you uninstall the plug-in that was installed using the Windows installation wizard, you need to reset the value of the credential-manager property manually.
+Reset the Configuration of Credential Manager
+Issue the reset command to reset the value of the credential manager configuration to default and deactivate the plug-in.

--- a/docs/user-guide/cli-scsplugin.md
+++ b/docs/user-guide/cli-scsplugin.md
@@ -1,4 +1,4 @@
-# Secure Credential Store Plug-in for Zowe CLI
+# Secure Credential Store Plug-in for Zowe&trade; CLI
 
 The Secure Credential Store (SCS) Plug-in for Zowe CLI lets you store your credentials securely in the credential manager of your operating system. The plug-in invokes a native Node module, [keytar](https://github.com/atom/node-keytar), that manages user IDs and passwords in a credential manager.
 
@@ -44,9 +44,7 @@ User profiles that you create *after* installing the plug-in will automatically 
 
 To secure credentials in existing user profiles (profiles that you created prior to installing the SCS plug-in), issue the following command:
 
-```
-zowe scs update
-```
+    zowe scs update
 
 Profiles are updated with secured credentials.
 
@@ -59,7 +57,7 @@ type: zosmf
 host: test
 port: 1234
 user: 'managed by @zowe/secure-credential-store-for-zowe-cli'
-pass: 'managed by @zowe/secure-credential-store-for-zowe-cli'
+password: 'managed by @zowe/secure-credential-store-for-zowe-cli'
 rejectUnauthorized: false
 ```
 
@@ -72,7 +70,7 @@ type: zosmf
 host: test
 port: 1234
 user: USERNAME
-pass: PASSWORD
+password: PASSWORD
 rejectUnauthorized: false
 ```
 
@@ -88,4 +86,4 @@ When you uninstall the plug-in, existing profiles become invalid and you must re
 
 **Reset the Configuration of Credential Manager**
 
-Issue the `zowe scs reset` command to reset the value of the credential manager configuration to default, which deactivates the plug-in.
+Issue the `zowe config reset CredentialManager` command to reset the value of the credential manager configuration to default, which deactivates the plug-in.

--- a/docs/user-guide/cli-scsplugin.md
+++ b/docs/user-guide/cli-scsplugin.md
@@ -10,11 +10,11 @@ The Secure Credential Store (SCS) Plug-in for Zowe CLI lets you store your crede
 
 ## Use Cases
 
-Storing your credentials securely prevents your username and password from being compromised as a result of a malware attack or unlawful actions by others.
+Zowe CLI stores credentials in plaintext by default. Use the SCS plug-in to store credentials more securely and prevent your username and password from being compromised as a result of a malware attack or unlawful actions by others.
 
 ## Commands
 
-For detailed command, actions, and option documentation for this plug-in, see our Web Help (available in three formats: interactive online, PDF, or ZIP):
+For detailed command, actions, and option documentation for this plug-in, see our Web Help (available online or as PDF or ZIP):
 
 - <a href="../web_help/index.html" target="_blank">Browse Online</a>
 - <a href="../zowe_web_help.zip">Download (ZIP)</a>
@@ -32,36 +32,40 @@ Use one of the following methods to install or update the plug-in:
 
 - [Installing plug-ins from a local package](cli-installplugins.md#installing-plug-ins-from-a-local-package)
 
-**Note:** Profiles that you created *before* installing the SCS plug-in must be manually updated. See the following section for details.
+**Note:** Existing user profiles are not updated automatically. See "Securing your Credentials" in the following section for details.
 
 ## Using
 
+The plug-in introduces a new command group named `zowe scs` that you can use to enable/disable the plug-in and update existing user profiles.
+
 ### Securing your credentials
+User profiles that you create *after* installing the plug-in are stored securely.
 
-New profiles that you create *after* installing the plug-in are stored securely by default.
+If you created user profiles prior to installing the SCS plug-in,
 
-For existing profiles, the plug-in introduces a new command group named `zowe scs` that converts the profile into securely-stored profiles. Issue the following command:
+
+that converts the profile into securely-stored profiles. Issue the following command:
 
 ```
 zowe scs update
 ```
 
-The following is an example of securely stored credentials in a user profile configuration file:
+**Example: Credentials Secured with SCS plug-in**
 
-**Example: Credentials Secured with CA Secure Credential Store Plug-in for Zowe CLI**
+The following is an example of securely stored credentials in a user profile configuration file:
 
 ```yaml
 type: zosmf
 host: test
 port: 1234
-user: 'managed by @brightside/secure-credential-store'
-pass: 'managed by @brightside/secure-credential-store'
+user: 'managed by @zowe/secure-credential-store'
+pass: 'managed by @zowe/secure-credential-store'
 rejectUnauthorized: false
 ```
 
-The following is an example of credentials that are stored with a *default *credential manager of your operating system.
+**Example: Credentials secured with default credential manager**
 
-**Example: Credentials Secured with a Default Credential Manager**
+The following is an example of credentials that are stored with the *default* credential manager:
 
 ```yaml
 type: zosmf
@@ -73,11 +77,13 @@ rejectUnauthorized: false
 ```
 
 ### Deactivating the plug-in
-Deactivate the Plug-in
+
 If you do not want to use CA Secure Credential Store Plug-in for Zowe CLI, choose one of the following methods to deactivate the plug-in:
+
 Uninstall the Plug-in
 Issue the zowe plugins uninstall [plugin] command to delete the plug-in from your computer.
 When you uninstall the plug-in, existing profiles become invalid and you have to recreate them. For more information, see Create CLI Profiles.
 If you uninstall the plug-in that was installed using the Windows installation wizard, you need to reset the value of the credential-manager property manually.
+
 Reset the Configuration of Credential Manager
 Issue the reset command to reset the value of the credential manager configuration to default and deactivate the plug-in.

--- a/docs/user-guide/cli-scsplugin.md
+++ b/docs/user-guide/cli-scsplugin.md
@@ -1,0 +1,71 @@
+# Secure Credential Store Plug-in for Zowe CLI
+
+The Secure Credential Store (SCS) Plug-in for Zowe CLI lets you store your credentials securely in the credential manager of your operating system. The plug-in invokes a native Node module, named Keytar, that manages user IDs and passwords in a credential manager.
+
+  - [Use Cases](#use-cases)
+  - [Commands](#commands)
+  - [Software requirements](#software-requirements)
+  - [Installing](#installing)
+  - [Using](#using)
+
+## Use Cases
+
+Storing your credentials securely prevents your username and password from being compromised as a result of a malware attack or unlawful actions by others.
+
+## Commands
+
+For detailed command, actions, and option documentation for this plug-in, see our Web Help (available in three formats: interactive online, PDF, or ZIP):
+
+- <a href="../web_help/index.html" target="_blank">Browse Online</a>
+- <a href="../zowe_web_help.zip">Download (ZIP)</a>
+- <a href="../CLIReference_Zowe.pdf">Download (PDF)</a>
+
+## Software requirements
+
+Before you install the plug-in, meet the software requirements in [Software requirements for Zowe CLI plug-ins](cli-swreqplugins.md).
+
+## Installing
+
+Use one of the following methods to install or update the plug-in:
+
+- [Installing plug-ins from an online registry](cli-installplugins.md#installing-plug-ins-from-an-online-registry)
+
+- [Installing plug-ins from a local package](cli-installplugins.md#installing-plug-ins-from-a-local-package)
+
+**Note:** Profiles that you create *after* you install the plug-in are secured automatically. Update your existing profiles to be securely stored.
+
+## Using
+
+### Securing your credentials
+The plug-in introduces a new command group named `zowe scs` that converts all existing plain-text profiles into securely-stored profiles. Issue the following command:
+
+```
+zowe scs update
+```
+
+The following is an example of securely stored credentials in a user profile
+
+**Example: Credentials Secured with CA Secure Credential Store Plug-in for Zowe CLI**
+
+```yaml
+type: zosmf
+host: test
+port: 1234
+user: 'managed by @brightside/secure-credential-store'
+pass: 'managed by @brightside/secure-credential-store'
+rejectUnauthorized: false
+```
+If you do not have or do not activate the plug-in, your credential appear to be visible and are stored in plain text. The following is an example of credentials that are stored with a default credential manager of your operating system.
+
+**Example: Credentials Secured with a Default Credential Manager**
+
+```yaml
+type: zosmf
+host: test
+port: 1234
+user: USERNAME
+pass: PASSWORD
+rejectUnauthorized: false
+```
+
+### Deactivating the plug-in

--- a/docs/user-guide/cli-scsplugin.md
+++ b/docs/user-guide/cli-scsplugin.md
@@ -32,23 +32,23 @@ Use one of the following methods to install or update the plug-in:
 
 - [Installing plug-ins from a local package](cli-installplugins.md#installing-plug-ins-from-a-local-package)
 
-**Note:** Existing user profiles are *not* automatically updated to securely store credentials. See [Securing your Credentials](#securing-your-credentials) in the following section for more information.
+**Note:** Existing user profiles are *not* automatically updated to securely store credentials.
 
 ## Using
 
-The plug-in introduces a new command group named `zowe scs` that lets you update existing user profiles and enable/disable the plug-in.
+The plug-in introduces a new command group, `zowe scs`, that lets you update existing user profiles and enable/disable the plug-in.
 
 ### Securing your credentials
 
 User profiles that you create *after* installing the plug-in will automatically store your credentials securely.
 
-To secure credentials securely in existing user profiles (profiles that you created prior to installing the SCS plug-in), issue the following command:
+To secure credentials in existing user profiles (profiles that you created prior to installing the SCS plug-in), issue the following command:
 
 ```
 zowe scs update
 ```
 
-Profiles are updated with secured credentials. See the following examples for more information.
+Profiles are updated with secured credentials.
 
 **Example: Secure credentials**
 

--- a/docs/user-guide/cli-scsplugin.md
+++ b/docs/user-guide/cli-scsplugin.md
@@ -1,6 +1,6 @@
 # Secure Credential Store Plug-in for Zowe CLI
 
-The Secure Credential Store (SCS) Plug-in for Zowe CLI lets you store your credentials securely in the credential manager of your operating system. The plug-in invokes a native Node module, named Keytar, that manages user IDs and passwords in a credential manager.
+The Secure Credential Store (SCS) Plug-in for Zowe CLI lets you store your credentials securely in the credential manager of your operating system. The plug-in invokes a native Node module, [keytar](https://github.com/atom/node-keytar), that manages user IDs and passwords in a credential manager.
 
   - [Use Cases](#use-cases)
   - [Commands](#commands)
@@ -10,7 +10,7 @@ The Secure Credential Store (SCS) Plug-in for Zowe CLI lets you store your crede
 
 ## Use Cases
 
-Zowe CLI stores credentials in plaintext by default. Use the SCS plug-in to store credentials more securely and prevent your username and password from being compromised as a result of a malware attack or unlawful actions by others.
+Zowe CLI stores credentials (your mainframe username and password) in plaintext by default. You can use the SCS plug-in to store credentials more securely and prevent your username and password from being compromised as a result of a malware attack or unlawful actions by others.
 
 ## Commands
 
@@ -32,25 +32,25 @@ Use one of the following methods to install or update the plug-in:
 
 - [Installing plug-ins from a local package](cli-installplugins.md#installing-plug-ins-from-a-local-package)
 
-**Note:** Existing user profiles are not updated automatically. See "Securing your Credentials" in the following section for details.
+**Note:** Existing user profiles are *not* automatically updated to securely store credentials. For more information, see [Securing your Credentials](#securing-your-credentials) in the following section.
 
 ## Using
 
-The plug-in introduces a new command group named `zowe scs` that you can use to enable/disable the plug-in and update existing user profiles.
+The plug-in introduces a new command group named `zowe scs` that lets you update existing user profiles and enable/disable the plug-in.
 
 ### Securing your credentials
-User profiles that you create *after* installing the plug-in are stored securely.
 
-If you created user profiles prior to installing the SCS plug-in,
+User profiles that you create *after* installing the plug-in will automatically have securely stored credentials.
 
-
-that converts the profile into securely-stored profiles. Issue the following command:
+To secure credentials in existing user profiles (profiles that you created prior to installing the SCS plug-in), issue the following command:
 
 ```
 zowe scs update
 ```
 
-**Example: Credentials Secured with SCS plug-in**
+Profiles are updated with secured credentials. See the following examples for more information.
+
+**Example: Secure credentials**
 
 The following is an example of securely stored credentials in a user profile configuration file:
 
@@ -58,12 +58,12 @@ The following is an example of securely stored credentials in a user profile con
 type: zosmf
 host: test
 port: 1234
-user: 'managed by @zowe/secure-credential-store'
-pass: 'managed by @zowe/secure-credential-store'
+user: 'managed by @zowe/secure-credential-store-for-zowe-cli'
+pass: 'managed by @zowe/secure-credential-store-for-zowe-cli'
 rejectUnauthorized: false
 ```
 
-**Example: Credentials secured with default credential manager**
+**Example: Default credential management**
 
 The following is an example of credentials that are stored with the *default* credential manager:
 
@@ -80,10 +80,11 @@ rejectUnauthorized: false
 
 If you do not want to use CA Secure Credential Store Plug-in for Zowe CLI, choose one of the following methods to deactivate the plug-in:
 
-Uninstall the Plug-in
+**Uninstall the Plug-in**
+
 Issue the zowe plugins uninstall [plugin] command to delete the plug-in from your computer.
 When you uninstall the plug-in, existing profiles become invalid and you have to recreate them. For more information, see Create CLI Profiles.
-If you uninstall the plug-in that was installed using the Windows installation wizard, you need to reset the value of the credential-manager property manually.
 
-Reset the Configuration of Credential Manager
+
+**Reset the Configuration of Credential Manager**
 Issue the reset command to reset the value of the credential manager configuration to default and deactivate the plug-in.

--- a/docs/user-guide/cli-scsplugin.md
+++ b/docs/user-guide/cli-scsplugin.md
@@ -10,7 +10,7 @@ The Secure Credential Store (SCS) Plug-in for Zowe CLI lets you store your crede
 
 ## Use Cases
 
-Zowe CLI stores credentials (your mainframe username and password) in plaintext by default. You can use the SCS plug-in to store credentials more securely and prevent your username and password from being compromised as a result of a malware attack or unlawful actions by others.
+Zowe CLI stores credentials (mainframe username and password) in plaintext on your computer by default. You can use the SCS plug-in to store credentials more securely and prevent your credentials from being compromised as a result of a malware attack or unlawful actions by others.
 
 ## Commands
 
@@ -32,7 +32,7 @@ Use one of the following methods to install or update the plug-in:
 
 - [Installing plug-ins from a local package](cli-installplugins.md#installing-plug-ins-from-a-local-package)
 
-**Note:** Existing user profiles are *not* automatically updated to securely store credentials. For more information, see [Securing your Credentials](#securing-your-credentials) in the following section.
+**Note:** Existing user profiles are *not* automatically updated to securely store credentials. See [Securing your Credentials](#securing-your-credentials) in the following section for more information.
 
 ## Using
 
@@ -40,9 +40,9 @@ The plug-in introduces a new command group named `zowe scs` that lets you update
 
 ### Securing your credentials
 
-User profiles that you create *after* installing the plug-in will automatically have securely stored credentials.
+User profiles that you create *after* installing the plug-in will automatically store your credentials securely.
 
-To secure credentials in existing user profiles (profiles that you created prior to installing the SCS plug-in), issue the following command:
+To secure credentials securely in existing user profiles (profiles that you created prior to installing the SCS plug-in), issue the following command:
 
 ```
 zowe scs update
@@ -78,13 +78,14 @@ rejectUnauthorized: false
 
 ### Deactivating the plug-in
 
-If you do not want to use CA Secure Credential Store Plug-in for Zowe CLI, choose one of the following methods to deactivate the plug-in:
+If you do not want to use the SCS Plug-in for Zowe CLI, choose one of the following methods to deactivate the plug-in:
 
 **Uninstall the Plug-in**
 
-Issue the zowe plugins uninstall [plugin] command to delete the plug-in from your computer.
-When you uninstall the plug-in, existing profiles become invalid and you have to recreate them. For more information, see Create CLI Profiles.
+Issue the `zowe plugins uninstall @zowe/secure-credential-store-for-zowe-cli` command to delete the plug-in from your computer.
 
+When you uninstall the plug-in, existing profiles become invalid and you must recreate them. For more information, see [Create CLI Profiles](cli-configuringcli.html#creating-zowe-cli-profiles.md).
 
 **Reset the Configuration of Credential Manager**
-Issue the reset command to reset the value of the credential manager configuration to default and deactivate the plug-in.
+
+Issue the `zowe scs reset` command to reset the value of the credential manager configuration to default, which deactivates the plug-in.

--- a/docs/user-guide/cli-swreqplugins.md
+++ b/docs/user-guide/cli-swreqplugins.md
@@ -4,10 +4,11 @@ Before you use Zowe&trade; CLI plug-ins, complete the following steps:
 
 1. Install [Zowe CLI](cli-installcli.md) on your computer.
 2. Complete the following configurations:
-   
+
 | Plug-in | Required Configurations |
 | --- | --- |
-| [IBM CICS Plug-in for Zowe CLI](cli-cicsplugin.md) | <ul><li>Ensure that [IBM CICS Transaction Server v5.2 or later](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.2.0/com.ibm.cics.ts.home.doc/welcomePage/welcomePage.html) is installed and running in your mainframe environment</li><li>[IBM CICS Management Client Interface (CMCI)](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.2.0/com.ibm.cics.ts.clientapi.doc/topics/clientapi_overview.html) is configured and running in your CICS region.</li></ul> | 
-| [IBM Db2 Database Plug-in for Zowe CLI](cli-db2plugin.md) | <ul> <li>Download and prepare the ODBC driver (required for only package installations) and address the licensing requirements. </li><li>**(MacOS)** Download and Install [Xcode](https://developer.apple.com/xcode/resources/).</li> </ul>| 
+| [IBM CICS Plug-in for Zowe CLI](cli-cicsplugin.md) | <ul><li>Ensure that [IBM CICS Transaction Server v5.2 or later](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.2.0/com.ibm.cics.ts.home.doc/welcomePage/welcomePage.html) is installed and running in your mainframe environment</li><li>[IBM CICS Management Client Interface (CMCI)](https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.2.0/com.ibm.cics.ts.clientapi.doc/topics/clientapi_overview.html) is configured and running in your CICS region.</li></ul> |
+| [IBM Db2 Database Plug-in for Zowe CLI](cli-db2plugin.md) | <ul> <li>Download and prepare the ODBC driver (required for only package installations) and address the licensing requirements. </li><li>**(MacOS)** Download and Install [Xcode](https://developer.apple.com/xcode/resources/).</li> </ul>|
+| [Secure Credential Store Plug-in for Zowe CLI](cli-scsplugin.md) | <ul> <li> (Linux only) Install libsecret on your computer. </li></ul> |
 
 **Important!** You can perform the required configurations for the plug-ins that you want to use ***before*** or ***after*** you install the plug-ins. However, if you do not perform the required configurations, the plug-ins will not function as designed.

--- a/docs/user-guide/cli-updatingcli.md
+++ b/docs/user-guide/cli-updatingcli.md
@@ -13,7 +13,7 @@ Zowe&trade; CLI is updated continuously. You can update Zowe CLI to a more recen
 Issue the following command:
 
 ```
-zowe -V 
+zowe -V
 ```
 
 ## (Optional) Identify the currently installed versions of Zowe CLI plug-ins
@@ -40,8 +40,9 @@ You can update Zowe CLI to the latest version from the online registry on Window
 2. Reinstall the plug-ins and update existing plug-ins using the following command:
 
    ```
-   zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental
+   zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@lts-zowe-v2.x
    ```
+<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 3. Recreate any user profiles that you created before you updated to the latest version of Zowe CLI.
 

--- a/docs/user-guide/cli-updatingcli.md
+++ b/docs/user-guide/cli-updatingcli.md
@@ -40,9 +40,8 @@ You can update Zowe CLI to the latest version from the online registry on Window
 2. Reinstall the plug-ins and update existing plug-ins using the following command:
 
    ```
-   zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@lts-zowe-v2.x
+   zowe plugins install @brightside/cics@lts-incremental @brightside/db2@lts-incremental @zowe/secure-credential-store-for-zowe-cli@zowe-v1-lts
    ```
-<!-- Note that SCS plug-in will be added to @zowe v1lts and not lts-incremental. -->
 
 3. Recreate any user profiles that you created before you updated to the latest version of Zowe CLI.
 

--- a/docs/user-guide/uninstall.md
+++ b/docs/user-guide/uninstall.md
@@ -29,7 +29,7 @@ You can uninstall Zowe&trade; if you no longer need to use it. Follow these proc
     tso delete 'your.zowe.proclib(zowesvr)'
     ```
 
-    To query which PROCLIB data set that ZOWESVR is put in, you can view the SDSF JOB log of ZOWESVR and look for the following message:  
+    To query which PROCLIB data set that ZOWESVR is put in, you can view the SDSF JOB log of ZOWESVR and look for the following message:
 
     ```
     IEFC001I PROCEDURE ZOWESVR WAS EXPANDED USING SYSTEM LIBRARY your.zowe.proclib
@@ -55,7 +55,7 @@ The following steps describe how to list the profiles that you created, delete t
 
 **Follow these steps:**
 
-1.  Open a command line window. 
+1.  Open a command line window.
 
     **Note:** If you do not want to delete the Zowe CLI profiles from your computer, go to Step 5.
 
@@ -74,16 +74,16 @@ The following steps describe how to list the profiles that you created, delete t
     $
     ```
 
-3.  Delete all of the profiles that are listed for the command group by issuing the following command: 
+3.  Delete all of the profiles that are listed for the command group by issuing the following command:
 
     **Tip:** For this command, use the results of the `list`
-    command.    
+    command.
 
     **Note:** When you issue the `delete` command, it deletes the
     specified profile and its credentials from the credential vault in your computer's operating system.
 
     ```
-    zowe profiles delete <profileType> <profileName> --force  
+    zowe profiles delete <profileType> <profileName> --force
     ```
       **Example:**
 
@@ -102,7 +102,7 @@ The following steps describe how to list the profiles that you created, delete t
         ```
 
     - If you installed Zowe CLI from the online registry, issue the following command:
-    
+
         ```
         npm uninstall --global brightside
         ```


### PR DESCRIPTION
Draft PR to review doc for the "Secure Credential Store plug-in for Zowe CLI", which is scheduled to be contributed to Zowe in the current PI. Content includes: 
- Plug-in topic w/ overview, Web Help, Installing, Using, and Uninstalling 
- Syntax added to all installation topics (Installing CLI, Installing Plug-ins, CLI Quick Start)  
- Plug-in listed in various topics (Release Notes, Available Plug-ins) 

TODO at a later time: 
- Upload Web Help files 
- TPSRs 
- Publish content/plug-in 