### PR TITLE
indicate clear link for CORS from Gateway to specific service

### DIFF
--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -47,7 +47,8 @@
 * **customMetadata.apiml.corsEnabled**
     
     When this parameter is set to `true`, CORS handling by the Gateway is enabled on the service level for all service routes. 
-    For more information, see [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
+    For more information, refer to enabling CORS with Custom Metadata on the Gateway: [Advanced Gateway features configuration](../../user-guide/api-mediation/api-gateway-configuration.md).
+    Additional information can be found in this article about [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
     
     **Note:** If you use the Spring enabler, use the following parameter name:
     
@@ -60,6 +61,8 @@
     **Note:** If you use the Spring enabler, use the following parameter name:
 
     `apiml.service.customMetadata.apiml.corsAllowedOrigins`
+
+    For more information, refer to enabling CORS with Custom Metadata on the Gateway: [Advanced Gateway features configuration](../../user-guide/api-mediation/api-gateway-configuration.md).
   
  * **customMetadata.apiml.lb.type**
    

--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -74,7 +74,7 @@
 
       The header name is `X-InstanceId`, and the sample value is `discoverable-client:discoverableclient:10012`. This is identical to `instanceId` property in the registration of the Discovery service.
     
-      In combination with enabling [Routed instance header](../../user-guide/api-mediation/api-gateway-configuration.md#routed-instance-header), the client can achieve sticky session functionality. (The term, 'sticky session' refers to the feature of many load balancing solutions to route the requests for a particular session to the same physical machine that serviced the first request for that session). The benefit of this approach is that there is no session on the Gateway, and the client ultimately decides whether or not to go to a specific instance. This method uses the following sequence:
+      In combination with enabling [Routed instance header](../../user-guide/api-mediation/api-gateway-configuration.md#routed-instance-header),  the client can achieve sticky session functionality. (The term, 'sticky session' refers to the feature of many load balancing solutions to route the requests for a particular session to the same physical machine that serviced the first request for that session). The benefit of this approach is that there is no session on the Gateway, and the client ultimately decides whether or not to go to a specific instance. This method uses the following sequence:
     
       1. The client calls API Gateway and gets routed to a service.
       2. The client reads the `X-InstanceId` header value from the response to understand the service was routed to.

--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -74,7 +74,7 @@
 
       The header name is `X-InstanceId`, and the sample value is `discoverable-client:discoverableclient:10012`. This is identical to `instanceId` property in the registration of the Discovery service.
     
-      In combination with enabling [Routed instance header](../../user-guide/api-mediation/api-gateway-configuration.md#routed-instance-header),  the client can achieve sticky session functionality. (The term, 'sticky session' refers to the feature of many load balancing solutions to route the requests for a particular session to the same physical machine that serviced the first request for that session). The benefit of this approach is that there is no session on the Gateway, and the client ultimately decides whether or not to go to a specific instance. This method uses the following sequence:
+      In combination with enabling [Routed instance header](../../user-guide/api-mediation/api-gateway-configuration.md#routed-instance-header), the client can achieve sticky session functionality. (The term, 'sticky session' refers to the feature of many load balancing solutions to route the requests for a particular session to the same physical machine that serviced the first request for that session). The benefit of this approach is that there is no session on the Gateway, and the client ultimately decides whether or not to go to a specific instance. This method uses the following sequence:
     
       1. The client calls API Gateway and gets routed to a service.
       2. The client reads the `X-InstanceId` header value from the response to understand the service was routed to.

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -13,7 +13,8 @@ Follow the procedures in the following sections to customize Gateway parameters 
 
   * [Prefer IP Address for API Layer services](#prefer-ip-address-for-api-layer-services)
   * [SAF as an Authentication provider](#saf-as-an-authentication-provider)
-  * [Enable Jwt token refresh endpoint](#enable-jwt-token-refresh-endpoint)
+  * [Enable JWT token refresh endpoint](#enable-jwt-token-refresh-endpoint)
+  * [Change password with SAF provider](#change-password-with-saf-provider)
   * [Gateway retry policy](#gateway-retry-policy)
   * [Gateway client certificate authentication](#gateway-client-certificate-authentication)
   * [Gateway timeouts](#gateway-timeouts)
@@ -53,7 +54,7 @@ the following procedure to switch to SAF.
 
 Authentication requests now utilize SAF as the authentication provider. API ML can run without z/OSMF present on the system. 
 
-## Enable Jwt token refresh endpoint
+## Enable JWT token refresh endpoint
 
 Enable the `/gateway/api/v1/auth/refresh` endpoint to exchange a valid JWT token for a new token with a new expiration date. Call the endpoint with a valid JWT token and trusted client certificate. In case of z/OSMF authentication provider, enable API Mediation Layer for passticket generation and configure z/OSMF APPLID. [Configure Passtickets](../../extend/extend-apiml/api-mediation-passtickets.md)
 
@@ -218,7 +219,7 @@ When the Gateway handles CORS on behalf of the service, it sanitizes the followi
 
  `Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Origin`
 
-The resulting request to the service is not a CORS request, and the service does not need to do anything extra. To override this list, specify a different comma-separated list in the property `APIML_SERVICE_IGNOREDHEADERSWHENCORSENABLED` in `<Zowe instance directory>/instance.env`
+The resulting request to the service is not a CORS request, and the service does not need to do anything extra. To override this list, specify a different comma-separated list in the property `APIML_SERVICE_IGNOREDHEADERSWHENCORSENABLED` in `<Zowe instance directory>/instance.env`.
 
 Additionally, the Gateway handles the preflight requests on behalf of the service when CORS is enabled in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), replying with CORS headers:
 - `Access-Control-Allow-Methods: GET,HEAD,POST,DELETE,PUT,OPTIONS`

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -215,7 +215,7 @@ Add the following properties to the file for the API Gateway:
 
 You can enable the Gateway to terminate CORS requests for the Gateway itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled, whereby CORS headers are not provided for Gateway routes `api/v1/gateway/**` nor for individual services. After enabling the feature as described in the following prodecure, API Gateway endpoints start handling CORS requests, whereby individual services control whether the Gateway handles the service CORS through specifications in the [Custom Metadata](../../extend/extend-apiml/custom-metadata.md) parameters.
 
-When the Gateway handles CORS on behalf of the service, it sanitizes the following default defined headers from the communication (upstream and downstream): 
+When the Gateway handles CORS on behalf of the service, it sanitizes the following defined headers by default from the communication (upstream and downstream): 
 
  `Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Origin`
 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -212,15 +212,17 @@ Add the following properties to the file for the API Gateway:
     
 ## CORS handling
 
-You can enable the Gateway to terminate CORS requests for itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled for Gateway routes `api/v1/gateway/**` and for individual services. After enabling the feature as stated in the prodecure below, API Gateway endpoints start handling CORS requests and individual services can control whether they want the Gateway to handle CORS for them through the [Custom Metadata](../../extend/extend-apiml/custom-metadata.md) parameters.
+You can enable the Gateway to terminate CORS requests for itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled and the CORS headers won't be provided for Gateway routes `api/v1/gateway/**` and for individual services. After enabling the feature as stated in the prodecure below, API Gateway endpoints start handling CORS requests and individual services can control whether they want the Gateway to handle CORS for them through the [Custom Metadata](../../extend/extend-apiml/custom-metadata.md) parameters.
 
 When the Gateway handles CORS on behalf of the service, it sanitizes defined headers from the communication (upstream and downstream). `Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin` The resulting request to the service is not a CORS request and the service does not need to do anything extra. The list can be overridden by specifying different comma-separated list in the property `APIML_SERVICE_IGNOREDHEADERSWHENCORSENABLED` in `<Zowe instance directory>/instance.env`
 
-Additionally, the Gateway handles the preflight requests on behalf of the service, replying with CORS headers:
+Additionally, the Gateway handles the preflight requests on behalf of the service when CORS is enabled in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), replying with CORS headers:
 - `Access-Control-Allow-Methods: GET,HEAD,POST,DELETE,PUT,OPTIONS`
 - `Access-Control-Allow-Headers: origin, x-requested-with`
 - `Access-Control-Allow-Credentials: true`
-- `Access-Control-Allow-Origin: *` or a list of origins as configured by the service.
+- `Access-Control-Allow-Origin: *` or a list of origins as configured by the service, associated with the value **customMetadata.apiml.corsAllowedOrigins** in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md).
+
+If CORS is enabled for Gateway routes but not in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), the Gateway does not set any of the above CORS headers and, therefore, rejects any CORS requests with an origin header for the Gateway routes.
 
 Use the following procedure to enable CORS handling.
 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -229,7 +229,7 @@ Additionally, the Gateway handles the preflight requests on behalf of the servic
 
 Alternatively, list the origins as configured by the service, associated with the value **customMetadata.apiml.corsAllowedOrigins** in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md).
 
-If CORS is enabled for Gateway routes but not in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), the Gateway does not set any of the above CORS headers. As such, the Gateway rejects any CORS requests with an origin header for the Gateway routes.
+If CORS is enabled for Gateway routes but not in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), the Gateway does not set any of the previously listed CORS headers. As such, the Gateway rejects any CORS requests with an origin header for the Gateway routes.
 
 Use the following procedure to enable CORS handling.
 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -215,7 +215,7 @@ Add the following properties to the file for the API Gateway:
 
 You can enable the Gateway to terminate CORS requests for the Gateway itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled, whereby CORS headers are not provided for Gateway routes `api/v1/gateway/**` nor for individual services. After enabling the feature as described in the following prodecure, API Gateway endpoints start handling CORS requests, whereby individual services control whether the Gateway handles the service CORS through specifications in the [Custom Metadata](../../extend/extend-apiml/custom-metadata.md) parameters.
 
-When the Gateway handles CORS on behalf of the service, it sanitizes the following defined headers from the communication (upstream and downstream). Include the following comma-separated list in the Custom metadata: 
+When the Gateway handles CORS on behalf of the service, it sanitizes the following default defined headers from the communication (upstream and downstream): 
 
  `Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Origin`
 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -212,17 +212,23 @@ Add the following properties to the file for the API Gateway:
     
 ## CORS handling
 
-You can enable the Gateway to terminate CORS requests for itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled and the CORS headers won't be provided for Gateway routes `api/v1/gateway/**` and for individual services. After enabling the feature as stated in the prodecure below, API Gateway endpoints start handling CORS requests and individual services can control whether they want the Gateway to handle CORS for them through the [Custom Metadata](../../extend/extend-apiml/custom-metadata.md) parameters.
+You can enable the Gateway to terminate CORS requests for the Gateway itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled, whereby CORS headers are not provided for Gateway routes `api/v1/gateway/**` nor for individual services. After enabling the feature as described in the following prodecure, API Gateway endpoints start handling CORS requests, whereby individual services control whether the Gateway handles the service CORS through specifications in the [Custom Metadata](../../extend/extend-apiml/custom-metadata.md) parameters.
 
-When the Gateway handles CORS on behalf of the service, it sanitizes defined headers from the communication (upstream and downstream). `Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allow-Origin,Access-Control-Allow-Methods,Access-Control-Allow-Headers,Access-Control-Allow-Credentials,Origin` The resulting request to the service is not a CORS request and the service does not need to do anything extra. The list can be overridden by specifying different comma-separated list in the property `APIML_SERVICE_IGNOREDHEADERSWHENCORSENABLED` in `<Zowe instance directory>/instance.env`
+When the Gateway handles CORS on behalf of the service, it sanitizes the following defined headers from the communication (upstream and downstream). Include the following comma-separated list in the Custom metadata: 
+
+ `Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Origin`
+
+The resulting request to the service is not a CORS request, and the service does not need to do anything extra. To override this list, specify a different comma-separated list in the property `APIML_SERVICE_IGNOREDHEADERSWHENCORSENABLED` in `<Zowe instance directory>/instance.env`
 
 Additionally, the Gateway handles the preflight requests on behalf of the service when CORS is enabled in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), replying with CORS headers:
 - `Access-Control-Allow-Methods: GET,HEAD,POST,DELETE,PUT,OPTIONS`
 - `Access-Control-Allow-Headers: origin, x-requested-with`
 - `Access-Control-Allow-Credentials: true`
-- `Access-Control-Allow-Origin: *` or a list of origins as configured by the service, associated with the value **customMetadata.apiml.corsAllowedOrigins** in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md).
+- `Access-Control-Allow-Origin: *` 
 
-If CORS is enabled for Gateway routes but not in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), the Gateway does not set any of the above CORS headers and, therefore, rejects any CORS requests with an origin header for the Gateway routes.
+Alternatively, list the origins as configured by the service, associated with the value **customMetadata.apiml.corsAllowedOrigins** in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md).
+
+If CORS is enabled for Gateway routes but not in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), the Gateway does not set any of the above CORS headers. As such, the Gateway rejects any CORS requests with an origin header for the Gateway routes.
 
 Use the following procedure to enable CORS handling.
 


### PR DESCRIPTION
Signed-off-by: Amanda D'Errico <amanda.derrico@ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [x] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (PR from api-layer: https://github.com/zowe/api-layer/issues/1011)

Docs: Updating docs to clearly describe the link from the general Gateway to specific service configuration for CORS enabling. Three states of CORS are described in api-gateway-configuration.md:

1. CORS is disabled on the gateway
2. CORS is enabled on the gateway and in the specific service config
3. CORS is enabled on the gateway but disabled in the specific service config

:heart:Thank you!

