### PR TITLE
Tn3270 short cuts

### DIFF
--- a/docs/user-guide/plugin-tn3270-keyboard.md
+++ b/docs/user-guide/plugin-tn3270-keyboard.md
@@ -1,0 +1,54 @@
+# Defaults
+The terminal bundle that is used by tn3270-ng2 has several keyboard shortcuts to execute common TN3270 emulator functionality. Below is the current list of what function is mapped to which key combination. 
+
+Be aware that some browsers intercept key combinations that are common to browsers, such as Control+R or Control+T, and that the OS may also intercept certain combinations such as Windows+R or Alt+F4. 
+
+Also be aware that the key combinations listed will only be handled by the terminal if the terminal has focus - which you can know by if the terminal's cursor is visible and blinking or not. To gain focus on the terminal, it is sufficient to click on the terminal's contents. The difference between focus and not focus may be the difference between F5 being interpreted as terminal PF5, or the browser reloading the page.
+
+
+Action | Keyboard Shortcut | Note
+-------|-------------------|------
+Back Tab | Shift+Tab |
+Backspace | Backspace |
+Clear | Ctrl+Shift+z |
+Cursor Down | ArrowDown, NumpadArrowDown |
+Cursor Left| ArrowLeft, NumpadArrowLeft |
+Cursor Right| ArrowRight, NumpadArrowRight |
+Cursor Up| ArrowUp, NumpadArrowUp |
+Delete | Delete, NumpadDelete |
+End | End, NumpadEnd |
+Enter | Enter, NumpadEnter |
+Erase End of Field (EOF) | Ctrl+e | Erases from cursor position to end of field
+Erase Field | Ctrl+l | Erases entire field
+Home | Home, NumpadHome |
+Insert | Insert, NumpadInsert | Toggles insert text mode
+New Line | Shift+Enter, Shift+NumpadEnter | Moves cursor to field on next row
+PA1 | Alt+1 |
+PA2 | Alt+2 |
+PA3 | Alt+3 |
+PF01 | F1 | 
+PF02 | F2 | 
+PF03 | F3 | 
+PF04 | F4 | 
+PF05 | F5 | 
+PF06 | F6 | 
+PF07 | F7 | 
+PF08 | F8 | 
+PF09 | F9 | 
+PF10 | F10 | 
+PF11 | F11 | 
+PF12 | F12 | 
+PF13 | Shift+F1 | 
+PF14 | Shift+F2 | 
+PF15 | Shift+F3 | 
+PF16 | Shift+F4 | 
+PF17 | Shift+F5 | 
+PF18 | Shift+F6 | 
+PF19 | Shift+F7 | 
+PF20 | Shift+F8 | 
+PF21 | Shift+F9 | 
+PF22 | Shift+F10 | 
+PF23 | Shift+F11 | 
+PF24 | Shift+F12 | 
+Reset | Alt+r | Terminal doesn't lock on bad input, just rejects and auto-resets. No use for reset button currently.
+Tab | Tab

--- a/docs/user-guide/zowe-getting-started-tutorial.md
+++ b/docs/user-guide/zowe-getting-started-tutorial.md
@@ -132,7 +132,7 @@ Close the JES Explorer window. Next, you'll use the TN3270 application plug-in i
 
 Use the 3270 Terminal application plug-in to view the same job that you filtered out in the previous task.
 
-Zowe not only provides new, modern applications to interact with z/OS®, but it also integrates the traditional 3270 terminal interface that you may also be familiar with. The 3270 Terminal application plug-in provides a basic, emulated 3270 terminal connection to the mainframe via the Zowe Application Server.
+Zowe not only provides new, modern applications to interact with z/OS®, but it also integrates the traditional 3270 terminal interface that you may also be familiar with. The 3270 Terminal application plug-in provides a basic, emulated 3270 terminal connection to the mainframe via the Zowe Application Server. The basic functionality includes the support for the [special keys](plugin-tn3270-keyboard.md) such as Attention or PF keys.
 
 **Follow these steps:**
 


### PR DESCRIPTION
### Description (including links to related git issues)
Users are not much aware of special keys for TN3270.
This is just a description of predefined keys made from the [TN3270 wiki page](https://github.com/zowe/tn3270-ng2/wiki/Keyboard-Shortcuts).

**closed** [https://github.com/zowe/zlux/issues/760](https://github.com/zowe/zlux/issues/760)



