### PR TITLE
new parameter that will allow services to set retry for all HTTP methods

### DIFF
--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -22,7 +22,7 @@
 
 * **customMetadata.apiml.okToRetryOnAllOperations**
     
-    Specifies whether all operations can be retried for this service. Default value is `false`. In this case, only GET requests will be retried, if they return response code `503`. Setting it `true`, will enable retry requests for all methods, which return response code `503`. Enabling retry can have an impact on the server’s resources, due to the buffering of the request body.
+    Specifies whether all operations can be retried for this service. The default value is `false`. The `false` value allows retries for only GET requests if a response code of `503` is returned. Setting this value to `true` enables retry requests for all methods, which return a `503` response code. Enabling retry can impact server resources resulting from buffering of the request body.
               
 * **customMetadata.apiml.corsEnabled**
     

--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -19,6 +19,10 @@
 * **customMetadata.apiml.connectionManagerTimeout**
     
     HttpClient employs a special entity to manage access to HTTP connections called by the HTTP connection manager. The purpose of an HTTP connection manager is to serve as a factory for new HTTP connections, to manage the life cycle of persistent connections, and to synchronize access to persistent connections. Internally, it works with managed connections which serve as proxies for real connections. ConnectionManagerTimeout specifies a period, in which managed connections with API ML should be established. The value is in milliseconds. If omitted, the default value specified in the API ML Gateway service configuration is used.
+
+* **customMetadata.apiml.okToRetryOnAllOperations**
+    
+    Specifies whether all operations can be retried for this service. Default value is `false`. In this case, only GET requests will be retried, if they return response code `503`. Setting it `true`, will enable retry requests for all methods, which return response code `503`. Enabling retry can have an impact on the server’s resources, due to the buffering of the request body.
               
 * **customMetadata.apiml.corsEnabled**
     

--- a/docs/extend/extend-apiml/onboard-direct-eureka-call.md
+++ b/docs/extend/extend-apiml/onboard-direct-eureka-call.md
@@ -232,7 +232,7 @@ The following parameters define service information for the API Catalog:
 
 * **apiml.okToRetryOnAllOperations**
     
-    Specifies whether all operations can be retried for this service. Default value is `false`. In this case, only GET requests will be retried, if they return response code `503`. Setting it `true`, will enable retry requests for all methods, which return response code `503`. Enabling retry can have an impact on the server’s resources, due to the buffering of the request body.
+    Specifies whether all operations can be retried for this service. The default value is `false`. The `false` value allows retries for only GET requests if a response code of `503` is returned. Setting this value to `true` enables retry requests for all methods, which return a `503` response code. Enabling retry can impact server resources resulting from buffering of the request body.
 
 * **apiml.service.corsEnabled**
     

--- a/docs/extend/extend-apiml/onboard-direct-eureka-call.md
+++ b/docs/extend/extend-apiml/onboard-direct-eureka-call.md
@@ -230,6 +230,10 @@ The following parameters define service information for the API Catalog:
     
     HttpClient employs a special entity to manage access to HTTP connections called by HTTP connection manager. The purpose of an HTTP connection manager is to serve as a factory for new HTTP connections, to manage the life cycle of persistent connections, and to synchronize access to persistent connections. Internally, it works with managed connections which serve as proxies for real connections. ConnectionManagerTimeout specifies a period, in which managed connections with API ML should be established. The value is in milliseconds. If omitted, the default value specified in the API ML Gateway service configuration is used.
 
+* **apiml.okToRetryOnAllOperations**
+    
+    Specifies whether all operations can be retried for this service. Default value is `false`. In this case, only GET requests will be retried, if they return response code `503`. Setting it `true`, will enable retry requests for all methods, which return response code `503`. Enabling retry can have an impact on the server’s resources, due to the buffering of the request body.
+
 * **apiml.service.corsEnabled**
     
     When this parameter is set to `true`, the Gateway allows CORS for the Gateway routes `api/v1/gateway/**`. 

