### PR TITLE
Document requirements for OMVS service in ZSS

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -86,6 +86,7 @@ The task starts a USS environment using `BPXBATSL` that executes the core Zowe D
 | FACILITY | `BPX.SERVER` + `BPX.DEAMON` | UPDATE | To allow the Zowe Desktop ZLUX server to run code on behalf of the API requester's TSO user ID. For more information, see [Security Environment Switching](./configure-zos-system.md#configure-security-environment-switching). |
 | FACILITY | `IRR.RUSERMAP` | READ | To allow Zowe to [map an X.509 client certificate to a z/OS identity](./configure-zos-system.md#configure-main-zowe-server-to-use-identity-mapping) | 
 | FACILITY | `BPX.JOBNAME` | READ | To allow z/OS address spaces for unix processes to be renamed for [ease of identification](./configure-zos-system.md#configure-address-space-job-naming) |
+| FACILITY | `IRR.RADMIN.LISTUSER` | READ | To allow Zowe to obtain information about OMVS segment of the user profile using `LISTUSER` TSO command |
 
 ### ZWESIUSR
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
### Description (including links to related git issues)

OMVS Service in ZSS requires `READ` access to `IRR.RADMIN.LISTUSER` profile in order to obtain information about OMVS segment of the user profile. This PR documents the requirement.

:heart:Thank you!

