### PR TITLE
Add documentation about HA for app-server and zss

### DIFF
--- a/docs/extend/extend-desktop/mvd-authentication-api.md
+++ b/docs/extend/extend-desktop/mvd-authentication-api.md
@@ -3,7 +3,77 @@ This topic describes the web service API for user authentication.
 
 The authentication mechanism of the ZLUX server allows for an administrator to gate access to services by a given auth handler, while on the user side the authentication structure allows for a user to login to one or more endpoints at once provided they share the same credentials given.
 
-## Check status
+## Handlers
+
+The auth handlers are a type of zlux server plugin (type=nodeAuthentication) which are categorized by which kind of authentication they can provide. Whether it's to z/OS via `type=saf` or theoretical authentication such as facebook or amazon cloud, the handler API is abstract to handle different types of security needs.
+
+### Handler installation
+
+Auth handler plugins are installed like any other plugin.
+
+### Handler configuration
+
+The server top-level configuration attribute `dataserviceAuthentication` states properties about which plugins to use and how to use them.
+
+For example,
+```json
+  "dataserviceAuthentication": {
+    "defaultAuthentication": "saf",
+    "rbac": true
+  }
+```
+
+The `dataserviceAuthentication` attribute has the following properties:
+
+* defaultAuthentication: Which authentication category to choose by default, in case multiple are installed.
+* rbac: Whether or not the server should do authority checks in addition to authentication checks when requesting a dataservice.
+
+
+### Handler context
+
+These plugins are given an object, `context`, in the constructor.
+Context has attributes to help the plugin know about the server configuration, provide a named logger, and more. The parameters include:
+
+* pluginDefinition: The object describing the plugin's definition file
+* pluginConf: An object that gives the plugin it's configuration from the [Config Service internal storage](https://github.com/zowe/zlux/wiki/Configuration-Dataservice#internal--bootstrapping-use)
+* serverConfiguration: The object describing the server's current configuration
+* context: An object holding contextual objects
+    * logger: A logger with the name of the plugin's ID
+
+### Handler capabilities
+
+A handler's constructor should return a capabilities object which states which capabilities the plugin has.
+If one is not returned, it is assumed only authenticate and authorize functions are implemented, for backward compatibility support.
+The capabilities object should include:
+
+* canGetCategories: (true/false) If the getCategories() function exists, which returns a string array of categories of auth the plugin can support given the server context. This is useful if the plugin can support multiple categories conditionally.
+* canLogout: (true/false) If the logout(request, sessionState) function exists. Used to clear state and cookies when a session should be ended.
+* canGetStatus: (true/false) If the getStatus(sessionState) function exists
+* canRefresh: (true/false) If the refreshStatus(request, sessionState) function exists, which is used to renew a session that has an expiration limit.
+* canAuthenticate: (true/false) If the authenticate(request, sessionState):Promise function exists (Required, assumed)
+* canAuthorized: (true/false) If the *authorized(request, sessionState, options) function exists (Required, assumed)
+* haCompatible: (true/false) Used to be sure that a plugin has no state that would be lost in a high availibility environment.
+* canGenerateHaSessionId: (true/false) If generateHaSessionId(request) exists, which is used to set the value used for an app-server session for a user. When not in a high availability environment, the app-server generates its own session ID.
+* canResetPassword: (true/false) If passwordRest(request, sessionState) exists
+* proxyAuthorizations: (true/false) If the addProxyAuthorizations(req1, req2Options, sessionState) function exists
+
+### Examples
+
+sso-auth, which conditionally implements the saf, zss, and apiml security types: https://github.com/zowe/zlux-server-framework/tree/v1.23.0-RC1/plugins/sso-auth
+
+### High availability (HA)
+
+Some auth handlers are not capable of working in a high availability environment.
+In these environments, there can be multiple zlux servers and there may not be a safe and secure way to share session state data.
+This extends to the zlux server cookie as well, which is not sharable between multiple servers by default.
+Therefore, high availability has two requirements from an auth handler plugin
+1) The plugin must state that it is HA capable by setting the capability flag `haCompatible=true`, usually indicating that the plugin has no state data.
+2) A plugin must have capability `canGenerateHaSessionId=true` so that the zlux server cookie is sharable between multiple zlux servers.
+
+
+## REST API
+
+### Check status
 Returns the current authentication status of the user to the caller.
 
 ```
@@ -18,9 +88,10 @@ Response example:
     "zss": { 
       "authenticated": true,
       "plugins": {
-        "org.zowe.zlux.auth.zss": {
+        "org.zowe.zlux.auth.safsso": {
           "authenticated": true,
-          "username":"foo"
+          "username":"foo",
+          "expms": 60000
         }
       }
     },
@@ -61,11 +132,13 @@ The categories parameter is optional. If omitted, all auth plugins are invoked w
 {
   "success": true,
   "categories": {
-    "zss": {
+    "saf": {
       "success": true,
       "plugins": {
-        "org.zowe.zlux.auth.zss": {
+        "org.zowe.zlux.auth.safsso": {
           "success": true
+          "username":"foo",
+          "expms": 60000
         }
       }
     },
@@ -92,11 +165,16 @@ The response received by the browser when calling any service, when the user is 
 HTTP 401
 
 {
-  "category": "zss",
-  "pluginID": "org.zowe.zlux.auth.zss",
+  "category": "saf",
+  "pluginID": "org.zowe.zlux.auth.safsso",
   "result": {
     "authenticated": false,
-    "authorized": false
+    "authorized": false,
+    "reason": "a category of success or error may appear here",
+    "reasonseCode": "ZSS 401 or other codes may appear here",
+    "error": {
+      "message": "an error message may appear here"
+    }
   }
 }
 ```
