### PR TITLE
Add --help --ac command

### DIFF
--- a/docs/user-guide/cli-usingcli.md
+++ b/docs/user-guide/cli-usingcli.md
@@ -26,7 +26,7 @@ zowe --help
 Alternatively, issue the following command to display a full list of all available commands:
 
 ```
-zowe --help --ac
+zowe --ac
 ```
 
 **Tip:** All Zowe CLI commands begin with `zowe.`

--- a/docs/user-guide/cli-usingcli.md
+++ b/docs/user-guide/cli-usingcli.md
@@ -23,6 +23,12 @@ zowe --help
 
 ![Issuing the help command](../images/guides/CLI/GetHelp.gif)
 
+Alternatively, issue the following command to display a full list of all available commands:
+
+```
+zowe --help --ac
+```
+
 **Tip:** All Zowe CLI commands begin with `zowe.`
 
 ### Group, action, and object help


### PR DESCRIPTION
Command to list all commands (`zowe --help --ac`) was missing from Docs. Adding example to the Get Help w/ CLI section. 