### PR TITLE
Add docs for customMetadata.apiml.response.headers

### DIFF
--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -111,6 +111,23 @@
     
       Compresses all paths that contain `compress` as a specific path
 
+* **customMetadata.apiml.response.headers**
+
+    (Optional) A service can specify headers that are added to the response by the Gateway. When this parameter is not set or is empty, no headers are added. Header names and header values are separated by `:`. Multiple headers can be added, delimited by `,`. If a header with the same name already exists in the response, the Gateway will overwrite that header's value.
+
+    **Examples:**
+
+    * `Strict-Transport-Security:max-age=1234; includeSubDomains`
+    
+      Sets a header with name `Strict-Transport-Security` and value `max-age=1234; includeSubDomains`.
+    
+    * `Strict-Transport-Security:max-age=1234; includeSubDomains, X-Frame-Options:SAMEORIGIN`
+
+      Sets two headers:
+
+        1) Header with name `Strict-Transport-Security` and value `max-age=1234; includeSubDomains`.
+        2) Header with name `X-Frame-Options` and value `SAMEORIGIN.
+
 * **customMetadata.apiml.headersToIgnore**
 
     (Optional) A service can specify headers that are removed from the request to the southbound service by the Gateway. When this parameter is not set or is empty, no headers are removed. Multiple headers can be removed, delimited by `,`.

--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -113,7 +113,7 @@
 
 * **customMetadata.apiml.response.headers**
 
-    (Optional) A service can specify headers that are added to the response by the Gateway. When this parameter is not set or is empty, no headers are added. Header names and header values are separated by `:`. Multiple headers can be added, delimited by `,`. If a header with the same name already exists in the response, the Gateway will overwrite that header's value.
+    (Optional) A service can specify headers that are added to the response by the Gateway. When this parameter is not set or is empty, no headers are added. Header names and header values are separated by `:`. Multiple headers can be added, delimited by `,`. If a header with the same name already exists in the response, the Gateway overwrites the value of the header. 
 
     **Examples:**
 


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Adds documentation for the new `customMetadata.apiml.response.headers` configuration parameter.

:heart:Thank you!

