### PR TITLE
Initial v1.18.0 setup

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,6 +1,6 @@
 // load versions list
 const ZOWE_VERSIONS = require('./versions.json')
-const CURRENT_ZOWE_VERSION = '1.17.0 LTS'
+const CURRENT_ZOWE_VERSION = '1.18.0 LTS'
 // Due to VuePress limitation, publish url path cannot have dot (.) inside
 // so we convert it to dash
 const PUBLISH_TARGET_PATH = (process.env.PUBLISH_TARGET_PATH || 'stable').replace(/\./g, '-')
@@ -131,7 +131,7 @@ module.exports = {
   version: CURRENT_ZOWE_VERSION,
   base: `/${PUBLISH_TARGET_PATH}/`,
   dest: `.deploy/${PUBLISH_TARGET_PATH}/`,
-  description: 'Version 1.17.x LTS',
+  description: 'Version 1.18.x LTS',
   extraWatchFiles: [
     '.vuepress/theme/'
   ],

--- a/docs/.vuepress/versions.json
+++ b/docs/.vuepress/versions.json
@@ -1,6 +1,10 @@
 [{
-  "text": "v1.17.x LTS",
+  "text": "v1.18.x LTS",
   "link": "stable/"
+},
+{
+  "text": "v1.17.x LTS",
+  "link": "v1.17.x LTS"
 },
 {
   "text": "v1.16.x LTS",

--- a/docs/.vuepress/versions.json
+++ b/docs/.vuepress/versions.json
@@ -4,7 +4,7 @@
 },
 {
   "text": "v1.17.x LTS",
-  "link": "v1.17.x LTS"
+  "link": "v1-17-x/"
 },
 {
   "text": "v1.16.x LTS",

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,9 +39,10 @@ footer: Except where otherwise noted, content on this site is licensed under a C
 
 ### Zowe documentation
 
-You can download the Version 1.x.x Zowe documentation in PDF format from the links below. The latest version on this website is 1.17.0.
+You can download the Version 1.x.x Zowe documentation in PDF format from the links below. The latest version on this website is 1.18.0.
 
-**[V1.17.0](https://docs.zowe.org/stable/Zowe_Documentation.pdf)** |
+**[V1.18.0](https://docs.zowe.org/stable/Zowe_Documentation.pdf)** |
+**[V1.17.0](./Zowe_Documentation_1.17.0.pdf)** |
 **[V1.16.0](./Zowe_Documentation_1.16.0.pdf)** |
 **[V1.15.0](./Zowe_Documentation_1.15.0.pdf)** |
 **[V1.14.0](./Zowe_Documentation_1.14.0.pdf)** |

--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -4,7 +4,7 @@ Learn about what is new, changed, or removed in Zowe&trade;.
 
 Zowe Version 1.18 and earlier releases include the following enhancements, release by release.
 
-- [Version 1.18.0 LTS (December 2020)](#version-1-17-0-lts-november-2020)
+- [Version 1.18.0 LTS (December 2020)](#version-1-18-0-lts-december-2020)
 - [Version 1.17.0 LTS (November 2020)](#version-1-17-0-lts-november-2020)
 - [Version 1.16.0 LTS (October 2020)](#version-1-16-0-lts-october-2020)
 - [Version 1.15.0 LTS (September 2020)](#version-1-15-0-lts-september-2020)

--- a/docs/getting-started/summaryofchanges.md
+++ b/docs/getting-started/summaryofchanges.md
@@ -2,8 +2,9 @@
 
 Learn about what is new, changed, or removed in Zowe&trade;.
 
-Zowe Version 1.17.0 and later releases include the following enhancements, release by release.
+Zowe Version 1.18 and earlier releases include the following enhancements, release by release.
 
+- [Version 1.18.0 LTS (December 2020)](#version-1-17-0-lts-november-2020)
 - [Version 1.17.0 LTS (November 2020)](#version-1-17-0-lts-november-2020)
 - [Version 1.16.0 LTS (October 2020)](#version-1-16-0-lts-october-2020)
 - [Version 1.15.0 LTS (September 2020)](#version-1-15-0-lts-september-2020)
@@ -27,6 +28,22 @@ Zowe Version 1.17.0 and later releases include the following enhancements, relea
 - [Version 1.0.1 (March 2019)](#version-1-0-1-march-2019)
 - [Version 1.0.0 (February 2019)](#version-1-0-0-february-2019)
 
+## Version 1.18.0 LTS (December 2020)
+### Notable changes
+
+### New features and enhancements
+#### Zowe installation
+#### Zowe API Mediation Layer
+#### Zowe App Server
+#### Zowe CLI
+#### Zowe Explorer
+
+### Bug Fixes
+#### Zowe installation
+#### Zowe API Mediation Layer
+#### Zowe App Server
+#### Zowe CLI
+#### Zowe Explorer
 ## Version 1.17.0 LTS (November 2020)
 
 ### Notable changes


### PR DESCRIPTION
Added the 1.18.0 versioning to doc site versions, config, readme, and release notes. 

Did _not_ archive the site, the PDF, etc.. since the release may still be a while in the future.  