### PR TITLE
Document APIML Gateway connection limit configuration

### DIFF
--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -17,6 +17,7 @@ Refer to the particular section in this table fo contents for specific instructi
   * [Gateway timeouts](#gateway-timeouts)
   * [Cors handling](#cors-handling)
   * [Encoded slashes](#encoded-slashes)
+  * [Connection limits](#connection-limits)
 
 ## Prefer IP Address for API Layer services
 
@@ -131,4 +132,15 @@ Use the following procedure to reject encoded slashes.
     
 Requests with encoded slashes are now rejected by the API Mediation Layer.
 
+## Connection limits
+
+By default, the API Gateway accepts up to 100 conncurrent connections per route and 1000 total concurrent connections. Any further concurrent requests are queued.
+
+Use the following procedure to change the number of concurrent connections.
+
+**Follow these steps:**
+
+1. Open the file `<Zowe instance directory>/instance.env`.
+2. Find the property `APIML_MAX_CONNECTIONS_PER_ROUTE` and set the value to an appropriate positive integer.
+3. Find the property `APIML_MAX_TOTAL_CONNECTIONS` and set the value to an appropriate positive integer.
 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -2,7 +2,7 @@
 
 As a system programmer who wants to configure advanced Gateway features of the API Mediation Layer, set the following parameters by modifying either of the following files:
 
-- `<Zowe install directory>/components/api-mediation/bin/start.sh` 
+- `<Zowe install directory>/components/api-mediation/bin/start-gateway.sh` 
 - `<Zowe instance directory>/instance.env`
 
 The parameters begin with the `-D` prefix, similar to all the other parameters in the file.


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [x] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Related to [APIML PR 985](https://github.com/zowe/api-layer/pull/985) and [APIML issue 843](https://github.com/zowe/api-layer/issues/843).

Documents new configuration for APIML Gateway to set the concurrent connection limit per route and in total.

:heart:Thank you!

