### PR TITLE
fix typos/formatting anomalies

### DIFF
--- a/docs/troubleshoot/cli/zosmf-cli.md
+++ b/docs/troubleshoot/cli/zosmf-cli.md
@@ -8,7 +8,7 @@ If you encounter HTTP 500 errors with the CLI, consider gathering the following 
 If you encounter HTTP 401 errors with the CLI, consider gathering the following information:
 1. Any security violations for the TSO user in SYSLOG
 
-## Alternate methods
+## Alternative methods
 At times, it may be beneficial to test z/OSMF outside of the CLI. You can use the CLI tool `curl` or a REST tool such as "Postman" to isolate areas where the problem might be occurring (CLI configuration, server-side, etc.).
 
 Example `curl` command to `GET /zosmf/info`:

--- a/docs/user-guide/cli-using-sharing-team-config-files.md
+++ b/docs/user-guide/cli-using-sharing-team-config-files.md
@@ -82,7 +82,7 @@ Team leaders can import configuration files from a web URL that is in raw json f
             Specifies the host name of the system
         - folderPath
 
-            Specifies the path to the configuration file
+            Specifies the path to the team configuration file
 
         **Note:** You can host team configuration files on **private** and **public** web servers. The user name and password are required for **only private URLs**. However, to maintain the highest level of security, you **should not store** team configuration files on public URLs.
 


### PR DESCRIPTION
Signed-off-by: JamesBauman <james.bauman@broadcom.com>

Fixed typo in z/osmf troubleshooting
Fixed formatting anomaly in sharing team config files