### PR TITLE
Move SSO out of requires action

### DIFF
--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -31,7 +31,7 @@ Zowe Version 1.12.0 and later releases include the following enhancements, relea
 The following features and enhancements were added.
 
 #### Zowe installation
-- Keystore directory updated to add new parameters. If you wish to enable SSO for the desktop you need to re-run the `zowe-setup-certificates.sh` script during the upgrade process, with new values in the `zowe-setup-certificates.env` file. [#1347](https://github.com/zowe/zowe-install-packaging/pull/1347) / Doc: [#1162](https://github.com/zowe/docs-site/issues/1162)
+- Keystore directory generation updated to add new parameters. If you wish to enable SSO for the desktop you need to re-run the `zowe-setup-certificates.sh` script during the upgrade process, with new values in the `zowe-setup-certificates.env` file. [#1347](https://github.com/zowe/zowe-install-packaging/pull/1347) / Doc: [#1162](https://github.com/zowe/docs-site/issues/1162)
 - Added a `-l` optional parameter to the `zowe-support.sh` script. This parameter allows you to specify the custom log directory used in install and configuration when collecting support data. [#1322](https://github.com/zowe/zowe-install-packaging/pull/1322) / Doc: [#1165](https://github.com/zowe/docs-site/issues/1165)
 - Added the validate only mode of Zowe. This allows you to check whether all the component validation checks of the Zowe installation pass without starting any of the components. [#1335](https://github.com/zowe/zowe-install-packaging/pull/1335) / Doc: [#1181](https://github.com/zowe/docs-site/pull/1181)
 - Separated ZSS component from the Zowe App Server component. [#1320](https://github.com/zowe/zowe-install-packaging/pull/1320)


### PR DESCRIPTION
Signed-off-by: stevenhorsman <steven@uk.ibm.com>

Since the release notes were written the UI squad have informed us that re-running of the keystore setup is not mandatory if a user doesn't require SSO on the desktop.