@@ -107,8 +185,8 @@ The client is supposed to address this by showing the user a login form which wi
 HTTP 403
 
 {
-  "category": "zss",
-  "pluginID": "org.zowe.zlux.auth.zss",
+  "category": "saf",
+  "pluginID": "org.zowe.zlux.auth.safsso",
   "result": {
     "authenticated": true,
     "authorized": false
@@ -116,3 +194,44 @@ HTTP 403
 }
 ```
 There's no general way for the client to address this, except than show the user an error message.
+
+
+### Refresh status
+If you have an active session, some auth plugins may be able to renew the session.
+Not all plugins support this action, so while the call may return successful, if there is an associated expiration time you may notice that the expiration time has not changed or been reset.
+
+```
+GET /auth-refresh
+```
+
+{
+  "success": true,
+  "categories": {
+    "saf": {
+      "success": true,
+      "plugins": {
+        "org.zowe.zlux.auth.safsso": {
+          "success": true
+          "username":"foo",
+          "expms": 60000
+        }
+      }
+    }
+  }
+}
+
+
+### Logout
+When you have an active session, you can terminate it early with a logout. This should remove cookies and tell the server to clear any cache it had about a session.
+
+```
+POST /auth-logout
+```
+
+
+### Password changes
+Some auth plugins will allow you to change your password, such as in the case that you need to set an initial password to a new account, or it expired, or you just want to change it. Depending on the backing security (such as SAF) you may need to supply your current password to change it.
+
+```
+POST /auth-password
+```

--- a/docs/extend/extend-desktop/mvd-dataservices.md
+++ b/docs/extend/extend-desktop/mvd-dataservices.md
@@ -32,11 +32,17 @@ To define your dataservice, create a set of keys and values for your dataservice
 
   - **java-war**: See the topic _Defining Java dataservices_ below.
 
+  - **external**: Used to set up an endpoint in your plugin's namespace as a proxy for an endpoint on another server. External services have the following values to state how to proxy.
+
 **name**
 
  The name of the service. Names must be unique within each `pluginDefinition.json` file. The name is used to reference the dataservice during logging and to construct the URL space that the dataservice occupies.
 
-**serviceLookupMethod**
+**version**
+
+ A semver version string. More than one version of the same service can be present within a plugin, but versions must be declared to track dependencies.
+
+**initializerLookupMethod**
 
  Specify `external` unless otherwise instructed.
 
@@ -44,13 +50,48 @@ To define your dataservice, create a set of keys and values for your dataservice
 
 The name of the file that is the entry point for construction of the dataservice, relative to the application's `/lib` directory. For example, for the `sample-app` the `fileName` value is `"helloWorld.js"` - without a path. So its typescript code is transpiled to JavaScript files that are placed directly into the `/lib` directory.
 
+**dependenciesIncluded**
+
+ Specify `true` for anything in the `pluginDefinition.json` file. Only specify `false` when you are adding dataservices to the server dynamically.
+
+### Router-type specific attributes
+
 **routerFactory (Optional)**
 
  When you use a router dataservice, the dataservice is included in the proxy server through a `require()` statement. If the dataservice's exports are defined such that the router is provided through a factory of a specific name, you must state the name of the exported factory using this attribute.
 
-**dependenciesIncluded**
+### Import-type specific attributes
 
- Specify `true` for anything in the `pluginDefinition.json` file. Only specify `false` when you are adding dataservices to the server dynamically.
+**sourcePlugin**
+
+ The ID of the plugin where the service can be found for an **import** type dataservice.
+
+**sourceName**
+
+ The name of the dataservice to be found in the source plugin when using an **import** type dataservice.
+
+**localName**
+
+ The name of the dataservice within your plugin's namespace when using an **import** type dataservice.
+
+**versionRange**
+
+ A semver string plus range modifiers such as "^" to denote what range of versions would satisfy the import.
+
+
+**Note: Import-type dataservices cannot at this time override the attributes of the imported dataservice. For example, if the original dataservice had `httpCaching:false`, and the import used `httpCaching:true`, the import's value is ignored and the original value used instead.**
+
+### External-type specific attributes
+
+**urlPrefix**
+
+ The prefix to be prepended when making the proxy connection to the external source. For example, if the user tried to access `<your external service>/foo`, but your urlPrefix was `/bar`, then the proxy would make a connection to `<your external destination>/bar/foo`.
+
+**isHttps**
+
+ Boolean used to tell the server whether to proxy to a destination that is or is not using https instead of http.
+
+**Note: External-type dataservices also require specification of the proxied host & port. This is accomplished via making a JSON file, `remote.json`, with attributes `host` and `port`, and placing it within the internal configuration storage for that dataservice. See more about that storage here: https://github.com/zowe/zlux/wiki/Configuration-Dataservice#internal--bootstrapping-use**
 
 ## Defining Java dataservices
 In addition to other types of dataservice, you can use Java (also called java-war) dataservices in your applications. Java dataservices are powered by Java Servlets.
@@ -165,7 +206,7 @@ Users must have READ access to the following profile:
 
 Profiles cannot contain more than 246 characters. If the path section of an endpoint URL makes the profile name exceed limit, the path is trimmed to only include elements that do not exceed the limit. For example, imagine that each path section in this endpoint URL contains 64 characters:
 
-`/ZLUX/plugins/org.zowe.zossystem.subsystems/services/data/_current/aa..a/bb..b/cc..c/dd..d` 
+`/ZLUX/plugins/org.zowe.zossystem.subsystems/services/data/_current/aa..a/bb..b/cc..c/dd..d`
 
 So `aa..a` is 64 "a" characters, `bb..b` is 64 "b" characters, and so on. The URL could then map to the following example profile:
 
@@ -185,13 +226,13 @@ Each Router dataservice can safely import Express, express-ws, and bluebird with
 
 #### HTTP/REST Router dataservices
 
-Router-based dataservices must return a (bluebird) Promise that resolves to an ExpressJS router upon success. For more information, see the ExpressJS guide on use of Router middleware: [Using Router Middleware](http://expressjs.com/en/guide/using-middleware#middleware.router).
+Router-based dataservices must return a (bluebird) Promise that resolves to an ExpressJS router upon success. For more information, see the ExpressJS guide on use of Router middleware: [Using Router Middleware](http://expressjs.com/en/guide/using-middleware.html#middleware.router).
 
 Because of the nature of Router middleware, the dataservice need only specify URLs that stem from a root '/' path, as the paths specified in the router are later prepended with the unique URL space of the dataservice.
 
 The Promise for the Router can be within a Factory export function, as mentioned in the `pluginDefinition` specification for *routerFactory* above, or by the module constructor.
 
-An example is available in `sample-app/nodeServer/ts/helloWorld.ts`
+An example is available in the [Sample Angular App.](https://github.com/zowe/sample-angular-app/blob/master/nodeServer/ts/helloWorld.ts)
 
 #### WebSocket Router dataservices
 
@@ -239,6 +280,120 @@ An object that contains more context from the plug-in scope, including:
 
     - **user**: Configuration information of the server, such as the port on which it is listening.
 
+#### Router storage API
+
+
+
+### ZSS based dataservices
+
+ZSS dataservices much like zlux router services can be used to implement REST or websocket APIs.
+Each service is associated with a URL which when requested will call a function to handle the request or websocket message event.
+
+#### HTTP/REST ZSS dataservices
+
+ZSS REST dataservices are registered into ZSS with a service installer function, where `initializerName` is the function name located in the dll `libraryName`. The `methods` list what HTTP methods are expected of this dataservice.
+Example:
+
+```
+{
+  "type": "service",
+  "name": "data",
+  "version": "1.0.0",
+  "initializerLookupMethod": "external",
+  "initializerName": "helloWorldDataServiceInstaller",
+  "libraryName": "helloWorld.so",
+  "methods": ["GET", "POST"],
+  "dependenciesIncluded": true
+}
+```
+
+The service installer is given `DataService`, which includes context such as the above definition plus a `loggingIdentifier`. The service is also given `HttpServer`, a reference to ZSS and its configuration.
+To register the dataservice, you must make an `HttpService` object like
+
+```
+HttpService *httpService = makeHttpDataService(dataService, server);
+```
+
+Then you must assign properties to the dataservice, such as
+
+* authType: What type of authentication and authorization checks should be done before calling this service. values such as `SERVICE_AUTH_NONE` when the service does not need securty or `SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN` when the service should be protected by ZSS's cookie are valid.
+* serviceFunction: The function within this dataservice that will be called whenever a request is received.
+* runInSubtask: (TRUE/FALSE) Whether to run the service function in a subtask or not whenever a request is received.
+* doImpersonation: (TRUE/FALSE) When true, the service function will be ran as the authenticated user, rather than the server user. This is recommended whenever possible to keep permissions management in line with the users own permissions.
+
+Example of service installer:
+
+```
+void helloWorldDataServiceInstaller(DataService *dataService, HttpServer *server) {
+  HttpService *httpService = makeHttpDataService(dataService, server);
+  httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
+  httpService->serviceFunction = serveHelloWorldDataService;
+  httpService->runInSubtask = TRUE;
+  httpService->doImpersonation = TRUE;
+
+  HelloServiceData *serviceData = (HelloServiceData*)safeMalloc(sizeof(HelloServiceData), "HelloServiceData");
+  serviceData->loggingId = dataService->loggingIdentifier;
+
+  httpService->userPointer = serviceData;
+}
+```
+
+When a request is received, the service function is called with the `HttpService` and `HttpResponse` objects. `HttpService` is used to store and retrieve cached data and access the storage API. `HttpRequest` is a pointer within the response object, and utilities exist to help with parsing it.
+
+Example of request handling:
+
+```
+static int serveHelloWorldDataService(HttpService *service, HttpResponse *response) {
+  HttpRequest *request = response->request;
+  char *routeFragment = stringListPrint(request->parsedFile, 1, 1000, "/", 0);
+  char *route = stringConcatenate(response->slh, "/", routeFragment);
+
+  HelloServiceData *serviceData = service->userPointer;
+  serviceData->timesVisited++;
+
+  zowelog(NULL, serviceData->loggingId, ZOWE_LOG_WARNING,
+          "Inside serveHelloWorldDataService\n");
+
+  if (!strcmp(request->method, methodGET)) {
+    jsonPrinter *p = respondWithJsonPrinter(response);
+
+    setResponseStatus(response, 200, "OK");
+    setDefaultJSONRESTHeaders(response);
+    writeHeader(response);
+
+    jsonStart(p);
+    {
+      jsonAddString(p, "message", "Hello World!");
+      jsonAddInt(p, "timesVisited", serviceData->timesVisited);
+    }
+    jsonEnd(p);
+  }
+
+  finishResponse(response);
+  return 0;
+}
+```
+
+#### ZSS dataservice context and structs
+
+Headers to important dataservice structs include
+* [HttpResponse](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/httpserver.h#L117)
+* [HttpRequest](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/http.h#L124)
+* [HttpService](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/httpserver.h#L173)
+* [HttpServer](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/httpserver.h#L223)
+* [Json handling](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/json.h)
+* [DataService context](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/dataservice.h#L57)
+* [Utilities](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/utils.h)
+* [Data structures](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/collections.h)
+
+
+#### ZSS storage API
+
+The [DataService](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/dataservice.h#L57) struct contains two [Storage structs](https://github.com/zowe/zowe-common-c/blob/zss-v1.23.0-RC1/h/storage.h#L22), `localStorage` and `remoteStorage`. They implement the same API for getting, setting, and removing data, but manage the data in different locations. `localStorage` stores data within the ZSS server, for high speed access. `remoteStorage` stores data in the Caching Service, for high availability state storage.
+
+Usage example:
+Sample angular app storage test api: https://github.com/zowe/sample-angular-app/blob/v1.23.0-RC1/zssServer/src/storage.c
+
 ## Documenting dataservices
 It is recommended that you document your RESTful application dataservices in OpenAPI (Swagger) specification documents. The Zowe Application Server hosts Swagger files for users to view at runtime.
 
@@ -250,7 +405,7 @@ To document a dataservice, take the following steps:
 
 3. Place the Swagger file in the `/doc/swagger` directory below your application plug-in directory, for example:
 
-   `/zlux-server-framework/plugins/<servicename>/doc/swagger/<servicename_1.1.0>.yaml`
+   `/sample-angular-app/doc/swagger/hello.yaml`
 
 
 
@@ -258,7 +413,7 @@ At runtime, the Zowe Application Server does the following:
 
 - Dynamically substitutes known values in the files, such as the hostname and whether the endpoint is accessible using HTTP or HTTPS.
 - Builds documentation for each dataservice and for each application plug-in, in the following locations:
-  - Dataservice documentation: `/ZLUX/plugins/<app_name>/catalogs/swagger/servicename` 
+  - Dataservice documentation: `/ZLUX/plugins/<app_name>/catalogs/swagger/servicename`
   - Application plug-in documentation: `/ZLUX/plugins/<app_name>/catalogs/swagger`
 
 - In application plug-in documentation, displays only stubs for undocumented dataservices, stating that the dataservice exists but showing no details. Undocumented dataservices include non-REST dataservices such as WebSocket services.


### PR DESCRIPTION
This updates the app framework documentation to explain how developers can make use of HA features, and what they can/cant do in an HA environment. Additionally I added some missing ZSS documentation while I was in that area of the doc.