### PR TITLE
Fixed a typo in configuration instructions for z/OS System

### DIFF
--- a/docs/user-guide/configure-zos-system.md
+++ b/docs/user-guide/configure-zos-system.md
@@ -486,7 +486,7 @@ To set up this security configuration, submit the `ZWESECUR` JCL member. For use
 
 ### Using RACF
 
-If you use RAFC, verify and update permission in the `FACILITY` class.
+If you use RACF, verify and update permission in the `FACILITY` class.
 
 **Follow these steps:**
 


### PR DESCRIPTION
### Description (including links to related git issues)
Fixed a typo in the z/OS System configuration instructions. 
