### PR TITLE
added info about converting v1 to v2 profiles.  added headings.  reor…

### DIFF
--- a/docs/user-guide/cli-using-using-profiles.md
+++ b/docs/user-guide/cli-using-using-profiles.md
@@ -26,7 +26,7 @@ Zowe CLI contains the following types of profiles:
 - You can convert all of your Zowe CLI and Zowe CLI plug-ins V1 profiles to V2 profiles by issuing the following command:
 
     ```
-    zowe config convert profiles
+    zowe config convert-profiles
     ```
 
     **Note:** You can continue using Zowe CLI and Zowe CLI plug-ins V1 profiles with Zowe CLI V2. However, we highly recommend that you implement V2 profiles with Zowe CLI V2.

--- a/docs/user-guide/cli-using-using-profiles.md
+++ b/docs/user-guide/cli-using-using-profiles.md
@@ -29,11 +29,11 @@ Zowe CLI contains the following types of profiles:
     zowe config convert-profiles
     ```
 
-    **Note:** You can continue using Zowe CLI and Zowe CLI plug-ins V1 profiles with Zowe CLI team profiles. However, we highly recommend that you implement team profiles with Zowe CLI V2.
+    **Note:** You can continue using Zowe CLI and Zowe CLI plug-ins V1 profiles with Zowe CLI V2. However, we highly recommend that you implement V2 profiles with Zowe CLI V2.
 
 - Commands in the `zowe config` [command group](../user-guide/cli-using-understanding-core-command-groups.md#config) now let you manage security for any option value.
 - The `zowe scs` and `zowe config` command groups were repurposed to work with team profiles.
-- Zowe CLI team profiles prompt you to enter the username and password securely by default.
+- Zowe CLI V2 prompts you to enter the username and password securely by default.
 
 ## Displaying profile help
 

--- a/docs/user-guide/cli-using-using-profiles.md
+++ b/docs/user-guide/cli-using-using-profiles.md
@@ -2,29 +2,38 @@
 
 As a system programmer, profiles let you store configuration details for reuse, and for logging in to authentication servers such as API Mediation layer. Create a profile that contains your username, password, and connection details for a mainframe service, then use that profile to avoid typing the information on every command. Switch between profiles to quickly target different mainframe subsystems. 
 
+## Zowe CLI profile types
+
 Zowe CLI contains the following types of profiles:
 
-- **Team profiles:** [Team profiles](../user-guide/cli-using-using-team-profiles.md) simplify profile management by letting you edit, store, and share mainframe configuration details in one location. You can use a text editor to populate global profiles with connection details for your mainframe services.
+- [**Team profiles**](../user-guide/cli-using-using-team-profiles.md) simplify profile management by letting you edit, store, and share mainframe configuration details in one location. You can use a text editor to populate global profiles with connection details for your mainframe services.
 
-- **Service profiles:** [Service profiles](#service-profiles) let you store connection information for specific mainframe service, such as IBM z/OSMF. Plug-ins can introduce other service profile types, such as the `cics` profile to connect to IBM CICS.
+    For more information, see [Configuring team profiles](../user-guide/cli-using-using-team-profiles.md).
 
-- **Base profiles:** [Base profiles](#base-profiles) let you store connection information for use with one or more services. Your service profiles can pull information from- base profiles as needed, so that you can specify a common username and password once. The base profile can optionally store tokens to connect to Zowe API Mediation Layer, which improves security by enabling Multi-Factor Authentication (MFA) and Single Sign-on (SSO).
+- [**Service profiles:**](#service-profiles) let you store connection information for specific mainframe service, such as IBM z/OSMF. Plug-ins can introduce other service profile types, such as the `cics` profile to connect to IBM CICS.
 
+- [**Base profiles:**](#base-profiles) let you store connection information for use with one or more services. Your service profiles can pull information from- base profiles as needed, so that you can specify a common username and password once. The base profile can optionally store tokens to connect to Zowe API Mediation Layer, which improves security by enabling Multi-Factor Authentication (MFA) and Single Sign-on (SSO).
 
-**Tips:**
+### Tips for using Zowe CLI profiles
 
 - You can have multiple service profiles and multiple base profiles.
 - Profiles are **not** required. You can choose to specify all connection details for every command.
-- Profile values are stored on your computer in plaintext in `C:\Users\<yourUsername>\.zowe\profiles` (Windows) or `~/.zowe/profiles` (Mac/Linux).
+- Profile values are stored on your computer in plaintext in `C:\Users\<yourUsername>\.zowe\profiles` (Windows) or in `~/.zowe/profiles` (Mac/Linux).
 
-**Important information about V2 profiles:**
+### Important information about V2 profiles
 
-- With the introduction of [team profiles](../user-guide/cli-using-using-team-profiles.md), the Secure Credential Store (SCS) Plug-in is deprecated. The `zowe scs` and `zowe config` command groups were repurposed to work with team profiles.
-- Secure credential encryption is now handled by the the secure array in the `zowe.config.json` file.
+- With the introduction of [team profiles](../user-guide/cli-using-using-team-profiles.md), the Secure Credential Store (SCS) Plug-in is deprecated. Secure credential encryption is now handled by the the secure array in the `zowe.config.json` file.
+- You can convert all of your Zowe CLI and Zowe CLI plug-ins V1 profiles to V2 profiles by issuing the following command:
+
+    ```
+    zowe config convert profiles
+    ```
+
+    **Note:** You can continue using Zowe CLI and Zowe CLI plug-ins V1 profiles with Zowe CLI V2. However, we highly recommend that you implement V2 profiles with Zowe CLI V2.
+
+- Commands in the `zowe config` [command group](../user-guide/cli-using-understanding-core-command-groups.md#config) now let you manage security for any option value.
+- The `zowe scs` and `zowe config` command groups were repurposed to work with team profiles.
 - Zowe CLI V2 prompts you to enter the username and password securely by default.
-- Commands in the `zowe config` command group now let you manage security for any option value.
-- You can continue using Zowe CLI V1 profiles with Zowe CLI V2. However, we highly recommend that you implement V2 profiles with Zowe CLI V2.
-
 
 ## Displaying profile help
 

--- a/docs/user-guide/cli-using-using-profiles.md
+++ b/docs/user-guide/cli-using-using-profiles.md
@@ -20,20 +20,20 @@ Zowe CLI contains the following types of profiles:
 - Profiles are **not** required. You can choose to specify all connection details for every command.
 - Profile values are stored on your computer in plaintext in `C:\Users\<yourUsername>\.zowe\profiles` (Windows) or in `~/.zowe/profiles` (Mac/Linux).
 
-### Important information about V2 profiles
+### Important information about team profiles
 
 - With the introduction of [team profiles](../user-guide/cli-using-using-team-profiles.md), the Secure Credential Store (SCS) Plug-in is deprecated. Secure credential encryption is now handled by the the secure array in the `zowe.config.json` file.
-- You can convert all of your Zowe CLI and Zowe CLI plug-ins V1 profiles to V2 profiles by issuing the following command:
+- You can convert all of your Zowe CLI and Zowe CLI plug-ins V1 profiles to team profiles by issuing the following command:
 
     ```
     zowe config convert-profiles
     ```
 
-    **Note:** You can continue using Zowe CLI and Zowe CLI plug-ins V1 profiles with Zowe CLI V2. However, we highly recommend that you implement V2 profiles with Zowe CLI V2.
+    **Note:** You can continue using Zowe CLI and Zowe CLI plug-ins V1 profiles with Zowe CLI team profiles. However, we highly recommend that you implement team profiles with Zowe CLI V2.
 
 - Commands in the `zowe config` [command group](../user-guide/cli-using-understanding-core-command-groups.md#config) now let you manage security for any option value.
 - The `zowe scs` and `zowe config` command groups were repurposed to work with team profiles.
-- Zowe CLI V2 prompts you to enter the username and password securely by default.
+- Zowe CLI team profiles prompt you to enter the username and password securely by default.
 
 ## Displaying profile help
 


### PR DESCRIPTION
@MikeBauerCA 

- Added bullet about converting v1 > v2 profiles
- Reorganized section Important info about v2 (seemed more logical)
- Added headings for Profile Tips and Important info about v2 (so the  headings display under **On this page**

you can preview the article here:
https://github.com/zowe/docs-site/blob/jabauman-v2-convert-profiles/docs/user-guide/cli-using-using-profiles.md

This is what currently published so that you can compare...

thx,
jb
 