### PR TITLE
Added back ICSF steps for ZSS

### DIFF
--- a/docs/user-guide/configure-zos-system.md
+++ b/docs/user-guide/configure-zos-system.md
@@ -173,6 +173,80 @@ To do this, issue the following commands that are also included in the `ZWESECUR
 - The cross memory server treats "no decision" style SAF return codes as failures. If there is no covering profile for the `ZWES.IS` resource in the FACILITY class, the request will be denied.
 - Cross memory server clients other than Zowe might have additional SAF security requirements. For more information, see the documentation for the specific client.
 
+## Configure an ICSF cryptographic services environment
+
+ZSS cookies require random number generation for security. ICSF is a secure way to do that. To generate symmetric keys, the `ZWESVUSR` user who runs `ZWESVSTC` requires READ access to `CSFRNGL` in the `CSFSERV` class.
+
+Define or check the following configurations depending on whether ICSF is already installed:
+
+- The ICSF or CSF job that runs on your z/OS system.
+- The configuration of ICSF options in `SYS1.PARMLIB(CSFPRM00)`, `SYS1.SAMPLIB`, `SYS1.PROCLIB`.
+- Create CKDS, PKDS, TKDS VSAM data sets.
+- Define and activate the CSFSERV class:
+
+    - If you use RACF, issue the following commands:
+        ```
+        RDEFINE CSFSERV profile-name UACC(NONE)
+        ```
+        ```
+        PERMIT profile-name CLASS(CSFSERV) ID(tcpip-stackname) ACCESS(READ)
+        ```
+        ```
+        PERMIT profile-name CLASS(CSFSERV) ID(userid-list)   ... [for 
+        userids IKED, NSSD, and Policy Agent]
+        ```
+        ```
+        SETROPTS CLASSACT(CSFSERV)
+        ```
+        ```
+        SETROPTS RACLIST(CSFSERV) REFRESH
+        ```
+    - If you use CA ACF2, issue the following commands (note that `profile-prefix` and `profile-suffix` are user-defined):
+        ```
+        SET CONTROL(GSO)
+        ```
+        ```
+        INSERT CLASMAP.CSFSERV RESOURCE(CSFSERV) RSRCTYPE(CSF)  
+        ```
+        ```
+        F ACF2,REFRESH(CLASMAP)
+        ```
+        ```
+        SET RESOURCE(CSF)
+        ```
+        ```
+        RECKEY profile-prefix ADD(profile-suffix uid(UID string for tcpip-stackname) SERVICE(READ) ALLOW)   
+        ```
+        ```
+        RECKEY profile-prefix ADD(profile-suffix uid(UID string for IZUSVR) SERVICE(READ) ALLOW)
+        ```
+        (repeat for userids IKED, NSSD, and Policy Agent)
+
+        ```
+        F ACF2,REBUILD(CSF)
+        ```
+    - If you use CA Top Secret, issue the following command (note that `profile-prefix` and `profile-suffix` are user defined):
+        ```
+        TSS ADDTO(owner-acid) RESCLASS(CSFSERV)              
+        ```
+        ```                  
+        TSS ADD(owner-acid) CSFSERV(profile-prefix.)
+        ```
+        ```
+        TSS PERMIT(tcpip-stackname) CSFSERV(profile-prefix.profile-suffix) ACCESS(READ)
+        ```
+        ```
+        TSS PERMIT(user-acid) CSFSERV(profile-prefix.profile-suffix) ACCESS(READ)
+        ```
+        (repeat for user-acids IKED, NSSD, and Policy Agent)
+
+**Notes:**
+
+- Determine whether you want SAF authorization checks against `CSFSERV` and set `CSF.CSFSERV.AUTH.CSFRNG.DISABLE` accordingly.
+- Refer to the [z/OS 2.3.0 z/OS Cryptographic Services ICSF System Programmer's Guide: Installation, initialization, and customization](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.csfb200/iandi.htm).
+- CCA and/or PKCS #11 coprocessor for random number generation.
+- Enable `FACILITY IRR.PROGRAM.SIGNATURE.VERIFICATION` and `RDEFINE CSFINPV2` if required.
+
 ## Configure security environment switching
     
 Typically, the user `ZWESVUSR` that the `ZWESVSTC` started task runs under needs to be able to change the security environment of its process to allow API requests to be issued on behalf of the logged on TSO user ID, rather than the server's user ID.  This capability provides the functionality that allows users to log on to the Zowe desktop and use apps such as the File Editor to list data sets or USS files that the logged on user is authorized to view and edit, rather than the user ID running the Zowe server. This technique is known as **impersonation**.  


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com>

fixes #991 

**Description:**
Per [comment](https://github.com/zowe/docs-site/issues/991#issuecomment-640736076), ICSF is required for ZSS setup so reverted the removal of ICSF steps. Also added one more description at the beginning of the section to clarify the reason. 
