### PR TITLE
update links in the topic "Install SDK from online registry"

### DIFF
--- a/docs/user-guide/sdks-using.md
+++ b/docs/user-guide/sdks-using.md
@@ -61,7 +61,7 @@ Pull the packages from an online registry such as npm or PyPi.
 
     - To define the versioning scheme for Node packages, use [semantic versioning](https://docs.npmjs.com/about-semantic-versioning).
 
-    - To define versioning for Python packages, specify versions or version ranges in a `requirements.txt` file checked-in to your project. More information, see [pip install in the pip documentation](https://pip.pypa.io/en/stable/cli/pip_install/)
+    - To define versioning for Python packages, specify versions or version ranges in a `requirements.txt` file checked-in to your project. For more information, see [pip install](https://pip.pypa.io/en/stable/cli/pip_install/) in the pip documentation.
 
 ### Install SDK from local package
 

--- a/docs/user-guide/sdks-using.md
+++ b/docs/user-guide/sdks-using.md
@@ -59,9 +59,9 @@ Pull the packages from an online registry such as npm or PyPi.
 
 2. **(Optional)** You might want to automatically update the SDK version when updates become available, or you might want to prevent automatic updates.
 
-    - To define the versioning scheme for Node packages, use [npm semver](https://docs.npmjs.com/misc/semver#x-ranges-12x-1x-12-).
+    - To define the versioning scheme for Node packages, use [semantic versioning](https://docs.npmjs.com/about-semantic-versioning).
 
-    - To define versioning for Python packages, specify versions or version ranges in a `requirements.txt` file checked-in to your project. More information, see [pip documentation](https://pip.pypa.io/en/stable/reference/pip_install/#example-requirements-file)
+    - To define versioning for Python packages, specify versions or version ranges in a `requirements.txt` file checked-in to your project. More information, see [pip install in the pip documentation](https://pip.pypa.io/en/stable/cli/pip_install/)
 
 ### Install SDK from local package
 


### PR DESCRIPTION
Signed-off-by: JamesBauman <james.bauman@broadcom.com>

The link to npm semver no longer exists. Searched their doc and found an alternative article.
The link to pip documentation was updated with a redirect.  i updated the link to the new article/URL....

Fixes: #1939 

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Please describe your pull request.

:heart:Thank you!

