### PR TITLE
Prepare v1.16.0 doc version

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,6 +1,6 @@
 // load versions list
 const ZOWE_VERSIONS = require('./versions.json')
-const CURRENT_ZOWE_VERSION = '1.15.0 LTS'
+const CURRENT_ZOWE_VERSION = '1.16.0 LTS'
 // Due to VuePress limitation, publish url path cannot have dot (.) inside
 // so we convert it to dash
 const PUBLISH_TARGET_PATH = (process.env.PUBLISH_TARGET_PATH || 'stable').replace(/\./g, '-')
@@ -131,7 +131,7 @@ module.exports = {
   version: CURRENT_ZOWE_VERSION,
   base: `/${PUBLISH_TARGET_PATH}/`,
   dest: `.deploy/${PUBLISH_TARGET_PATH}/`,
-  description: 'Version 1.15.x LTS',
+  description: 'Version 1.16.x LTS',
   extraWatchFiles: [
     '.vuepress/theme/'
   ],

--- a/docs/.vuepress/versions.json
+++ b/docs/.vuepress/versions.json
@@ -1,6 +1,10 @@
 [{
-  "text": "v1.15.x LTS",
+  "text": "v1.16.x LTS",
   "link": "stable/"
+},
+{
+  "text": "v1.15.x LTS",
+  "link": "v1-15-x/"
 },
 {
   "text": "v1.14.x LTS",

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,8 @@ footer: Except where otherwise noted, content on this site is licensed under a C
 
 You can download the Version 1.x.x Zowe documentation in PDF format from the links below. The latest version on this website is 1.14.0.
 
-**[V1.15.0](https://docs.zowe.org/stable/Zowe_Documentation.pdf)** |
+**[V1.16.0](https://docs.zowe.org/stable/Zowe_Documentation.pdf)** |
+**[V1.15.0](./Zowe_Documentation_1.15.0.pdf)** |
 **[V1.14.0](./Zowe_Documentation_1.14.0.pdf)** |
 **[V1.13.0](./Zowe_Documentation_1.13.0.pdf)** |
 **[V1.12.0](./Zowe_Documentation_1.12.0.pdf)** |


### PR DESCRIPTION
Added:
- 1.16.0 versioning
- Archived master branch  (lmk if any of your PRs with `base:master` should have been merged before this.  I'll help add them back to the archived branch and PDF since this was my doing :P) 
- Archived 1.15 PDF
- Updated Algolia search

TODO:
- [] Release Notes (pls be sure changleogs are complete before they build package on Monday)
- [] TPSRs 
- [] BoM (or not)
