### PR TITLE
Add section detailing how to define TLS rule on client system

### DIFF
--- a/docs/user-guide/mvd-configuration.md
+++ b/docs/user-guide/mvd-configuration.md
@@ -452,6 +452,35 @@ The following steps assume you have installed a Zowe runtime instance (which inc
 
    `ZIS status - Ok (name='ZWESIS_MYSRV    ', cmsRC=0, description='Ok', clientVersion=2)`
 
+### Configuring AT-TLS on Client System
+
+When connecting to a Zowe instance whose host system is configured to use AT-TLS for HTTPS, the connecting client/client system must also define an outbound AT-TLS rule. To define the AT-TLS rule, use the sample below to specify values in your AT-TLS Policy Agent Configuration file:
+
+```
+TTLSRule                     XYZClientRule
+{
+  RemotePortRange                   [gateway_or_desktop_port]
+  Direction                         Outbound
+  TTLSGroupActionRef                XYZGroup
+  TTLSEnvironmentActionRef          XYZClientEnvironment
+}
+TTLSGroupAction              XYZGroup
+{
+  TTLSEnabled                       On
+}
+TTLSEnvironmentAction        XYZClientEnvironment
+{
+  TTLSKeyRingParms
+    {
+      Keyring                       [client_key_ring]
+    }
+  HandshakeRole                     CLIENT
+  Trace                             7
+}
+```
+
+**Note:** \[client_key_ring\] is a key ring containing the client certificate. To retrieve a signed client certificate, contact the administrator of the host system.
+
 ## Controlling access to applications
 
 You can control which applications are accessible (visible) to all Zowe desktop users, and which are accessible only to individual users. For example, you can make an application that is under development only visible to the team working on it.


### PR DESCRIPTION
Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [X] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
For Zowe hosts configured to use AT-TLS, the connecting client systems must also define AT-TLS rules. This pull request adds a section containing a sample configuration.

