### PR TITLE
docs: Zowe V2 LTS extends support for both base authentication paths until March 2023

### DIFF
--- a/docs/extend/extend-apiml/api-mediation-security.md
+++ b/docs/extend/extend-apiml/api-mediation-security.md
@@ -162,7 +162,7 @@ The API ML TLS requires servers to provide HTTPS ports. Each API ML service has 
  
 #### Authentication endpoints
 
-The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints. The `api/v1/gateway/auth` base path reaches end-of-support by March 2023 for Zowe V2 LTS, and `gateway/api/v1/auth` will be the only base path supported.
+The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints. The `api/v1/gateway/auth` base path reaches end-of-support by March 2023 for Zowe V2 LTS, in which `gateway/api/v1/auth` will be the only base path supported.
 
 - `auth/login`
   

--- a/docs/extend/extend-apiml/api-mediation-security.md
+++ b/docs/extend/extend-apiml/api-mediation-security.md
@@ -162,7 +162,9 @@ The API ML TLS requires servers to provide HTTPS ports. Each API ML service has 
  
 #### Authentication endpoints
 
-The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints. The `api/v1/gateway/auth` base path reaches end-of-support by March 2023 for Zowe V2 LTS, in which `gateway/api/v1/auth` will be the only base path supported.
+The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints.
+
+**Note:** The `api/v1/gateway/auth` base path reaches end-of-support in March 2023 for Zowe V2 LTS. After this date, `gateway/api/v1/auth` will be the only base path supported.
 
 - `auth/login`
   
@@ -204,7 +206,7 @@ The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as
 
   **Notes:** 
   
-   - The endpoint is disabled by default. [Jwt token refresh endpoint   enablement](../../user-guide/api-mediation/api-gateway-configuration.  md#jwt-token-refresh-endpoint-enablement)
+   - The endpoint is disabled by default. [Jwt token refresh endpoint enablement](../../user-guide/api-mediation/api-gateway-configuration.md#jwt-token-refresh-endpoint-enablement)
    - The endpoint is protected by a client certificate.
   
   The `auth/refresh` endpoint generates a new token for the user based on valid jwt token. The full path of the `auth/refresh` endpoint appears as `https://{gatewayUrl}:{gatewayPort}/gateway/api/v1/auth/refresh` (preferred option) or `https://{gatewayUrl}:{gatewayPort}/api/v1/gateway/auth/refresh`. The new token overwrites the old cookie with a `Set-Cookie` header. As part of the process, the old token gets invalidated and is not usable anymore.

--- a/docs/extend/extend-apiml/api-mediation-security.md
+++ b/docs/extend/extend-apiml/api-mediation-security.md
@@ -159,7 +159,7 @@ The API ML TLS requires servers to provide HTTPS ports. Each API ML service has 
     - Authentication is service-dependent
     - It is recommended to use the Authentication and Authorization Service for authentication
 
-
+ 
 #### Authentication endpoints
 
 The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints. The `api/v1/gateway/auth` base path reaches end-of-support by March 2023 for Zowe V2 LTS, in which `gateway/api/v1/auth` will be the only base path supported.

--- a/docs/extend/extend-apiml/api-mediation-security.md
+++ b/docs/extend/extend-apiml/api-mediation-security.md
@@ -159,7 +159,7 @@ The API ML TLS requires servers to provide HTTPS ports. Each API ML service has 
     - Authentication is service-dependent
     - It is recommended to use the Authentication and Authorization Service for authentication
 
- 
+
 #### Authentication endpoints
 
 The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints. The `api/v1/gateway/auth` base path reaches end-of-support by March 2023 for Zowe V2 LTS, in which `gateway/api/v1/auth` will be the only base path supported.

--- a/docs/extend/extend-apiml/api-mediation-security.md
+++ b/docs/extend/extend-apiml/api-mediation-security.md
@@ -162,7 +162,7 @@ The API ML TLS requires servers to provide HTTPS ports. Each API ML service has 
 
 #### Authentication endpoints
 
-The API Gateway contains the following REST API authentication endpoints:
+The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints. The `api/v1/gateway/auth` base path reaches end-of-support by March 2023 for Zowe V2 LTS, and `gateway/api/v1/auth` will be the only base path supported.
 
 - `auth/login`
   

--- a/docs/extend/extend-apiml/api-mediation-security.md
+++ b/docs/extend/extend-apiml/api-mediation-security.md
@@ -159,7 +159,7 @@ The API ML TLS requires servers to provide HTTPS ports. Each API ML service has 
     - Authentication is service-dependent
     - It is recommended to use the Authentication and Authorization Service for authentication
 
-
+ 
 #### Authentication endpoints
 
 The API Gateway supports both `gateway/api/v1/auth` and `api/v1/gateway/auth` as base authentication paths for the following REST API authentication endpoints. The `api/v1/gateway/auth` base path reaches end-of-support by March 2023 for Zowe V2 LTS, and `gateway/api/v1/auth` will be the only base path supported.


### PR DESCRIPTION
Signed-off-by: Amanda D'Errico <amanda.derrico@ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description ([#2182](https://github.com/zowe/api-layer/issues/2182))
Docs include both `api/v1/gateway/auth` and `gateway/api/v1/auth` as supported base authentication paths for Zowe V2 LTS, up until March 2023.

:heart:Thank you!

