### PR TITLE
Update cli-using-understanding-core-command-groups.md

### DIFF
--- a/docs/user-guide/cli-using-understanding-core-command-groups.md
+++ b/docs/user-guide/cli-using-understanding-core-command-groups.md
@@ -1,6 +1,6 @@
 # Understanding core command groups
 
-Zowe CLI contains command groups that focus on specific business processes. For example, the `zos-files` command group lets you interact with mainframe data sets. This article provides a brief synopsis of the tasks that you can perform with each group. For more information, see [Displaying help](cli-using-displaying-help).
+Zowe CLI contains command groups that focus on specific business processes. For example, the `zos-files` command group lets you interact with mainframe data sets. This article provides a brief synopsis of the tasks that you can perform with each group. For more information, see [Displaying help](../user-guide/cli-using-displaying-help.md).
 
 The commands available in the product are organized in a hierarchical structure. Command groups (for example, `zos-files`) contain actions (for example, `create`) that let you perform actions on specific objects (for example, a specific type of data set). For each action that you perform on an object, you can specify options that affect the operation of the command.
 Zowe CLI contains the following command groups:


### PR DESCRIPTION
fix broken link at [Understanding core command groups](https://github.com/zowe/docs-site/blob/master/docs/user-guide/cli-using-understanding-core-command-groups.md)
Working https://docs.zowe.org/stable/user-guide/cli-using-displaying-help
Broken: https://docs.zowe.org/stable/user-guide/cli-using-understanding-core-command-groups/cli-using-displaying-help