### PR TITLE
Exclude docs/.vuepress/public subdirectories from link checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: pending to verify dead links.\"",
-    "test:links": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url / --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" ./.deploy/",
-    "test:links:stable": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url /stable/ --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" ./.deploy/stable/",
+    "test:links": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url / --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/",
+    "test:links:stable": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url /stable/ --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/stable/",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "docs:pdf": "./docs/.pdf/build.sh"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: pending to verify dead links.\"",
-    "test:links": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url / --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude-docs \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/",
-    "test:links:stable": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url /stable/ --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude-docs \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/stable/",
+    "test:links": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url / --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude-docs \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" ./.deploy/",
+    "test:links:stable": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url /stable/ --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude-docs \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" ./.deploy/stable/",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "docs:pdf": "./docs/.pdf/build.sh"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: pending to verify dead links.\"",
-    "test:links": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url / --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/",
-    "test:links:stable": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url /stable/ --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/stable/",
+    "test:links": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url / --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude-docs \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/",
+    "test:links:stable": "w3c-linkchecker-local --checklink-command docker --base-domain zowe-docs-test-links --base-url /stable/ --summary --recursive --ignore-robots-forbidden --ignore-broken-fragments --ignore-redirection --timeout 120 --exclude \"https?:\\/\\/((?![^/]*zowe-docs-test-links|zowe\\.org|www\\.zowe\\.org|docs\\.zowe\\.org|zowe\\.github\\.io)[^/]*)/\" --exclude-docs \"https?:\\/\\/[^/]+(/stable)?/(typedoc|web_help)/\" ./.deploy/stable/",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "docs:pdf": "./docs/.pdf/build.sh"


### PR DESCRIPTION
Follow up to #1708 which inadvertently broke [master build](https://wash.zowe.org:8443/blue/organizations/jenkins/docs-site/detail/master/315/pipeline) by making the link checker time out.

The directories inside docs/.vuepress/public (typedoc and web_help) contain automatically generated content that doesn't need to have its links checked, and makes the link checker take significantly longer.

This change should approximately halve the time of the "test" stage in the pipeline, since web_help folder used to be included in link check.

Thanks to @jackjia-ibm for helping me to fix this 🙂