### PR TITLE
remove potential support of JDK v11

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -51,7 +51,7 @@ Be sure your z/OS system meets the following prerequisites.
 
 ### Java 
 
-- IBM SDK for Java Technology Edition V8 or later
+- IBM SDK for Java Technology Edition V8
 
 ### z/OSMF (Optional) 
 


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)

`IBM SDK for Java Technology Edition V8 or higher` indicates we may support JDK v11, which is not. So remove `or higher` wording.

:heart:Thank you!

