### PR TITLE
docs: Update description about node v8.16.1 issue and workaround in v1.6.x

### DIFF
--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -10,10 +10,6 @@ You can obtain IBM SDK for Node.js - z/OS for free in one of the following ways:
 
 For details, see the blog ["How to obtain IBM SDK for Node.js - z/OS, at no charge"](https://developer.ibm.com/mainframe/2019/04/17/ibm-sdk-for-node-js-z-os-at-no-charge/).
 
-**Known issue:** There is a known issue with node v8.16.1 and Zowe desktop encoding. See [https://github.com/ibmruntimes/node/issues/142](https://github.com/ibmruntimes/node/issues/142) for details.
-
-**Workaround:** Use node v8.16.0 which is available at [https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos). Download the `ibm-trial-node-v8.16.0-os390-s390x.pax.Z` file.
-
 ## Hardware and software requirements
 
 **Hardware:**

--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -10,6 +10,10 @@ You can obtain IBM SDK for Node.js - z/OS for free in one of the following ways:
 
 For details, see the blog ["How to obtain IBM SDK for Node.js - z/OS, at no charge"](https://developer.ibm.com/mainframe/2019/04/17/ibm-sdk-for-node-js-z-os-at-no-charge/).
 
+**Known issue:** There is a known issue with node v8.16.1 and Zowe desktop encoding. See [https://github.com/ibmruntimes/node/issues/142](https://github.com/ibmruntimes/node/issues/142) for details.
+
+**Workaround:** Use node.js v8.16.2 which is available at [https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos). Download the `pax.Z` file under **IBM SDK for Node.js - z/OS, V8 - (v8.16.2 - November 2019 Build)**. Note that node v12 is not yet supported on Zowe.
+
 ## Hardware and software requirements
 
 **Hardware:**


### PR DESCRIPTION
<!--
Thank you for your pull request! Please provide a description of the changes in this PR in the field above and review
the requirements below.
-->

#### Is there a related issue for this PR? 
Issue number: #890 

#### Developer's Certificate of Origin (DCO)

<!-- All commits must be signed off. Add a Signed-off-by line to your commit messages and this PR. Example: 

Signed-off-by: Random J Developer <random@developer.example.org>

-->
Signed-off-by: nannanli <nannanli@cn.ibm.com>

- Added back the known issue with node v8.16.1 for 8.16.1 is still not supported.
- Updated the workaround to guide users to use v8.16.2.
- State that v12 is not supported yet.