### PR TITLE
Remove active dev from versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before you get started with the authoring work, it's necessary that you understa
 
   Docs for the upcoming `vNext` release. When Zowe has a release, its `docs-staging` branch will be merged into `master` and the content will be visible on [https://docs.zowe.org/stable](https://docs.zowe.org/stable).
 
-* (REMOVED TEMPORATRILY UNTIL NEW COMPONENT FEATURES ARE AVAILABLE) **[`active-development`](https://github.com/zowe/docs-site/tree/active-development/docs)** - protected branch
+* (REMOVED TEMPORARILY UNTIL NEW COMPONENT FEATURES ARE AVAILABLE) **[`active-development`](https://github.com/zowe/docs-site/tree/active-development/docs)** - protected branch
 
   Docs for a forward-version that includes features not yet included in the Zowe Stable version. Its content is published on [https://docs.zowe.org/active-development](https://docs.zowe.org/active-development) for early validation purpose.
 * **`v<v.r>.x`** - protected branches

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Before you get started with the authoring work, it's necessary that you understa
 * **[`docs-staging`](https://github.com/zowe/docs-site/tree/docs-staging/docs)** - protected branch
 
   Docs for the upcoming `vNext` release. When Zowe has a release, its `docs-staging` branch will be merged into `master` and the content will be visible on [https://docs.zowe.org/stable](https://docs.zowe.org/stable).
-* **[`active-development`](https://github.com/zowe/docs-site/tree/active-development/docs)** - protected branch
+
+* (REMOVED TEMPORATRILY UNTIL NEW COMPONENT FEATURES ARE AVAILABLE) **[`active-development`](https://github.com/zowe/docs-site/tree/active-development/docs)** - protected branch
 
   Docs for a forward-version that includes features not yet included in the Zowe Stable version. Its content is published on [https://docs.zowe.org/active-development](https://docs.zowe.org/active-development) for early validation purpose.
 * **`v<v.r>.x`** - protected branches

--- a/docs/.vuepress/versions.json
+++ b/docs/.vuepress/versions.json
@@ -1,9 +1,4 @@
 [{
-
-    "text": "Active Development",
-    "link": "active-development/"
-},
-{
   "text": "v1.10.x LTS",
   "link": "stable/"
 },


### PR DESCRIPTION
Removing the Active Development documentation from the live doc site.

**Reason:** Active Development CLI package on Zowe.org is outdated and should be removed. zowe/zowe.github.io#91 is open to remove the package. We can reintroduce it when more forward features are added to @latest CLI or another Zowe component.

**Note:** Port  this change to archived doc branches.