### PR TITLE
updated link to refer reader to the nodejs and python sdk websites

### DIFF
--- a/docs/user-guide/sdks-using.md
+++ b/docs/user-guide/sdks-using.md
@@ -10,7 +10,9 @@ The following SDKs are available.
 
 ## API documentation
 
-For details about the available API endpoints, browse or download the [API Reference documentation](https://docs.zowe.org/stable/#zowe-client-sdk-reference-guides).
+For information about the available API endpoints, see the following SDK documentation:
+- [Zowe Node.js SDK](https://docs.zowe.org/stable/typedoc/index.html)
+- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/)
 
 ## Software requirements
 


### PR DESCRIPTION
Signed-off-by: JamesBauman <james.bauman@broadcom.com>

Per chat convo with Fernando...

Should the API reference doc link in this page (https://docs.zowe.org/stable/user-guide/sdks-using/) be pointing to https://docs.zowe.org/stable/typedoc/index.html

James Bauman, 8:14 AM
Seems like this is the correct link:  https://docs.zowe.org/stable/appendix/zowe-api-reference

if not, please advise...

Fernando Rijo Cedeno, 8:41 AM
🤔
That's more for the Swagger APIs
The one I sent (https://docs.zowe.org/stable/user-guide/sdks-using/) is more referring to the SDKs
which I think should be a list of links (similar to the API one)
NodeJS: https://docs.zowe.org/stable/typedoc/index.html
Python: https://zowe-client-python-sdk.readthedocs.io/en/latest/


@MikeBauerCA Mike, Fernando asked me to tag you so that you can weigh in on what we changed.  We wanted to be sure that you are ok with adding the python link in the article.