### PR TITLE
(FIX) Re-branding issue (for V1.25)

### DIFF
--- a/static/Zowe_introduction_video_script.txt
+++ b/static/Zowe_introduction_video_script.txt
@@ -15,7 +15,7 @@ Because the CLI is running on the user's laptop, it can be embedded and executed
 
 As well as core capabilities, Zowe CLI is built to be an extensible framework. This allows additional plugins to be installed, such as those for CICS, Db2 and other mainframe runtimes. This is done using an extensible API so that software vendors can build their own CLI plugins using these fully supported interfaces and extension points.
 
-The Zowe conformance program is a certification process that issues badges to extensions who are built, packaged and executed using these APIs. This ensures consistency of end user experience and compatibility between plugins. A number of extensions are already available from vendors including CA Endeavor, IBM z/OS Connect, Phoenix Software EJES, and more.
+The Zowe conformance program is a certification process that issues badges to extensions who are built, packaged and executed using these APIs. This ensures consistency of end user experience and compatibility between plugins. A number of extensions are already available from vendors including Endeavor, IBM z/OS Connect, Phoenix Software EJES, and more.
 
 The second component to look at is the Zowe Explorer, an extension to the popular Visual Studio Code Integrated Development Environment. With the Zowe Explorer installed from the marketplace, it can be launched from the Zowe icon in the VS Code sidebar.
 

