### PR TITLE
updated to describe the content that is contained in the V2 version o…

### DIFF
--- a/docs/appendix/zowe-cli-command-reference.md
+++ b/docs/appendix/zowe-cli-command-reference.md
@@ -1,11 +1,10 @@
 # Zowe CLI command reference guide
 
-View detailed documentation about commands, actions, and options in Zowe CLI.
+View detailed documentation on commands, actions, and options in Zowe CLI. You can read an interactive online version, download a PDF document, or download a ZIP file containing the HTML for the online version.
 
-This reference document is based on the `@zowe-v2-lts` version of Zowe CLI. The content also contains the web help for all Zowe ecosystem-conformant plug-ins that contributed to this website.
+Currently, this reference documentation only contains the web help for 
+the Zowe CLI core component and CLI plug-ins maintained by Zowe. As third-party plug-ins are approved under the Zowe V2 LTS Conformance Program and contribute their web help to Zowe, we will update the documentation accordingly. To view the web help for V1 conformant plug-ins, click the version drop-menu on the top right corner of this page and click the link to any previous v1.xx.x version of this page.
 
-You can read an interactive online version, download a PDF document, or download a ZIP file containing the HTML for the online version:
-- <b><a href="/stable/web_help/index.html" target="_blank">Browse online</a></b>
-- <b><a href="/stable/CLIReference_Zowe.pdf" target="_blank">Download CLI reference in PDF format</a></b>
-- <b><a href="/stable/zowe_web_help.zip" target="_blank">Download CLI reference in ZIP format</a></b>
-
+- <a href="/stable/web_help/index.html" target="_blank">Browse online</a>
+- <a href="/stable/CLIReference_Zowe.pdf" target="_blank">Download CLI reference in PDF format</a>
+- <a href="/stable/zowe_web_help.zip" target="_blank">Download CLI reference in ZIP format</a>


### PR DESCRIPTION
@JTonda 

Please approve so that i can publish to the preview branch.  This was Mike's ask during planning earlier today.

Thx

=========================================
From our chat

James Bauman, 2:49 PM
Content for the Zowe CLI command reference guide. Update to the following:

View detailed documentation on commands, actions, and options in Zowe 
CLI. You can read an interactive online version, download a PDF 
document, or download a ZIP file containing the HTML for the online 
version.

This reference documentation contains the web help for 
only the Zowe CLI core component and Zowe CLI plug-ins. As third-party 
plug-ins are approved under the Zowe Conformance Program and contribute 
the web help for the plug-ins to Zowe, we will update the documentation 
to contain the web help for the plug-ins. To view the web help for V1 
conformant plug-ins, click the version drop-menu on the top right corner
 of this page and click the link to any previous v1.xx.x version of this
 page.

Current doc:
https://docs.zowe.org/stable/appendix/zowe-cli-command-reference

Michael Bauer, 42 min, Edited
Small rewording:
Currently, this reference documentation only contains the web help for 
the Zowe CLI core component and CLI plug-ins maintained by Zowe. As third-party 
plug-ins are approved under the Zowe V2 LTS Conformance Program and contribute 
their web help to Zowe, we will update the documentation accordingly. To view the web help for V1 
conformant plug-ins, click the version drop-menu on the top right corner
 of this page and click the link to any previous v1.xx.x version of this
 page.
==============================================





















