### PR TITLE
Doc that ZWED0159W errors don't occur in 1.11

### DIFF
--- a/docs/troubleshoot/app-framework/app-troubleshoot.md
+++ b/docs/troubleshoot/app-framework/app-troubleshoot.md
@@ -223,7 +223,7 @@ Host & Port for proxy destination are required but were missing.
 ```
 
 **Solution:**   
-You can ignore these messages. 
+You can ignore these messages which should not occur in 1.11 or later releases.  To check which release of Zowe you are running, see [Determining the Zowe release number](../../troubleshoot/troubleshooting.md#determining-the-zowe-release-number).
 
 ## Warning: ZWED0050W - Could not read swagger doc folder (..)
  

--- a/docs/troubleshoot/app-framework/app-troubleshoot.md
+++ b/docs/troubleshoot/app-framework/app-troubleshoot.md
@@ -216,7 +216,6 @@ You can ignore these messages. These messages are timing-related where different
 The Zowe started task `ZWESVSTC` log contains messages
 
 ```
-yyyy-mm-dd hh:mm:ss:ms ZWED:16843061 ZWESVUSR WARN (_zsf.install,index.js:255) 
 ZWED0159W - Plugin (org.zowe.zlux.proxy.zosmf) loading failed. 
 Message: "ZWED0047E - Proxy (org.zowe.zlux.proxy.zosmf:data) setup failed.
 Host & Port for proxy destination are required but were missing.


### PR DESCRIPTION
### Is there a related issue for this PR? 
ZWED0159W errors are in troublehooting as they are silent and can be ignored, however they don't get logged in 1.11
