### PR TITLE
Fix broken link and clarify lifecycle scripts

### DIFF
--- a/docs/extend/lifecycling-with-zwesvstc.md
+++ b/docs/extend/lifecycling-with-zwesvstc.md
@@ -24,6 +24,8 @@ Each Zowe component will be installed with its own USS directory, which contains
 - Used for the base Zowe components that are included with the core Zowe runtime.
 - Applies to extensions to allow vendor offerings to be able to have the lifecycle of their 'microservices' within the Zowe USS shell and be included as address spaces under the `ZWESVSTC` started task.
 
+Please note, all lifecycle scripts are executed from directory of the component root directory. This directory will usually be the parent of your `/bin` directory.
+
 ### Validate
 
 Each component can optionally instruct Zowe runtime to validate itself with a USS command defined in manifest `commands.validate`. If this is not defined, for backward compatible purpose, a call to its `/bin/validate.sh` script will be executed if it exists.
@@ -43,7 +45,9 @@ If the component has manifest defined, some configure actions will be performed 
 
 - `apimlServices.static`: Zowe runtime will automatically parse and add your static definition to API Mediation Layer.
 
-For backward compatible purpose, you can choose to configure component by yourself with `/bin/configure.sh`. An example configuration step is if a component wants to install applications into the Zowe desktop as iframes, or add API endpoints statically into the API Mediation Layer.  Because a component's `configure.sh` script is run inside the USS shell that the `instance.env` has initialized, it will have all of the shell variables for prerequisites set, so the configure step can be used to query these in order to prepare the component ready for launch.  
+For backward compatible purpose, you can choose to configure component by yourself with `/bin/configure.sh`. An example configuration step is if a component wants to install applications into the Zowe desktop as iframes, or add API endpoints statically into the API Mediation Layer.  Because a component's `configure.sh` script is run inside the USS shell that the `instance.env` has initialized, it will have all of the shell variables for prerequisites set, so the configure step can be used to query these in order to prepare the component ready for launch.
+
+From v1.20.0 or above, you can pass along configuration variables from `configure` step to `start` step by exporting it. Each components are running in separated shell space, that means variable from one component will not affect same variable of another component. For example, `export MY_VAR=val` in `/bin/configure.sh`, then `${MY_VAR}` should be available in your `/bin/start.sh`. But `${MY_VAR}` is not available for other components.
 
 ### Start
 

--- a/docs/extend/packaging-zos-extensions.md
+++ b/docs/extend/packaging-zos-extensions.md
@@ -27,7 +27,7 @@ where,
 
 - `manifest.yaml`: This is the Zowe component manifest file. You can find detailed definition of manifest in [Zowe Component Manifest](#zowe-component-manifest).
 - `apiml-static-registration.yaml.template`: This is a supporting file that instructs the Zowe launch script how to register this extension service to the API Mediation Layer Discovery service. In this case, this file is referred in the `manifest.yaml` `apimlServices.static[0].file` field. This file is optional depending on the function of the component and you can change and customize the file name in the manifest file.
-- `bin/(configure|start|validate).sh`: These are Zowe component lifecycle scripts. You may not need these files depending on the function of the component. You can find detailed definition of lifecycle scripts in [Zowe lifecycle](#zowe-runtime-lifecycle).
+- `bin/(configure|start|validate).sh`: These are Zowe component lifecycle scripts. You may not need these files depending on the function of the component. You can find detailed definition of lifecycle scripts in [Zowe component runtime lifecycle](lifecycling-with-zwesvstc.md#zowe-component-runtime-lifecycle).
 
 It is also suggested that you put the following files into the package:
 


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Please describe your pull request.

- There is broken link (with hash) in https://docs.zowe.org/stable/extend/packaging-zos-extensions.html#zowe-server-component-package-format `You can find detailed definition of lifecycle scripts in Zowe lifecycle.`.
- How variables are handled by lifecycle scripts are not very clear.

:heart:Thank you!

