### PR TITLE
Zowe Explorer video part 2, doc update

### DIFF
--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -107,6 +107,8 @@ Review the [Zowe Explorer Change Log](https://github.com/zowe/vscode-extension-f
 
 You can install the latest version of the extension from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe).
 
+Watch a video on how to [work with data sets using Zowe Explorer](https://docs.zowe.org/stable/user-guide/cli-vscodeplugin.html).
+
 ### Bug fixes
 
 The following bugs were fixed:

--- a/docs/user-guide/cli-vscodeplugin.md
+++ b/docs/user-guide/cli-vscodeplugin.md
@@ -40,6 +40,8 @@ The extension is now installed and available for use.
 
 **Tip:** For information about how to install the extension from a `VSIX` file and run system tests on the extension, see the Developer [README](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README.md) file in the Zowe VSCode extension GitHub repository.
 
-You can also watch the following video to learn how to get started with Zowe Explorer.
+You can also watch the following videos to learn how to get started with Zowe Explorer, and work with data sets.
 
 <iframe class="embed-responsive-item" id="youtubeplayer" title="Getting Started with Zowe" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/G_WCsFZIWt4" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen> </iframe>
+
+<iframe class="embed-responsive-item" id="youtubeplayer" title="How to Work with Data Sets" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/X4oSHrI4oN4" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen> </iframe>


### PR DESCRIPTION
Update the [Zowe Explorer](https://docs.zowe.org/stable/user-guide/cli-vscodeplugin.html) page to include the second part of Zowe Explorer video.

#### Is there a related issue for this PR? 
Issue number: [944](https://github.com/zowe/docs-site/issues/944)

#### Developer's Certificate of Origin (DCO)

Signed-off-by: Igor Kazmyr <43951184+IgorCATech@users.noreply.github.com>