### PR TITLE
Fix the ZE FAQ anchor link

### DIFF
--- a/docs/getting-started/freqaskques.md
+++ b/docs/getting-started/freqaskques.md
@@ -4,7 +4,7 @@ Check out the following FAQs to learn more about the purpose and function of Zow
 
 - [Zowe FAQ](#zowe-faq)
 - [Zowe CLI FAQ](#zowe-cli-faq)
-- [Zowe Explorer FAQ](#zowe-explorer-FAQ)
+- [Zowe Explorer FAQ](#zowe-explorer-faq)
 
 ## Zowe FAQ
 


### PR DESCRIPTION
Signed-off-by: Igor Kazmyr <43951184+IgorCATech@users.noreply.github.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
It's a quick fix. The Zowe Explorer FAQ anchor link (in TOC) was broken. This PR fixes the issue.

:heart:Thank you!

