### PR TITLE
Log location, nodejs version suggestion fixes

### DIFF
--- a/docs/troubleshoot/app-framework/app-known-issues.md
+++ b/docs/troubleshoot/app-framework/app-known-issues.md
@@ -14,7 +14,7 @@ When you open apps in the desktop they display a page with the message "The plug
 
 NodeJS v8.16.1 performs auto-encoding in a way that breaks Zowe apps. See [https://github.com/ibmruntimes/node/issues/142](https://github.com/ibmruntimes/node/issues/142) for details.
 
-Use node v8.16.0 which is available at [https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos). Download the `ibm-trial-node-v8.16.0-os390-s390x.pax.Z` file.
+Use a different version of NodeJS 8, such as v8.17.0, or try NodeJS version 12 which are both available at [https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos](https://www.ibm.com/ca-en/marketplace/sdk-nodejs-compiler-zos). Download the `ibm-trial-node-v8.17.0-os390-s390x.pax.Z` file.
 
 ## NODEJSAPP disables immediately
 
@@ -42,7 +42,7 @@ Authentication failed for 1 types:  Types: ["zss"]
 For the Zowe Desktop to work, the node server that runs under the ZWESVSTC started task must be able to make cross memory calls to the ZWESIS01 load module running under the ZWESISTC started task. If this communication fails, you see the authentication error.
 
 To solve the problem, follow these steps: 
-1. Open the log file `/zlux-app-server/log/zssServer-yyyy-mm-dd-hh-ss.log`.  This file is created each time ZWESVSTC is started and only the last five files are kept.  
+1. Open the log file `$INSTANCE_DIR/logs/zssServer-yyyy-mm-dd-hh-ss.log`.  This file is created each time ZWESVSTC is started and only the last five files are kept.  
 
 2. Look for the message that starts with `ZIS status`.  
 
@@ -81,7 +81,7 @@ To solve the problem, follow these steps:
 ## Server startup problem ret=1115
 
 **Symptom:**
-When ZWESVSTC is restarted, the following message is returned in the output of the ZSS server log file, `/zlux-app-server/log/zssServer-yyyy-mm-dd-hh-ss.log`:
+When ZWESVSTC is restarted, the following message is returned in the output of the ZSS server log file, `$INSTANCE_DIR/logs/zssServer-yyyy-mm-dd-hh-ss.log`:
 ```
 server startup problem ret=1115
 ```


### PR DESCRIPTION
Log location specific is outdated (pre 1.8), and nodejs issue does not recommend node 12, which is honestly the best one to use these days.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>