### PR TITLE
Resolve 693: Remove unused cipher parameter

### DIFF
--- a/docs/extend/extend-apiml/onboard-plain-java-enabler.md
+++ b/docs/extend/extend-apiml/onboard-plain-java-enabler.md
@@ -215,7 +215,6 @@ authentication:
     enabled: true
     verifySslCertificatesOfServices: true
     protocol: TLSv1.2
-    ciphers: TLS_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_EMPTY_RENEGOTIATION_INFO_SCSV
     keyAlias: localhost
     keyPassword: password
     keyStore: keystore/localhost.keystore.p12
@@ -647,20 +646,9 @@ TLS/SSL configuration consists of the following parameters:
 
   This parameter specifies the truststore type. The default for this parameter is PKCS12.
 
-* **ciphers:** (Optional)
-
-    This parameter specifies the recommended ciphers.
-
-    ```
-    TLS_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_EMPTY_RENEGOTIATION_INFO_SCSV
-    ```
-  
-    To secure the transfer of data, TLS/SSL uses one or more cipher suites. A cipher suite is a combination of authentication, encryption, and message authentication code (MAC) algorithms. Ciphers are used during the negotiation of security settings for a TLS/SSL connection as well as for the transfer of data.
-
 **Notes:**
 
 * Ensure that you define both the key store and the trust store even if your server is not using an Https port.
-* Currently `ciphers` is not used. It is optional and serves as a place holder only.
 
 ### SAF Keyring configuration
 

--- a/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
+++ b/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
@@ -307,7 +307,6 @@ apiml:
         ssl:
             enabled: ${server.ssl.enabled}
             verifySslCertificatesOfServices: true
-            ciphers: ${server.ssl.ciphers}
             protocol: ${server.ssl.protocol}
             enabled-protocols: ${server.ssl.protocol}
             keyStoreType: ${server.ssl.keyStoreType}


### PR DESCRIPTION
Cipher parameter was unused and removed to avoid confusion. Code PR: https://github.com/zowe/api-layer/pull/753

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [x] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Remove ciphers ssl parameter to avoid confusion, as it is unused. [Code PR.](https://github.com/zowe/api-layer/pull/753) [Issue.](https://github.com/zowe/api-layer/issues/693)