### PR TITLE
fix: Use awk instead of grep for health check example

### DIFF
--- a/docs/user-guide/verify-zowe-runtime-install.md
+++ b/docs/user-guide/verify-zowe-runtime-install.md
@@ -42,7 +42,7 @@ where,
 The following example illustrates how to use the **curl** utility to invoke API Mediation Layer endpoint and the **grep** utility to parse out the response status variable value
 
 ```
-$ curl -v -k --silent https://myhost:httpsPort/api/v1/apicatalog/application/health 2>&1 | grep -Po '(?<=\"status\"\:\")[^\"]+'
+$ curl -v -k --silent https://myhost:httpsPort/api/v1/apicatalog/application/health 2>&1 | awk '/"status":"UP"/' | awk -F\" '{print$4;}'
 UP
 ```
 


### PR DESCRIPTION
Signed-off-by: Carson Cook <carson.cook@ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
`grep` can be quite different on different systems, and the documented example uses options that aren't consistently available across all platforms. `awk` is more stable.

:heart:Thank you!