--- a/versioned_docs/version-v1.25.x/extend/extend-apiml/api-mediation-passtickets.md
+++ b/versioned_docs/version-v1.25.x/extend/extend-apiml/api-mediation-passtickets.md
@@ -14,8 +14,8 @@ The API Gateway provides the user ID and password in the Authorization header of
 
 - [Outline for enabling PassTicket support](#outline-for-enabling-passticket-support)
 - [Security configuration that allows the Zowe API Gateway to generate PassTickets for an API service](#security-configuration-that-allows-the-zowe-api-gateway-to-generate-passtickets-for-an-api-service)
-  - [CA ACF2](#ca-acf2)
-  - [CA Top Secret](#ca-top-secret)
+  - [ACF2](#acf2)
+  - [Top Secret](#top-secret)
   - [RACF](#racf)
 - [API services that support PassTickets](#api-services-that-support-passtickets)
   - [API Services that register dynamically with API ML that provide authentication information](#api-services-that-register-dynamically-with-api-ml-that-provide-authentication-information)
@@ -48,7 +48,7 @@ Use the following variables to generate PassTickets for the API service to enabl
 
 Replace the variables in the following examples with actual values.
 
-### CA ACF2
+### ACF2
 
 Grant the Zowe started task user ID permission to generate PassTickets for users of that API service.
 The following code is an example of security commands that need to be issued.
@@ -63,7 +63,7 @@ F ACF2,REBUILD(PTK),CLASS(P)
 END
 ```
 
-### CA Top Secret
+### Top Secret
 
 Grant the Zowe started task user ID permission to generate PassTickets for users of that API service.
 

--- a/versioned_docs/version-v1.25.x/extend/extend-apiml/api-mediation-security.md
+++ b/versioned_docs/version-v1.25.x/extend/extend-apiml/api-mediation-security.md
@@ -308,7 +308,7 @@ apiml.security.auth.provider: dummy
 
 Authorization is a method used to determine access rights of an entity.
 
-In the API ML, authorization is performed by the z/OS security manager ([CA ACF2](https://www.broadcom.com/products/mainframe/identity-access/acf2), [IBM RACF](https://www.ibm.com/support/knowledgecenter/zosbasics/com.ibm.zos.zsecurity/zsecc_042.htm), [CA Top Secret](https://www.broadcom.com/products/mainframe/identity-access/top-secret)). An authentication token is used as proof of valid authentication. The authorization checks, however, are always performed by the z/OS security manager.
+In the API ML, authorization is performed by the z/OS security manager ([ACF2](https://www.broadcom.com/products/mainframe/identity-access/acf2), [IBM RACF](https://www.ibm.com/support/knowledgecenter/zosbasics/com.ibm.zos.zsecurity/zsecc_042.htm), [Top Secret](https://www.broadcom.com/products/mainframe/identity-access/top-secret)). An authentication token is used as proof of valid authentication. The authorization checks, however, are always performed by the z/OS security manager.
 
 ### JWT Token
 

--- a/versioned_docs/version-v1.25.x/extend/extend-apiml/service-information.md
+++ b/versioned_docs/version-v1.25.x/extend/extend-apiml/service-information.md
@@ -36,7 +36,7 @@ In IBM RACF, the access to the service information can be given by:
 PERMIT APIML.SERVICES CLASS(ZOWE) ID(user) ACCESS(READ)
 ```
 
-In CA Top Secret:
+In Top Secret:
 
 ```markup
 TSS PERMIT(user) ZOWE(APIML.SERVICES) ACCESS(READ)

--- a/versioned_docs/version-v1.25.x/getting-started/overview.md
+++ b/versioned_docs/version-v1.25.x/getting-started/overview.md
@@ -108,7 +108,7 @@ The API Catalog is the catalog of published API services and their associated do
 
 **Catalog Security**
 
-Access to the API Catalog can be protected with an Enterprise z/OS Security Manager such as IBM RACF, CA ACF2, or CA Top Secret. Only users who provide proper mainframe credentials can access the Catalog. Client authentication is implemented through the z/OSMF API.
+Access to the API Catalog can be protected with an Enterprise z/OS Security Manager such as IBM RACF, ACF2, or Top Secret. Only users who provide proper mainframe credentials can access the Catalog. Client authentication is implemented through the z/OSMF API.
 
 **Caching Service**
 

--- a/versioned_docs/version-v1.25.x/user-guide/api-mediation/api-mediation-overview.md
+++ b/versioned_docs/version-v1.25.x/user-guide/api-mediation/api-mediation-overview.md
@@ -36,7 +36,7 @@ The API Catalog is the catalog of published API services and their associated do
 
 #### Catalog Security
  
-Access to the API Catalog can be protected with an Enterprise z/OS Security Manager such as IBM RACF, CA ACF2, or CA Top Secret. Only users who provide proper mainframe credentials can access the Catalog. Client authentication is implemented through the zOSMF API. 
+Access to the API Catalog can be protected with an Enterprise z/OS Security Manager such as IBM RACF, ACF2, or Top Secret. Only users who provide proper mainframe credentials can access the Catalog. Client authentication is implemented through the zOSMF API. 
 
 ## Onboarding APIs
 The most important part of the ecosystem are the real API services that provide useful APIs. Use the following topics to understand what options you have for adding new APIs to the Mediation Layer:

--- a/versioned_docs/version-v1.25.x/user-guide/configure-certificates-keyring.md
+++ b/versioned_docs/version-v1.25.x/user-guide/configure-certificates-keyring.md
@@ -25,7 +25,7 @@ To customize the `ZWEKRING` JCL, edit the JCL variables at the beginning of the 
 
 ### `PRODUCT` variable
 
-The `PRODUCT` variable specifies the z/OS security manager.  The default value is `RACF`. Change the value to `ACF2` or `TSS` if you are using ACF2 or CA Top Secret for z/OS as your z/OS security manager.  
+The `PRODUCT` variable specifies the z/OS security manager.  The default value is `RACF`. Change the value to `ACF2` or `TSS` if you are using ACF2 or Top Secret for z/OS as your z/OS security manager.  
 
 ```
 //         SET  PRODUCT=RACF         * RACF, ACF2, or TSS

--- a/versioned_docs/version-v1.25.x/user-guide/configure-certificates-keystore.md
+++ b/versioned_docs/version-v1.25.x/user-guide/configure-certificates-keystore.md
@@ -171,7 +171,7 @@ To customize the `ZWESSOTK` JCL, edit the JCL variables at the beginning of the 
 
 #### `PRODUCT` variable
 
-The `PRODUCT` variable specifies the z/OS security manager. The default value is `RACF`. Change the value to `ACF2` or `TSS` if you are using ACF2 or CA Top Secret for z/OS as your z/OS security manager.
+The `PRODUCT` variable specifies the z/OS security manager. The default value is `RACF`. Change the value to `ACF2` or `TSS` if you are using ACF2 or Top Secret for z/OS as your z/OS security manager.
 
 ```
 //         SET  PRODUCT=RACF         * RACF, ACF2, or TSS

--- a/versioned_docs/version-v1.25.x/user-guide/configure-zos-system.md
+++ b/versioned_docs/version-v1.25.x/user-guide/configure-zos-system.md
@@ -45,14 +45,14 @@ For every TSO user ID that is going to log on to Zowe and use services that requ
   CONNECT (userid) GROUP(IZUUSER)
   ```
 
-- If you use CA ACF2, issue the following commands:
+- If you use ACF2, issue the following commands:
 
   ```
   ACFNRULE TYPE(TGR) KEY(IZUUSER) ADD(UID(<uid string of user>) ALLOW)
   F ACF2,REBUILD(TGR)
   ```
 
-- If you use CA Top Secret, issue the following commands:
+- If you use Top Secret, issue the following commands:
 
   ```
   TSS ADD(userid)  PROFILE(IZUUSER)
@@ -95,7 +95,7 @@ Define or check the following configurations depending on whether ICSF is alread
         ```
         SETROPTS RACLIST(CSFSERV) REFRESH
         ```
-    - If you use CA ACF2, issue the following commands (note that `profile-prefix` and `profile-suffix` are user-defined):
+    - If you use ACF2, issue the following commands (note that `profile-prefix` and `profile-suffix` are user-defined):
         ```
         SET CONTROL(GSO)
         ```
@@ -119,7 +119,7 @@ Define or check the following configurations depending on whether ICSF is alread
         ```
         F ACF2,REBUILD(CSF)
         ```
-    - If you use CA Top Secret, issue the following command (note that `profile-prefix` and `profile-suffix` are user defined):
+    - If you use Top Secret, issue the following command (note that `profile-prefix` and `profile-suffix` are user defined):
         ```
         TSS ADDTO(owner-acid) RESCLASS(CSFSERV)              
         ```
@@ -156,14 +156,14 @@ You can issue the following commands first to check whether you already have the
     ```
     RLIST FACILITY BPX.DAEMON AUTHUSER
     ```
-- If you use CA Top Secret, issue the following commands:
+- If you use Top Secret, issue the following commands:
     ```
     TSS WHOHAS IBMFAC(BPX.SERVER)
     ```
     ```
     TSS WHOHAS IBMFAC(BPX.DAEMON)
     ```
-- If you use CA ACF2, issue the following commands:
+- If you use ACF2, issue the following commands:
     ```
     SET RESOURCE(FAC)
     ```
@@ -208,7 +208,7 @@ If the user `ZWESVUSR` who runs the Zowe server started task does not have UPDAT
       ```
       RLIST FACILITY BPX.DAEMON AUTHUSER
       ```
-- If you use CA Top Secret, complete the following steps:  
+- If you use Top Secret, complete the following steps:  
       
    1. Define the BPX Resource and access for <zowe_stc_user>.
       ```
@@ -228,7 +228,7 @@ If the user `ZWESVUSR` who runs the Zowe server started task does not have UPDAT
       ```
       TSS WHOHAS IBMFAC(BPX.DAEMON)
       ```
-- If you use CA ACF2, complete the following steps:
+- If you use ACF2, complete the following steps:
    1. Define the BPX Resource and access for <zowe_stc_user>.
       ```
       SET RESOURCE(FAC)
@@ -360,7 +360,7 @@ If you have not run `ZWESECUR` and are configuring your z/OS environment manuall
   SETROPTS REFRESH RACLIST(STARTED)
   ```
 
-- If you use CA ACF2, issue the following commands:
+- If you use ACF2, issue the following commands:
 
   ```
   SET CONTROL(GSO)
@@ -368,7 +368,7 @@ If you have not run `ZWESECUR` and are configuring your z/OS environment manuall
   F ACF2,REFRESH(STC)
   ```
 
-- If you use CA Top Secret, issue the following commands:
+- If you use Top Secret, issue the following commands:
 
   ```
   TSS ADDTO(STC) PROCNAME(ZWESVSTC) ACID(ZWESVUSR)
@@ -392,7 +392,7 @@ If you have not run `ZWESECUR` and are configuring your z/OS environment manuall
   SETROPTS REFRESH RACLIST(STARTED)
   ```
 
-- If you use CA ACF2, issue the following commands:
+- If you use ACF2, issue the following commands:
 
   ```
   SET CONTROL(GSO)
@@ -400,7 +400,7 @@ If you have not run `ZWESECUR` and are configuring your z/OS environment manuall
   F ACF2,REFRESH(STC)
   ```
 
-- If you use CA Top Secret, issue the following commands:
+- If you use Top Secret, issue the following commands:
 
   ```
   TSS ADDTO(STC) PROCNAME(ZWESLSTC) ACID(ZWESVUSR)
@@ -454,7 +454,7 @@ To do this, issue the following commands that are also included in the `ZWESECUR
         ```
         This shows the user IDs who have access to the `ZWES.IS` class, which should include Zowe's started task user ID with READ access.
 
-- If you use CA ACF2, issue the following commands:
+- If you use ACF2, issue the following commands:
 
     ```
     SET RESOURCE(FAC)
@@ -466,7 +466,7 @@ To do this, issue the following commands that are also included in the `ZWESECUR
     F ACF2,REBUILD(FAC)
     ```
 
-- If you use CA Top Secret, issue the following commands, where `owner-acid` can be IZUSVR or a different ACID:
+- If you use Top Secret, issue the following commands, where `owner-acid` can be IZUSVR or a different ACID:
 
     ```
     TSS ADD(`owner-acid`) IBMFAC(ZWES.)

--- a/versioned_docs/version-v1.25.x/user-guide/install-ha-sysplex.md
+++ b/versioned_docs/version-v1.25.x/user-guide/install-ha-sysplex.md
@@ -96,7 +96,7 @@ You can configure the Zowe high availability runtime by using JCL and shell scri
    SETROPTS RACLIST(STARTED) REFRESH
    ```
 
-   - If you use CA ACF2, issue the following commands:
+   - If you use ACF2, issue the following commands:
 
    ```
    SET CONTROL(GSO)
@@ -107,7 +107,7 @@ You can configure the Zowe high availability runtime by using JCL and shell scri
    F ACF2,REFRESH(STC)  
    ```
 
-   - If you use CA Top Secret, issue the following commands:
+   - If you use Top Secret, issue the following commands:
 
    ```
    TSS ADD(STC) PROCNAME(&ZLNCHSTC.) ACID(&ZOWEUSER.)

--- a/versioned_docs/version-v1.25.x/user-guide/systemrequirements-zosmf-lite.md
+++ b/versioned_docs/version-v1.25.x/user-guide/systemrequirements-zosmf-lite.md
@@ -201,11 +201,11 @@ Check out the video for a demo of the process:
 
 The security job IZUNUSEC contains a minimal set of RACF® commands for creating security profiles for the z/OSMF nucleus. The profiles are used to protect the resources that are used by the z/OSMF server, and to grant users access to the z/OSMF core functions. IZUNUSEC is a simplified version of the sample job IZUSEC, which is intended for a more complete installation of z/OSMF.
 
-**Note:** If your implementation uses an external security manager other than RACF (for example, CA Top Secret or CA ACF2), provide equivalent commands for your environment. For more information, see the following CA Technologies product documentation:
+**Note:** If your implementation uses an external security manager other than RACF (for example, Top Secret or ACF2), provide equivalent commands for your environment. For more information, see the following  product documentation:
 
-- [Configure z/OS Management Facility for CA Top Secret](https://docops.ca.com/ca-top-secret-for-z-os/16-0/en/installing/configure-z-os-management-facility-for-ca-top-secret)
+- [Configure z/OS Management Facility for Top Secret](https://docops.ca.com/ca-top-secret-for-z-os/16-0/en/installing/configure-z-os-management-facility-for-ca-top-secret)
 
-- [Configure z/OS Management Facility for CA ACF2](https://techdocs.broadcom.com/us/en/ca-mainframe-software/security/ca-acf2-for-z-os/16-0/installing/configure-z-os-management-facility-for-ca-acf2.html)
+- [Configure z/OS Management Facility for ACF2](https://techdocs.broadcom.com/us/en/ca-mainframe-software/security/ca-acf2-for-z-os/16-0/installing/configure-z-os-management-facility-for-ca-acf2.html)
 
 #### Before you begin
 

--- a/versioned_docs/version-v1.25.x/user-guide/systemrequirements-zosmf.md
+++ b/versioned_docs/version-v1.25.x/user-guide/systemrequirements-zosmf.md
@@ -101,11 +101,11 @@ User IDs   | User IDs require a TSO segment (access) and an OMVS segment. During
 
     Point your browser at the nominated z/OSMF STANDALONE Server home page and you should see its Welcome Page where you can log in.
 
-**Note:** If your implementation uses an external security manager other than RACF (for example, CA Top Secret for z/OS or CA ACF2 for z/OS), you provide equivalent commands for your environment. For more information, see the following product documentation:
+**Note:** If your implementation uses an external security manager other than RACF (for example, Top Secret for z/OS or ACF2 for z/OS), you provide equivalent commands for your environment. For more information, see the following product documentation:
 
-- [Configure z/OS Management Facility for CA Top Secret](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/security/ca-top-secret-for-z-os/16-0/installing/configure-z-os-management-facility-for-ca-top-secret.html)
+- [Configure z/OS Management Facility for Top Secret](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/security/ca-top-secret-for-z-os/16-0/installing/configure-z-os-management-facility-for-ca-top-secret.html)
 
-- [Configure z/OS Management Facility for CA ACF2](https://techdocs.broadcom.com/us/en/ca-mainframe-software/security/ca-acf2-for-z-os/16-0/installing/configure-z-os-management-facility-for-ca-acf2.html)
+- [Configure z/OS Management Facility for ACF2](https://techdocs.broadcom.com/us/en/ca-mainframe-software/security/ca-acf2-for-z-os/16-0/installing/configure-z-os-management-facility-for-ca-acf2.html)
 
 ## z/OSMF REST services for the Zowe CLI
 The Zowe CLI uses z/OSMF Representational State Transfer (REST) APIs to work with system resources and extract system data. Ensure that the following REST services are configured and available.


### PR DESCRIPTION
Signed-off-by: ik673626 <igor.kazmyr@broadcom.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [x] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
This PR addresses an issue with some CA references that 'slipped though' into v1.25 of Zowe Docs. 

I and Andrew couldn't figure out the cause of the issue despite the thorough check of the initial PR that aimed to rebrand all the former CA names. In addition to that, while searching for any CA references in v1.25 on Zowe Docs, the search didn't come up with any results. 

:heart: Thank you!

