### PR TITLE
sidebar remove migrate cli

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -38,7 +38,6 @@ module.exports = {
       items: [
     //    "getting-started/migrate-instance",  //Not ready yet, need to check
         "extend/migrate-extensions",
-        "getting-started/migrate-cli",
         "getting-started/zowe-office-hours"
       ],
     },


### PR DESCRIPTION
to remove Migrate CLI from V1 to V@ from the sidebar.  topic not required

@JTonda 