### PR TITLE
Add reference links to api docs

### DIFF
--- a/docs/.vuepress/pages.json
+++ b/docs/.vuepress/pages.json
@@ -272,7 +272,11 @@
     "canHideFirst": true,
     "items": [{
         "text": "Zowe CLI command reference",
-        "link": "#zowe-cli-command-reference-guide"
+        "link": "appendix/zowe-cli-commannd-reference.md"
+      },
+      {
+        "text": "Zowe API reference",
+        "link": "appendix/zowe-api-reference.md"
       },
       {
         "text": "Bill of Materials",
@@ -281,22 +285,6 @@
       {
         "text": "Third-Party Software Requirements",
         "link": "appendix/tpsr.md"
-      },
-      {
-        "text": "REST API for the Data sets and z/OS Unix Files Services",
-        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/datasets.json"
-      },
-      {
-        "text": "REST API for the API Gateway service",
-        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/gateway.json"
-      },
-      {
-        "text": "REST API for the JES Jobs Service",
-        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/jobs.json"
-      },
-      {
-        "text": "REST API for ZLUX Plugin",
-        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/zlux-plugin.json"
       }
     ]
   }

--- a/docs/.vuepress/pages.json
+++ b/docs/.vuepress/pages.json
@@ -281,6 +281,22 @@
       {
         "text": "Third-Party Software Requirements",
         "link": "appendix/tpsr.md"
+      },
+      {
+        "text": "REST API for the Data sets and z/OS Unix Files Services",
+        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/datasets.json"
+      },
+      {
+        "text": "REST API for the API Gateway service",
+        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/gateway.json"
+      },
+      {
+        "text": "REST API for the JES Jobs Service",
+        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/jobs.json"
+      },
+      {
+        "text": "REST API for ZLUX Plugin",
+        "link": "https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/zlux-plugin.json"
       }
     ]
   }

--- a/docs/appendix/zowe-api-reference.md
+++ b/docs/appendix/zowe-api-reference.md
@@ -1,0 +1,11 @@
+# Zowe API reference
+
+Find and learn about the Zowe APIs that you can use.
+
+- **[REST API for the Data sets and z/OS Unix Files Services](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/datasets.json)**
+
+- **[REST API for the API Gateway service](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/gateway.json)**
+
+- **[REST API for the JES Jobs Service](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/jobs.json)**
+
+- **[REST API for ZLUX Plug-in](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/zlux-plugin.json)**

--- a/docs/appendix/zowe-cli-commannd-reference.md
+++ b/docs/appendix/zowe-cli-commannd-reference.md
@@ -1,0 +1,6 @@
+# Zowe CLI command reference guide
+
+View detailed documentation on commands, actions, and options in Zowe CLI. The reference document is based on the `@zowe-v1-lts` version of the CLI. You can read an interactive online version, download a PDF document, or download a ZIP file containing the HTML for the online version:
+- **[Browse online](../web_help/index.html)**
+- **[Download CLI reference in PDF format](../CLIReference_Zowe.pdf)**
+- **[Download CLI reference in ZIP format](../zowe_web_help.zip)**


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

### Your checklist for this pull request
Using master because this API documentation is for the current release.

### Description (including links to related git issues)
Resolve #537. Adds reference links to generated API swagger files, displayed by petstore.swagger.io. [Example here.](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/zowe/docs-site/docs-staging/api_definitions/datasets.json)

