### PR TITLE
added auto-init info for connecting to API-ML; fixed broken link in t…

### DIFF
--- a/docs/getting-started/user-roadmap-zowe-cli.md
+++ b/docs/getting-started/user-roadmap-zowe-cli.md
@@ -53,7 +53,7 @@ The following definition of skill levels about Zowe will help you gather most re
 
 > Zowe skill level: Intermediate
 
-- [**Configuring Zowe CLI environment variables**](../user-guide/cli-configuringcli.md)
+- [**Configuring Zowe CLI environment variables**](../user-guide/cli-configuringcli-ev.md)
 
    Explains how to configure Zowe CLI environment variables, such as changing log levels, setting the home directory location, and daemon mode.
 

--- a/docs/user-guide/cli-using-initializing-team-configuration.md
+++ b/docs/user-guide/cli-using-initializing-team-configuration.md
@@ -23,19 +23,13 @@ After you create the configuration files, you can use a text editor or IDE, such
 
 The following steps describe how to interactively initialize team profile configuration. It is the recommended method to initialize team configuration.
 
-1. Issue the following command:
-    ```
-    zowe config init
-    ```
-    The CLI responds with prompts for a username and password.
+**Important!** If API ML installed and configured, using the `auto-init` command is the recommended method to use to configure your profile. For more information, see [Connecting profiles to API Mediation Layer](#connecting-profiles-to-api-mediation-layer). 
 
-2.  Respond to the prompts with a username and password for a mainframe service such as z/OSMF.
+**Follow these steps:**
 
-    The `zowe config init` command ensures that your credentials are stored securely on your computer by default.
-    
-    After you respond, the `zowe.config.json` team configuration file is added to your local `.zowe` directory. This location is the primary location where your mainframe service connection details are defined, such as host and port. You use Use this configuration file for the following procedures.
+1. [Create team profile configuration files.](#create-team-profile-configuration-files)
 
-3.  (Optional) Issue a Zowe CLI command to test that you can access z/OSMF.
+2.  (Optional) Issue a Zowe CLI command to test that you can access z/OSMF.
 
     **Example:** List all data sets under your user ID:
     ```
@@ -46,14 +40,14 @@ The following steps describe how to interactively initialize team profile config
     
     If the CLI returns an error message, verify that you have access to the target system. Examine your configuration files in a text editor to verify that the information you entered is correct.
 
-**Important:** After the configuration files are in place (either via the zowe config init command or by manually creating the files), the now-deprecated zowe profiles commands will no longer function. Zowe CLI will return errors if you attempt to use deprecated profile commands.
+**Important:** After the configuration files are in place (either by using the `zowe config init` command or by manually creating the files), the now-deprecated zowe profiles commands no longer function. Zowe CLI returns errors when you attempt to use deprecated profile commands.
 
 ## Connecting profiles to API Mediation Layer
 
-To configure your profile to connect to API ML, issue the following command to set up your initial `zowe.config.json` file:
+If you are using the API Mediation Layer, you can automatically set up your `zowe.config.json` file to access the services that are registered to it by issuing the following command:
 
 ```
-zowe-config-auto-init
+zowe config auto-init
 ```
 
 After you issue the command, Zowe CLI prompts you to specify the following information:

--- a/docs/user-guide/cli-using-initializing-team-configuration.md
+++ b/docs/user-guide/cli-using-initializing-team-configuration.md
@@ -16,7 +16,7 @@ You can use methods that are described in this article to initialize team config
 
     The `zowe config init` command ensures that your credentials are stored securely on your computer by default.
 
-    After you respond, the `zowe.config.json` team configuration file is added to your local `.zowe` directory. This location is the primary location where your mainframe service connection details are defined, such as host and port. You use Use this configuration file for the following procedures.
+    After you respond, the `zowe.config.json` team configuration file is added to your local `.zowe` directory. This location is the primary location where your mainframe service connection details are defined, such as host and port. You use this configuration file for the following procedures.
 
 After you create the configuration files, you can use a text editor or IDE, such as *Visual Studio Code*, to populate global profiles with connection details for your mainframe services.
 ## Creating team profiles by defining a connection to z/OSMF
@@ -48,3 +48,25 @@ The following steps describe how to interactively initialize team profile config
 
 **Important:** After the configuration files are in place (either via the zowe config init command or by manually creating the files), the now-deprecated zowe profiles commands will no longer function. Zowe CLI will return errors if you attempt to use deprecated profile commands.
 
+## Connecting profiles to API Mediation Layer
+
+To configure your profile to connect to API ML, issue the following command to set up your initial `zowe.config.json` file:
+
+```
+zowe-config-auto-init
+```
+
+After you issue the command, Zowe CLI prompts you to specify the following information:
+
+- The host name and port to your API ML instance
+- Your username and password
+
+If you are using certificates to authenticate, you can specify the details for the certificates by issuing the following commands:
+
+```
+zowe auth login apiml --cert-file
+```
+
+```
+zowe auth login apiml --cert-key-file
+```

--- a/docs/user-guide/cli-using-initializing-team-configuration.md
+++ b/docs/user-guide/cli-using-initializing-team-configuration.md
@@ -16,8 +16,9 @@ You can use one of the following methods to initialize team configuration.
 
     The `zowe config init` command ensures that your credentials are stored securely on your computer by default.
 
-    After you respond, the `zowe.config.json` team configuration file is added to your local `.zowe` directory. This location is the primary location where your mainframe service connection details are defined, such as host and port. You use this configuration file for the following procedures.
-
+    After you respond, the `zowe.config.json` team configuration file is added to your local `.zowe` directory. You can then use a text editor or IDE, such as *Visual Studio Code*, to add the connection details for your mainframe services.
+    
+    
 3.  (Optional) Issue a Zowe CLI command to test that you can access z/OSMF.
 
     **Example:** List all data sets under your user ID:
@@ -29,7 +30,6 @@ You can use one of the following methods to initialize team configuration.
     
     If the CLI returns an error message, verify that you have access to the target system. Examine your configuration files in a text editor to verify that the information you entered is correct.
 
-After you create the configuration files, you can use a text editor or IDE, such as *Visual Studio Code*, to populate global profiles with connection details for your mainframe services.
 
 **Important:** After the configuration files are in place (either by using the `zowe config init` command or by manually creating the files), the now-deprecated zowe profiles commands no longer function. Zowe CLI returns errors when you attempt to use deprecated profile commands.
 

--- a/docs/user-guide/cli-using-initializing-team-configuration.md
+++ b/docs/user-guide/cli-using-initializing-team-configuration.md
@@ -2,6 +2,8 @@
 
 You can use one of the following methods to initialize team configuration.
 
+**Tip:** If API Mediation Layer is running on your site, *Connecting profiles to API Mediation Layer* is the recommended method to use to initialize team configuration.
+
 ## Create team profile configuration files
 
 1. Issue the following command:

--- a/docs/user-guide/cli-using-initializing-team-configuration.md
+++ b/docs/user-guide/cli-using-initializing-team-configuration.md
@@ -1,6 +1,6 @@
 # Initializing team configuration
 
-You can use methods that are described in this article to initialize team configuration.
+You can use one of the following methods to initialize team configuration.
 
 ## Create team profile configuration files
 
@@ -18,18 +18,7 @@ You can use methods that are described in this article to initialize team config
 
     After you respond, the `zowe.config.json` team configuration file is added to your local `.zowe` directory. This location is the primary location where your mainframe service connection details are defined, such as host and port. You use this configuration file for the following procedures.
 
-After you create the configuration files, you can use a text editor or IDE, such as *Visual Studio Code*, to populate global profiles with connection details for your mainframe services.
-## Creating team profiles by defining a connection to z/OSMF
-
-The following steps describe how to interactively initialize team profile configuration. It is the recommended method to initialize team configuration.
-
-**Important!** If API ML installed and configured, using the `auto-init` command is the recommended method to use to configure your profile. For more information, see [Connecting profiles to API Mediation Layer](#connecting-profiles-to-api-mediation-layer). 
-
-**Follow these steps:**
-
-1. [Create team profile configuration files.](#create-team-profile-configuration-files)
-
-2.  (Optional) Issue a Zowe CLI command to test that you can access z/OSMF.
+3.  (Optional) Issue a Zowe CLI command to test that you can access z/OSMF.
 
     **Example:** List all data sets under your user ID:
     ```
@@ -40,11 +29,13 @@ The following steps describe how to interactively initialize team profile config
     
     If the CLI returns an error message, verify that you have access to the target system. Examine your configuration files in a text editor to verify that the information you entered is correct.
 
+After you create the configuration files, you can use a text editor or IDE, such as *Visual Studio Code*, to populate global profiles with connection details for your mainframe services.
+
 **Important:** After the configuration files are in place (either by using the `zowe config init` command or by manually creating the files), the now-deprecated zowe profiles commands no longer function. Zowe CLI returns errors when you attempt to use deprecated profile commands.
 
 ## Connecting profiles to API Mediation Layer
 
-If you are using the API Mediation Layer, you can automatically set up your `zowe.config.json` file to access the services that are registered to it by issuing the following command:
+If you are using the API Mediation Layer, you can set up your `zowe.config.json` file to automatically access the services that are registered to the API ML by issuing the following command:
 
 ```
 zowe config auto-init
@@ -55,12 +46,10 @@ After you issue the command, Zowe CLI prompts you to specify the following infor
 - The host name and port to your API ML instance
 - Your username and password
 
-If you are using certificates to authenticate, you can specify the details for the certificates by issuing the following commands:
+**Using Certificates:**
+
+If you are using certificates to authenticate, you can specify the details for the certificates by issuing the following command:
 
 ```
-zowe auth login apiml --cert-file
-```
-
-```
-zowe auth login apiml --cert-key-file
+zowe auth login apiml --cert-file "/path/to/cert/file" --cert-key-file "/path/to/cert/key/file"
 ```


### PR DESCRIPTION
@MikeBauerCA 

Added auto-init 

Rather than add a note that might become hidden to the user, i created a topic named ***Connecting profiles to API Mediation Layer***. When we publish, the user sees a link under **On this page**.

I am not sure if i framed the info correctly; but i'll let you be the judge.  

Also, we we describe the commands to use certificates, I included the full command.  i hope i did that right. More > the chat message implied that both commands are required.  i could have misinterpreted.

Anyway, please review and comment.  Quick view: 
https://github.com/zowe/docs-site/blob/jabauman-misc/docs/user-guide/cli-using-initializing-team-configuration.md

Note that i slipped in another article that contains a broken link.

thx,
jb
