### PR TITLE
Indentation and consistency for enablers 

### DIFF
--- a/docs/extend/extend-apiml/onboard-direct-eureka-call.md
+++ b/docs/extend/extend-apiml/onboard-direct-eureka-call.md
@@ -147,7 +147,7 @@ At registration time, provide metadata in the following format. Metadata paramet
       <apiml.routes.ws__v1.serviceUrl>/sampleclient/ws</apiml.routes.ws__v1.serviceUrl>
       <apiml.authentication.scheme>httpBasicPassTicket</apiml.authentication.scheme>
       <apiml.authentication.applid>ZOWEAPPL</apiml.authentication.applid>
-      <apiml.apiInfo.0.apiId>org.zowe.sampleclient</apiml.apiInfo.0.apiId>
+      <apiml.apiInfo.0.apiId>zowe.apiml.sampleclient</apiml.apiInfo.0.apiId>
       <apiml.apiInfo.0.swaggerUrl>https://hostname/sampleclient/api-doc</apiml.apiInfo.0.swaggerUrl>
       <apiml.apiInfo.0.gatewayUrl>api/v1</apiml.apiInfo.0.gatewayUrl>
       <apiml.apiInfo.0.documentationUrl>https://www.zowe.org</apiml.apiInfo.0.documentationUrl>
@@ -361,7 +361,7 @@ The following parameters provide the information properties of a single API:
 In the following example, `0` represents the `api-index`.
 
 ```
-<apiml.apiInfo.0.apiId>org.zowe.sampleclient</apiml.apiInfo.0.apiId>
+<apiml.apiInfo.0.apiId>zowe.apiml.sampleclient</apiml.apiInfo.0.apiId>
 <apiml.apiInfo.0.swaggerUrl>https://hostname/sampleclient/api-doc</apiml.apiInfo.0.swaggerUrl>
 <apiml.apiInfo.0.gatewayUrl>api/v1</apiml.apiInfo.0.gatewayUrl>
 <apiml.apiInfo.0.documentationUrl>https://www.zowe.org</apiml.apiInfo.0.documentationUrl>

--- a/docs/extend/extend-apiml/onboard-nodejs-enabler.md
+++ b/docs/extend/extend-apiml/onboard-nodejs-enabler.md
@@ -71,7 +71,7 @@ The following example shows a sample configuration.
       - gatewayUrl: api/v1
         serviceRelativeUrl: /api/v1
     apiInfo:
-      - apiId: org.zowe.hwexpress
+      - apiId: zowe.apiml.hwexpress
         gatewayUrl: "api/v1"
         swaggerUrl: https://localhost:10020/swagger.json
     catalogUiTile:
@@ -104,7 +104,7 @@ The following example shows a sample configuration.
         apiml.catalog.tile.version: '1.0.0'
         apiml.routes.api_v1.gatewayUrl: "api/v1"
         apiml.routes.api_v1.serviceUrl: "/api/v1"
-        apiml.apiInfo.0.apiId: org.zowe.hwexpress
+        apiml.apiInfo.0.apiId: zowe.apiml.hwexpress
         apiml.apiInfo.0.gatewayUrl: "api/v1"
         apiml.apiInfo.0.swaggerUrl: https://localhost:10020/swagger.json
         apiml.service.title: 'Zowe Sample Node Service'

--- a/docs/extend/extend-apiml/onboard-overview.md
+++ b/docs/extend/extend-apiml/onboard-overview.md
@@ -110,7 +110,7 @@ Verify that your service is discovered by the Discovery Service with the followi
                 <apiml.catalog.tile.description>Applications which demonstrate how to make a service integrated to the API Mediation Layer ecosystem</apiml.catalog.tile.description>
                 <apiml.service.title>Sample Service ©</apiml.service.title>
                 <apiml.routes.ui__v1.gatewayUrl>ui/v1</apiml.routes.ui__v1.gatewayUrl>
-                <apiml.apiInfo.0.apiId>org.zowe.sampleclient</apiml.apiInfo.0.apiId>
+                <apiml.apiInfo.0.apiId>zowe.apiml.sampleclient</apiml.apiInfo.0.apiId>
                 <apiml.apiInfo.0.gatewayUrl>api/v1</apiml.apiInfo.0.gatewayUrl>
                 <apiml.apiInfo.0.documentationUrl>https://www.zowe.org</apiml.apiInfo.0.documentationUrl>
                 <apiml.catalog.tile.id>samples</apiml.catalog.tile.id>

--- a/docs/extend/extend-apiml/onboard-plain-java-enabler.md
+++ b/docs/extend/extend-apiml/onboard-plain-java-enabler.md
@@ -195,12 +195,12 @@ authentication:
     applid: ZOWEAPPL
 
  apiInfo:
-     - apiId: org.zowe.sampleservice
+     - apiId: zowe.apiml.sampleservice
        version: 1.0.0
        gatewayUrl: api/v1
        swaggerUrl: http://${sampleServiceSwaggerHost}:${sampleServiceSwaggerPort}/sampleservice/api-doc
        doumentationUrl: http://
-     - apiId: org.zowe.sampleservice
+     - apiId: zowe.apiml.sampleservice
        version: 2.0.0
        gatewayUrl: api/v2
        swaggerUrl: http://${sampleServiceSwaggerHost}:${sampleServiceSwaggerPort}/sampleservice/api-doc?group=api-v2
@@ -363,12 +363,12 @@ The following snippet presents the information properties of a single API:
 
 ```
 apiInfo:
-    - apiId: org.zowe.sampleservice
-    version: v1
-    gatewayUrl: api/v1
-    swaggerUrl: http://localhost:10021/sampleservice/api-doc
-    documentationUrl: http://your.service.documentation.url
-    defaultApi: true
+    - apiId: zowe.apiml.sampleservice
+      version: 1.0.0
+      gatewayUrl: api/v1
+      swaggerUrl: http://localhost:10021/sampleservice/api-doc
+      documentationUrl: http://your.service.documentation.url
+      defaultApi: true
 ```
 
 where:

--- a/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
+++ b/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
@@ -294,12 +294,12 @@ apiml:
             applid: ZOWEAPPL
 
         apiInfo:
-            -   apiId: org.zowe.sampleservice
+            -   apiId: zowe.apiml.sampleservice
                 version: 1.0.0
                 gatewayUrl: api/v1
                 swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/api-doc
                 documentationUrl: https://www.zowe.org
-            -   apiId: org.zowe.sampleservice
+            -   apiId: zowe.apiml.sampleservice
                 version: 2.0.0
                 gatewayUrl: api/v2
                 swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}${apiml.service.contextPath}/api-doc?group=apiv2


### PR DESCRIPTION

### Description (including links to related git issues)
Fix indentation in plain java enabler sample. Set apiId consistent throughout document and according to conformance criteria. Fixes  https://github.com/zowe/api-layer/issues/1103

