### PR TITLE
Document configuration parameter for SAF as authentication provider

### DIFF
--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -33,9 +33,9 @@ Requests through the Gateway now contain a CORS header.
 
 ### apiml.security.auth.provider
 
-By default, API Gateway uses zOSMF as an authentication provider. It is possible to switch to SAF as the authentication
-provider instead of the zOSMF. The intended usage of the SAF as an authentication provider is for systems without zOSMF.
-Ife SAF is used and the zOSMF is available on the system, the created tokens are not accepted by zOSMF. Use
+By default, the API Gateway uses z/OSMF as an authentication provider. It is possible to switch to SAF as the authentication
+provider instead of z/OSMF. The intended usage of SAF as an authentication provider is for systems without z/OSMF.
+If SAF is used and the z/OSMF is available on the system, the created tokens are not accepted by z/OSMF. Use
 the following procedure to switch to SAF. 
 
 **Follow these steps:**
@@ -48,7 +48,7 @@ Authentication requests now utilize SAF as the authentication provider. API ML c
 
 ## Retry policy
 
-In default configuration, retry for all requests is disabled, with one exception. The server retries `GET` requests that finish with status code `503`. 
+In default configuration, retry for all requests is disabled, with one exception: the server retries `GET` requests that finish with status code `503`. 
 To change this default configuration, include the following parameters:
 
 * **ribbon.retryableStatusCodes**
@@ -69,4 +69,4 @@ To change this default configuration, include the following parameters:
     
 * **ribbon.MaxAutoRetriesNextServer**
     
-    The number of servers to try excluding the first one. The default value is `5`. 
+    The number of additional servers that attempt to make the request. This number excleds the first server. The default value is `5`. 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -17,7 +17,7 @@ By default, the API Mediation Layer rejects encoded slashes in the URL path of t
 2. Find the line that contains the `-Dapiml.service.allowEncodedSlashes=false` parameter and set the value to `true`.
 3. Restart Zowe&trade. 
     
-Requests with encoded slashes will now be passed to onboarded services. 
+Requests with encoded slashes are now passed to onboarded services. 
        
 ### apiml.service.corsEnabled
 
@@ -29,13 +29,13 @@ By default, CORS are disabled in the API Gateway for the Gateway routes `api/v1/
 2. Find the line that contains the `-Dapiml.service.corsEnabled=false` parameter and set the value to `true`.
 3. Restart Zowe&trade.
   
-Requests through the Gateway will now contain CORS header. 
+Requests through the Gateway now contain a CORS header. 
 
 ### apiml.security.auth.provider
 
 By default, API Gateway uses zOSMF as an authentication provider. It is possible to switch to SAF as the authentication
 provider instead of the zOSMF. The intended usage of the SAF as an authentication provider is for systems without zOSMF.
-In case the SAF is used and the zOSMF is available on the system the created tokens won't be accepted by zOSMF. Use
+Ife SAF is used and the zOSMF is available on the system, the created tokens are not accepted by zOSMF. Use
 the following procedure to switch to SAF. 
 
 **Follow these steps:**
@@ -44,12 +44,13 @@ the following procedure to switch to SAF.
 2. Find the line that contains the `-Dapiml.security.auth.zosmfServiceId=zosmf` parameter and replace it with `-Dapiml.security.auth.provider=saf`.
 3. Restart Zowe&trade.
 
-Authentication requests will now leverage SAF as authentication provider and the API ML will run without the zOSMF present
-on the system. 
+Authentication requests now utilize SAF as the authentication provider. API ML can run without zOSMF present on the system. 
 
 ## Retry policy
 
-In default configuration, retry for all request is disabled, with one exception. The server will retry `GET` requests that finish with status code `503`. You can modify this behavior with these parameters:
+In default configuration, retry for all requests is disabled, with one exception. The server retries `GET` requests that finish with status code `503`. 
+To change this default configuration, include the following parameters:
+
 * **ribbon.retryableStatusCodes**
 
     Provide a list of status codes, for which the server should retry the request.
@@ -58,12 +59,14 @@ In default configuration, retry for all request is disabled, with one exception.
     
 * **ribbon.OkToRetryOnAllOperations**
 
-     Specifies whether all operations can be retried for this service. The default value is `false`. In this case, only GET requests will be retried if they return any response code that is listed in `ribbon.retryableStatusCodes`. Setting this parameter to `true` enables retry requests for all methods which return response code listed in `ribbon.retryableStatusCodes`. Enabling retry can impact on server resources as the result of buffering of the request body.
+     Specifies whether all operations can be retried for this service. The default value is `false`. In this case, only GET requests are retried if they return a response code that is listed in `ribbon.retryableStatusCodes`. Setting this parameter to `true` enables retry requests for all methods which return response code listed in `ribbon.retryableStatusCodes`. 
+     
+**Note:** Enabling retry can impact server resources due to request body buffering.
 
 * **ribbon.MaxAutoRetries**
     
-    The number of times a failed request is retried on the same server. This number is multiplied with `ribbon.MaxAutoRetriesNextServer`. Default value is `0`.
+    The number of times a failed request is retried on the same server. This number is multiplied with `ribbon.MaxAutoRetriesNextServer`. The default value is `0`.
     
 * **ribbon.MaxAutoRetriesNextServer**
     
-    The number of servers to try excluding the first one. Default value is `5`. 
+    The number of servers to try excluding the first one. The default value is `5`. 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -31,6 +31,22 @@ By default, CORS are disabled in the API Gateway for the Gateway routes `api/v1/
   
 Requests through the Gateway will now contain CORS header. 
 
+### apiml.security.auth.provider
+
+By default, API Gateway uses zOSMF as an authentication provider. It is possible to switch to SAF as the authentication
+provider instead of the zOSMF. The intended usage of the SAF as an authentication provider is for systems without zOSMF.
+In case the SAF is used and the zOSMF is available on the system the created tokens won't be accepted by zOSMF. Use
+the following procedure to switch to SAF. 
+
+**Follow these steps:**
+     
+1. Open the file `<Zowe install directory>/components/api-mediation/bin/start.sh`.
+2. Find the line that contains the `-Dapiml.security.auth.zosmfServiceId=zosmf` parameter and replace it with `-Dapiml.security.auth.provider=saf`.
+3. Restart Zowe&trade.
+
+Authentication requests will now leverage SAF as authentication provider and the API ML will run without the zOSMF present
+on the system. 
+
 ## Retry policy
 
 In default configuration, retry for all request is disabled, with one exception. The server will retry `GET` requests that finish with status code `503`. You can modify this behavior with these parameters:


### PR DESCRIPTION
Signed-off-by: Jakub Balhar <jakub.balhar@broadcom.com>

### Description (including links to related git issues)
The PR is linked to the https://github.com/zowe/api-layer/issues/472 

The PR explains the configuration parameter which uses SAF as authentication provide instead of zOSMF and as such removes the need to have running zOSMF on the system. 
