### PR TITLE
Hold off client certificate auth documentation for this release

### DIFF
--- a/docs/extend/extend-apiml/api-mediation-security.md
+++ b/docs/extend/extend-apiml/api-mediation-security.md
@@ -168,7 +168,6 @@ The API Gateway contains two REST API authentication endpoints: `auth/login` and
 The `/login` endpoint authenticates mainframe user credentials and returns an authentication token. The login request requires user credentials though one of the following methods:
   * Basic access authentication
   * JSON with user credentials
-  * Client certificate
 
 When authentication is successful, the response to the request is an empty body and a token is contained in a secure `HttpOnly` cookie named `apimlAuthenticationToken`. When authentication fails, a user gets a 401 status code.
 
@@ -203,23 +202,6 @@ with each authentication provider.
 
 The client can authenticate via Username and password. There are multiple methods which can be used to deliver  
 credentials. There are more details in the ZAAS Client documentation. 
-
-##### Client certificate
-
-If the keyring or truststore contain at least one valid certificate authority (CA) other than the CA of the API ML, it is possible to use the client certificates issued by this CA to authenticate to the API ML and subsequent services. This feature is not enabled by default and needs to be configured.
-
-Authentication is performed in the following ways:
-* The client calls the API ML Gateway login endpoint with the client certificate and its private key.
-* The client certificate and private key are checked as a valid TLS client certificate against the Gateway's trusted CAs.
-* The public part of the provided client certificate is checked against SAF and SAF subsequently returns a user ID that owns this certificate. ZSS is providing this API for Mediation Layer.
-* The Gateway performs the login of the mapped user and returns a valid JWT token.
-
-**Prerequisities:**
-* Ensure that you have an external Certificate Authority and signed client certificates, or generate these certificates in SAF.
-* Import the client certificates to SAF, or add them to a user profile (for example `RACDCERT ADD` or `RACDCERT GENCERT`. For details, please refer to your security system documentation)
-* Import the external CA to the truststore of the API Mediation Layer
-* [Configure Gateway for client certificate authentication](../../user-guide/api-mediation/api-gateway-configuration.md#gateway-client-certificate-authentication)
-* [For upgrade from zowe 1.16 or lower, please review the additional security rights that need to be granted](../../user-guide/configure-zos-system.md#configure-main-Zowe-server-use-identity-mapping)
 
 ##### JWT Token
 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -14,7 +14,6 @@ Refer to the particular section in this table fo contents for specific instructi
   * [Prefer IP Address for API Layer services](#prefer-ip-address-for-api-layer-services)
   * [SAF as an Authentication provider](#saf-as-an-authentication-provider)
   * [Gateway retry policy](#gateway-retry-policy)
-  * [Gateway client certificate authentication](#gateway-client-certificate-authentication)
   * [Gateway timeouts](#gateway-timeouts)
   * [Cors handling](#cors-handling)
   * [Encoded slashes](#encoded-slashes)
@@ -73,39 +72,6 @@ To change this default configuration, include the following parameters:
     
     Specfies the number of additional servers that attempt to make the request. This number excleds the first server. The default value is `5`. 
     
-## Gateway client certificate authentication
-
-Use the following procedure to enable the feature of using a client certificate as a method of authentication for the API Mediation Layer Gateway.
-
-**Follow these steps:**
-
-1. Open the `<Zowe instance directory>/instance.env` configuration file.
-2. Configure the following properties:
-
-   * **APIML_SECURITY_X509_ENABLED**
-
-     This is the global feature toggle. Set value to `true` to enable client certificate functionality.
-
-   * **APIML_SECURITY_ZOSMF_APPLID**
-
-     When z/OSMF is used as an authentication provider, provide a valid APPLID to allow for client certificate authentication. The API ML authenticates to z/OSMF through the generation of a passticket and subsequently uses this passticket to authenticate to z/OSMF. The value in the default installation of the z/OSMF is `IZUDFLT`.
-
-3. Open the file `<Zowe install directory>/components/api-mediation/bin/start.sh`.
-4. Configure the following properties:
-
-   * **apiml.security.x509.externalMapperUrl**
-
-     The API Mediation Gateway uses an external API to map a certificate to the owner in SAF. This property informs the Gateway about the location of this API. ZSS is provides this API in Zowe. Provide the ZSS URL in the following format:
-     ```
-     -Dapiml.security.x509.externalMapperUrl=http://localhost:<ZSS-PORT>/certificate/x509/map
-     ```
-     The default port is `8542`. The hostname is `localhost` as the ZSS server is accessible only locally.
-
-   * **apiml.security.x509.externalMapperUser**
-
-     To authenticate to the mapping API, a JWT token is sent with the request. The token represents the user that is configured with this property. The user is then authorized to use the `IRR.RUSERMAP` resource within the `FACILITY` class. The default value is `ZWESVUSR`, and the permissions are set up during installation with the `ZWESECUR` jcl or workflow. If you decide to customize the ZWESECUR jcl or workflow (`// SET ZOWEUSER=ZWESVUSR * userid for Zowe started task`), change the `apiml.security.x509.externalMapperUser` to a new value.
-
-Restart Zowe&trade.
 
 ## Gateway timeouts
 

--- a/docs/user-guide/configure-instance-directory.md
+++ b/docs/user-guide/configure-instance-directory.md
@@ -141,7 +141,6 @@ To determine which ports are not available, follow these steps:
 - `APIML_CORS_ENABLED`: When this parameter is set to `true`, CORS are enabled in the API Gateway for Gateway routes `api/v1/gateway/**`.
 - `APIML_PREFER_IP_ADDRESS`: Set the value of the parameter to `true` if you want to advertise a service IP address instead of its hostname.
 - `APIML_GATEWAY_TIMEOUT_MILLIS`: Timeout for connection to the services. 
-- `APIML_SECURITY_X509_ENABLED`: When this parameter is set to `true`, the client certificate authentication functionality through ZSS is enabled.
 - `APIML_SECURITY_ZOSMF_APPLID`: The z/OSMF APPLID used for PassTicket.
 - `APIML_SECURITY_AUTH_PROVIDER`: The authentication provider used by the API Gateway. By default, the API Gateway uses z/OSMF as an authentication provider, but it is possible to switch to SAF as the authentication provider instead of z/OSMF.
 


### PR DESCRIPTION
This is documentation revert for client cert auth, which should not go to the upcomming release. It will be added back when the client cert auth is ready.

There is no need for TI review imho.