### PR TITLE
Remove Gateway client certificate note

### DIFF
--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -141,8 +141,6 @@ To change this default configuration, include the following parameters:
     
 ## Gateway client certificate authentication
 
-Beginning with release 1.19 LTS, it is possible to authenticate using client certificates. The feature is functional and tested, but automated testing on various security systems is not complete. As such, the feature is provided as a beta release for early preview. If you would like to offer feedback using client certificate authentication, please create an issue against the api-layer repository. Client Certificate authentication will move out of Beta once test automation is fully implemented across different security systems.
-
 Use the following procedure to enable the feature to use a client certificate as the method of authentication for the API Mediation Layer Gateway.
 
 **Follow these steps:**


### PR DESCRIPTION
Remove note Re: Gateway client cert authentication out of beta

Resolves issue: [#2356](https://app.zenhub.com/workspaces/community-5c93e02fa70b456d35b8f0ed/issues/zowe/api-layer/2356)

