### PR TITLE
Typo in SYSIN for GIMUNZIP (EXTRACT JCL)

### DIFF
--- a/docs/user-guide/install-zowe-smpe.md
+++ b/docs/user-guide/install-zowe-smpe.md
@@ -579,7 +579,7 @@ The AZWE001.readme.txt file uploaded in the previous step holds a sample JCL to 
   <ARCHDEF archid="AZWE001.F2"
   newname="@PREFIX@.ZOWE.AZWE001.F2"/>
   <ARCHDEV archid="AZWE001.F3"
-  nawname="@PREFIX@.ZOWE.AZWE001.F3"/>
+  newname="@PREFIX@.ZOWE.AZWE001.F3"/>
   <ARCHDEF archid="AZWE001.F4"
   newname="@PREFIX@.ZOWE.AZWE001.F4"/>
   </GIMUNZIP>

--- a/docs/user-guide/install-zowe-smpe.md
+++ b/docs/user-guide/install-zowe-smpe.md
@@ -578,7 +578,7 @@ The AZWE001.readme.txt file uploaded in the previous step holds a sample JCL to 
   newname="@PREFIX@.ZOWE.AZWE001.F1"/>
   <ARCHDEF archid="AZWE001.F2"
   newname="@PREFIX@.ZOWE.AZWE001.F2"/>
-  <ARCHDEV archid="AZWE001.F3"
+  <ARCHDEF archid="AZWE001.F3"
   newname="@PREFIX@.ZOWE.AZWE001.F3"/>
   <ARCHDEF archid="AZWE001.F4"
   newname="@PREFIX@.ZOWE.AZWE001.F4"/>


### PR DESCRIPTION
From ```nawname="@PREFIX@.ZOWE.AZWE001.F3"/>``` to  ```newname="@PREFIX@.ZOWE.AZWE001.F3"/>```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Please describe your pull request.

:heart:Thank you!

