### PR TITLE
fix: Add central version dropdown for downloadable files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3475,10 +3475,27 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
       "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "peer": true
+    },
     "node_modules/@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.47",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz",
+      "integrity": "sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -3495,6 +3512,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.5",
@@ -5701,6 +5724,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.1",
@@ -19356,10 +19385,27 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
       "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
     },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "peer": true
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "@types/react": {
+      "version": "17.0.47",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz",
+      "integrity": "sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==",
+      "peer": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -19376,6 +19422,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "peer": true
     },
     "@types/unist": {
       "version": "2.0.5",
@@ -21056,6 +21108,12 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
+    },
+    "csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+      "peer": true
     },
     "debug": {
       "version": "4.3.1",

--- a/src/components/DownloadableFiles/DownloadableFiles.js
+++ b/src/components/DownloadableFiles/DownloadableFiles.js
@@ -15,8 +15,7 @@ const downloadableFiles = [
       </>
     ),
     firstSubDescription: <>Select the version to download</>,
-    version: true,
-    dropdown: true,
+    downloadDocsPDF: true,
   },
   {
     title: "Zowe CLI command reference guides",
@@ -29,10 +28,10 @@ const downloadableFiles = [
       </>
     ),
     firstSubDescription: <>Online interactive version</>,
-    firstViewOnlineLink: "./stable/web_help/index.html",
-    firstDownloadLink: "./stable/CLIReference_Zowe.pdf",
+    firstViewOnlineLink: "web_help/index.html",
+    firstDownloadLink: "CLIReference_Zowe.pdf",
     secondSubDescription: <>ZIP format</>,
-    secondDownloadLink: "./stable/zowe_web_help.zip",
+    secondDownloadLink: "zowe_web_help.zip",
   },
   {
     title: "Zowe Client SDK reference guides",
@@ -43,8 +42,8 @@ const downloadableFiles = [
       </>
     ),
     firstSubDescription: <>Node SDK Reference</>,
-    firstViewOnlineLink: "./stable/typedoc/index.html",
-    firstDownloadLink: "./stable/zowe-nodejs-sdk-typedoc.zip",
+    firstViewOnlineLink: "typedoc/index.html",
+    firstDownloadLink: "zowe-nodejs-sdk-typedoc.zip",
     secondSubDescription: <>Python SDK Reference</>,
     secondViewOnlineLink:
       "https://zowe-client-python-sdk.readthedocs.io/en/latest/index.html",
@@ -55,8 +54,7 @@ const downloadableFiles = [
 
 function DownloadableFile({
   title,
-  version,
-  dropdown,
+  downloadDocsPDF,
   description,
   firstSubDescription,
   firstViewOnlineLink,
@@ -64,24 +62,16 @@ function DownloadableFile({
   secondSubDescription,
   secondViewOnlineLink,
   secondDownloadLink,
+  siteConfig,
+  selectedVersion,
 }) {
-  const { siteConfig } = useDocusaurusContext();
-  const [clicked, setClicked] = useState(false);
-  const [isVersion, setIsVersion] = useState(false);
-  const [selectedVersion, setSelectedVersion] = useState(
-    siteConfig.customFields.latestVersion
-  );
+  firstViewOnlineLink = selectedVersion != siteConfig.customFields.latestVersion ? `./${selectedVersion}/${firstViewOnlineLink}` : `/stable/${firstViewOnlineLink}`;
+  firstDownloadLink = selectedVersion != siteConfig.customFields.latestVersion ? `./${selectedVersion}/${firstDownloadLink}` : `./stable/${firstDownloadLink}`;
 
-  //Appended latest version in the versionsArray
-  const newVersionsArray = [siteConfig.customFields.latestVersion].concat(
-    versionsArray
-  );
-
-  function handleClick(props) {
-    setIsVersion(true);
-    setClicked(true);
-    setSelectedVersion(props);
+  if (!secondViewOnlineLink) {
+    secondDownloadLink = selectedVersion != siteConfig.customFields.latestVersion ? `./${selectedVersion}/${secondDownloadLink}` : `./stable/${secondDownloadLink}`;
   }
+
   return (
     <div className={clsx("col col--4 margin-bottom--lg")}>
       <div className={clsx("padding--lg item shadow--lw", styles.card)}>
@@ -90,7 +80,7 @@ function DownloadableFile({
           <h4>{title}</h4>
           <p>
             {description}{" "}
-            {version && siteConfig.customFields.latestVersion + "."}
+            {downloadDocsPDF && siteConfig.customFields.latestVersion + "."}
           </p>
         </div>
         <div>
@@ -99,7 +89,7 @@ function DownloadableFile({
               <p className="margin-bottom--sm">{firstSubDescription}</p>
             )}
             <div className="display-flex">
-              {firstViewOnlineLink && (
+              {!downloadDocsPDF && (
                 <div className="margin-right--md display-flex row--align-center pointer">
                   <img
                     className="lightTheme"
@@ -122,55 +112,7 @@ function DownloadableFile({
                 </div>
               )}
 
-              {/* Version Download Dropdown */}
-              {dropdown && (
-                <div className="dropdown dropdown--hoverable margin-right--md">
-                  <button
-                    className={clsx(
-                      "button button--outline button--primary display-flex",
-                      styles.versionButton
-                    )}
-                  >
-                    {isVersion
-                      ? selectedVersion
-                      : siteConfig.customFields.latestVersion}
-                    <img
-                      className="margin-left--xs lightTheme"
-                      alt="right arrow"
-                      src={useBaseUrl("/img/down-arrow-light-icon.svg")}
-                    />
-                    <img
-                      className="margin-left--xs darkTheme"
-                      alt="right arrow"
-                      src={useBaseUrl("/img/down-arrow-dark-icon.svg")}
-                    />
-                  </button>
-                  <ul
-                    className={
-                      clicked
-                        ? clsx(styles.displayNone)
-                        : clsx(
-                            "dropdown__menu pointer thin-scrollbar",
-                            styles.overflow
-                          )
-                    }
-                    onMouseLeave={() => setClicked(false)}
-                  >
-                    {newVersionsArray.map((props, idx) => (
-                      <li key={idx}>
-                        <a
-                          className="dropdown__link"
-                          onClick={() => handleClick(props)}
-                        >
-                          {props}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {dropdown && (
+              {downloadDocsPDF && (
                 <div className="display-flex row--align-center pointer">
                   <img
                     className="lightTheme"
@@ -185,7 +127,7 @@ function DownloadableFile({
                   <a
                     className="margin--xs"
                     href={
-                      dropdown &&
+                      downloadDocsPDF &&
                       selectedVersion != siteConfig.customFields.latestVersion
                         ? "/zowe-docs-" + selectedVersion + ".pdf"
                         : "/zowe-docs.pdf"
@@ -198,7 +140,7 @@ function DownloadableFile({
                 </div>
               )}
 
-              {firstDownloadLink && (
+              {!downloadDocsPDF && firstDownloadLink && (
                 <div className="display-flex row--align-center pointer">
                   <img
                     className="lightTheme"
@@ -253,7 +195,7 @@ function DownloadableFile({
                 </div>
               )}
 
-              {secondDownloadLink && (
+              {!downloadDocsPDF && (
                 <div className="display-flex row--align-center pointer">
                   <img
                     className="lightTheme"
@@ -284,6 +226,24 @@ function DownloadableFile({
 }
 
 function DownloadableFiles() {
+  const { siteConfig } = useDocusaurusContext();
+  const [clicked, setClicked] = useState(false);
+  const [isVersion, setIsVersion] = useState(false);
+  const [selectedVersion, setSelectedVersion] = useState(
+    siteConfig.customFields.latestVersion
+  );
+
+  //Appended latest version in the versionsArray
+  const newVersionsArray = [siteConfig.customFields.latestVersion].concat(
+    versionsArray
+  );
+
+  function handleClick(props) {
+    setIsVersion(true);
+    setClicked(true);
+    setSelectedVersion(props);
+  }
+
   return (
     <>
       {downloadableFiles && downloadableFiles.length > 0 && (
@@ -291,11 +251,56 @@ function DownloadableFiles() {
           <div className="row margin-horiz--lg">
             <div className={clsx("col col--2 p-none")}>
               <h3 className="container-h3">Downloadable files</h3>
+              <div className="dropdown dropdown--hoverable margin-right--md">
+                <button
+                  className={clsx(
+                    "button button--outline button--primary display-flex",
+                    styles.versionButton
+                  )}
+                >
+                  {isVersion
+                    ? selectedVersion
+                    : siteConfig.customFields.latestVersion}
+                  <img
+                    style={{marginRight: "15px", maxWidth: "50%"}}
+                    className="lightTheme margin-left--xs"
+                    alt="right arrow"
+                    src={useBaseUrl("/img/down-arrow-light-icon.svg")}
+                  />
+                  <img
+                    className="margin-left--xs darkTheme"
+                    alt="right arrow"
+                    src={useBaseUrl("/img/down-arrow-dark-icon.svg")}
+                  />
+                </button>
+                <ul
+                  className={
+                    clicked
+                      ? clsx(styles.displayNone)
+                      : clsx(
+                          "dropdown__menu pointer thin-scrollbar",
+                          styles.overflow
+                        )
+                  }
+                  onMouseLeave={() => setClicked(false)}
+                >
+                  {newVersionsArray.map((props, idx) => (
+                    <li key={idx}>
+                      <a
+                        className="dropdown__link"
+                        onClick={() => handleClick(props)}
+                      >
+                        {props}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
             <div className={clsx("col col--10 p-none")}>
               <div className={clsx("row")}>
                 {downloadableFiles.map((props, idx) => (
-                  <DownloadableFile key={idx} {...props} />
+                  <DownloadableFile key={idx} {...props} clicked={clicked} isVersion={isVersion} selectedVersion={selectedVersion} siteConfig={siteConfig} />
                 ))}
               </div>
             </div>

--- a/src/components/DownloadableFiles/DownloadableFiles.js
+++ b/src/components/DownloadableFiles/DownloadableFiles.js
@@ -10,21 +10,22 @@ const downloadableFiles = [
     title: "Zowe documentation",
     description: (
       <>
-        Download the Zowe documentation in PDF format
-        from the links below. The latest version on this website is
+        Download the Zowe documentation in PDF format. The latest version 
+        on this website is 
       </>
     ),
-    firstSubDescription: <>Select the version to download</>,
+    firstSubDescription: <>Zowe Docs PDF</>,
     downloadDocsPDF: true,
   },
   {
     title: "Zowe CLI command reference guides",
     description: (
       <>
-        View documentation on commands, actions, and options in Zowe CLI. The
-        reference document is based on the <code>@zowe-v2-lts</code> version of
-        the CLI. It contains the web help for all Zowe ecosystem-conformant 
-        plug-ins that contributed to this website.
+        View or download Zowe CLI web help. The web help contains information about
+        commands, actions, and options for Zowe CLI and all Zowe ecosystem-conformant 
+        plug-ins that contributed to this website. The web help is based on the 
+        <code>@zowe-v2-lts</code> version of the CLI. To view or download a previous version, select 
+        a version from the drop-down list.
       </>
     ),
     firstSubDescription: <>Online interactive version</>,
@@ -37,14 +38,15 @@ const downloadableFiles = [
     title: "Zowe Client SDK reference guides",
     description: (
       <>
-        Refer to the following Zowe Client SDK reference guides for information
-        about the API endpoints.
+        View or download Zowe Client SDK reference guides. The guides contain 
+        information about the API endpoints. To view or download a previous 
+        version, select a version from the drop-down list.
       </>
     ),
     firstSubDescription: <>Node SDK Reference</>,
     firstViewOnlineLink: "typedoc/index.html",
     firstDownloadLink: "zowe-nodejs-sdk-typedoc.zip",
-    secondSubDescription: <>Python SDK Reference</>,
+    secondSubDescription: <>Python SDK Reference (Latest version only)</>,
     secondViewOnlineLink:
       "https://zowe-client-python-sdk.readthedocs.io/en/latest/index.html",
     secondDownloadLink:


### PR DESCRIPTION
### Description
Add central version dropdown for downloadable files section.
**Note**: For Python SDKs, the link always points to the latest version.

<img width="1262" alt="Screenshot 2022-06-18 at 12 44 31 PM" src="https://user-images.githubusercontent.com/53327173/174427236-95660146-3b3b-4aff-b87e-c101f7573b7b.png">

:heart:Thank you!

