### PR TITLE
Fix noting that schema is required

### DIFF
--- a/docs/appendix/server-component-manifest.md
+++ b/docs/appendix/server-component-manifest.md
@@ -30,11 +30,11 @@ The manifest file contains the following properties:
   
 - **`schemas`**
 
-  Defines the location of json schema files that are compatible with certain portions of Zowe as denoted by each child property.
+  (Required) Defines the location of json schema files that are compatible with certain portions of Zowe as denoted by each child property.
   
   * **`configs`**
   
-    Defines the location of the json schema file which extends the Zowe Component base schema.
+    (Required) Defines the location of the json schema file which extends the Zowe Component base schema.
 
 - **`build`**
 


### PR DESCRIPTION
Adding the (required) statement to make it abundantly clear of our intent to require schemas no matter how trivial https://github.com/zowe/docs-site/pull/2108