### PR TITLE
Create robots.txt to disallow crawl of archived docs

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,8 @@
 User-agent: *
 
 # Zowe doc archives
+Disallow: /active-development/
+Disallow: /v0-9-x/
 Disallow: /v1-0-x/
 Disallow: /v1-1-x/
 Disallow: /v1-2-x/

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,20 @@
+User-agent: *
+
+# Zowe doc archives
+Disallow: /v1-0-x/
+Disallow: /v1-1-x/
+Disallow: /v1-2-x/
+Disallow: /v1-3-x/
+Disallow: /v1-4-x/
+Disallow: /v1-5-x/
+Disallow: /v1-6-x/
+Disallow: /v1-7-x/
+Disallow: /v1-8-x/
+Disallow: /v1-9-x/
+Disallow: /v1-10-x/
+Disallow: /v1-11-x/
+Disallow: /v1-12-x/
+Disallow: /v1-13-x/
+Disallow: /v1-14-x/
+Disallow: /v1-15-x/
+Disallow: /v1-16-x/


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [x] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.
#1503 

### Description (including links to related git issues)
Please describe your pull request.

Blocking all web crawlers from crawling docs of v1.16.0 and earlier versions. This will ensure that older versions of docs do not display in search results but are still accessible via direct URL. 

:heart:Thank you!

