### PR TITLE
migrated new v1 content into v2 content on the docs home page > Downloadable files

### DIFF
--- a/src/components/DownloadableFiles/DownloadableFiles.js
+++ b/src/components/DownloadableFiles/DownloadableFiles.js
@@ -23,8 +23,9 @@ const downloadableFiles = [
     description: (
       <>
         View documentation on commands, actions, and options in Zowe CLI. The
-        reference document is based on the <code>@zowe-v1-lts</code> version of
-        the CLI.
+        reference document is based on the <code>@zowe-v2-lts</code> version of
+        the CLI. It contains the web help for all Zowe ecosystem-conformant 
+        plug-ins that contributed to this website.
       </>
     ),
     firstSubDescription: <>Online interactive version</>,


### PR DESCRIPTION


Signed-off-by: JamesBauman <james.bauman@broadcom.com>


We recently update the docs-site home page > Downloadable files.  Migrating the v1 changes in to the v2 version of the page.