### PR TITLE
Adjust header font size

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -11,8 +11,11 @@
     &:hover
         background-color lighten(#1e73be, 10%)
 
-h3, h4
-    font-size 1.35rem
+h3
+    font-size 1.25rem
+
+h4
+    font-size 1.00rem
 
 h1, h2, h3, h4, h5, h6
   .content:not(.custom) > &


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Please describe your pull request.
**This addresses the feedback that H3 and H4 headers font size looks similar so not able to identify the correct topic hierarchy.** 

Previously:
<img width="696" alt="image" src="https://user-images.githubusercontent.com/14340789/102334255-6b884080-3fc9-11eb-8fda-537a1ba2de26.png">

Now:
<img width="696" alt="image" src="https://user-images.githubusercontent.com/14340789/102334455-a68a7400-3fc9-11eb-81c9-77cc0d98b48c.png">


:heart:Thank you!