--- a/docs/extend/extend-apiml/onboard-direct-eureka-call.md
+++ b/docs/extend/extend-apiml/onboard-direct-eureka-call.md
@@ -220,7 +220,7 @@ The following parameters define service information for the API Catalog:
 
 * **apiml.connectTimeout**
     
-    The value in milliseconds that specifies a period, in which API ML should establish a single, non-managed connection with this service. If omitted, the default value specified in the API ML Gateway service configuration is used.
+    The value in milliseconds that specifies a period in which API ML should establish a single, non-managed connection with this service. If omitted, the default value specified in the API ML Gateway service configuration is used.
 
 * **apiml.readTimeout**
     
@@ -228,7 +228,7 @@ The following parameters define service information for the API Catalog:
     
 * **apiml.connectionManagerTimeout**
     
-    HttpClient employs a special entity to manage access to HTTP connections called by HTTP connection manager. The purpose of an HTTP connection manager is to serve as a factory for new HTTP connections, to manage the life cycle of persistent connections, and to synchronize access to persistent connections. Internally, it works with managed connections which serve as proxies for real connections. ConnectionManagerTimeout specifies a period, in which managed connections with API ML should be established. The value is in milliseconds. If omitted, the default value specified in the API ML Gateway service configuration is used.
+    HttpClient employs a special entity to manage access to HTTP connections called by HTTP connection manager. The purpose of an HTTP connection manager is to serve as a factory for new HTTP connections, to manage the life cycle of persistent connections, and to synchronize access to persistent connections. Internally, an HTTP connection manager works with managed connections, which serve as proxies for real connections. `ConnectionManagerTimeout` specifies a period in which managed connections with API ML should be established. The value is in milliseconds. If omitted, the default value specified in the API ML Gateway service configuration is used.
 
 * **apiml.okToRetryOnAllOperations**
     
@@ -236,8 +236,8 @@ The following parameters define service information for the API Catalog:
 
 * **apiml.service.corsEnabled**
     
-    When this parameter is set to `true`, CORS is enabled on the service level for all the service routes. 
-    The same parameter can be also set on the service level, by providing the parameter as a `customMetadata` as shown [here](custom-metadata.md).
+    When this parameter is set to `true`, CORS is enabled on the service level for all service routes. 
+    The same parameter can also be set on the service level, by providing the parameter as `customMetadata` as shown in the [custom metadata.md](custom-metadata.md).
       
 #### Routing parameters
 Routing parameters are grouped under the prefix: `apiml.routes`
@@ -277,7 +277,7 @@ This prefix is used to differentiate the routes. This prefix must be provided ma
 For more information about API ML routing, see [API Gateway Routing](https://github.com/zowe/api-layer/wiki/API-Gateway-Routing).
 
 #### Authentication parameters
-Authentication parameters are grouped under the prefix: `apiml.authentication`. When not specified, the default values are used.
+Authentication parameters are grouped under the prefix: `apiml.authentication`. When unspecified, the default values are used.
 
 This parameter enables a service to accept the Zowe JWT token. The API Gateway translates the token to an authentication method supported by a service.
 

--- a/docs/extend/extend-apiml/onboard-direct-eureka-call.md
+++ b/docs/extend/extend-apiml/onboard-direct-eureka-call.md
@@ -236,7 +236,7 @@ The following parameters define service information for the API Catalog:
 
 * **apiml.service.corsEnabled**
     
-    When this parameter is set to `true`, the Gateway allows CORS for the Gateway routes `api/v1/gateway/**`. 
+    When this parameter is set to `true`, CORS is enabled on the service level for all the service routes. 
     The same parameter can be also set on the service level, by providing the parameter as a `customMetadata` as shown [here](custom-metadata.md).
       
 #### Routing parameters


### PR DESCRIPTION
Signed-off-by: achmelo <a.chmelo@gmail.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Parameter that will allow retry per service on specific status code for all http methods.

:heart:Thank you!

