### PR TITLE
reorganizing environment variables doc

### DIFF
--- a/docs/user-guide/cli-configuringcli-ev.md
+++ b/docs/user-guide/cli-configuringcli-ev.md
@@ -4,6 +4,8 @@ This section explains how to configure Zowe CLI using environment variables.
 
 By default, Zowe CLI configuration is stored on your computer in the `C:\Users\user01\.zowe` directory. The directory includes log files, profile information, and installed CLI plug-ins. When troubleshooting, refer to the logs in the `imperative` and `zowe` folders.
 
+**Note:** For advanced configuration on using environment variables, [click here](cli-using-using-environment-variables.md).
+
 ## Setting the CLI home directory
 
 You can set the location on your computer where Zowe CLI creates the *.zowe* directory, which contains log files, profiles, and plug-ins for the product:

--- a/docs/user-guide/cli-using-formatting-environment-variables.md
+++ b/docs/user-guide/cli-using-formatting-environment-variables.md
@@ -1,0 +1,18 @@
+# Formatting environment variables
+
+Transform an option into the proper format for a Zowe CLI environment variable, then define a value to the variable. Transform option names according to the following rules:
+
+* Prefix environment variables with `ZOWE_OPT_`.
+* Convert lowercase letters in arguments/options to uppercase letters.
+* Convert hyphens in arguments/options to underscores.
+
+**Tip:** Refer to your operating system documentation for information about how to set and get environment variables. The procedure varies between Windows, Mac, and various versions of Linux.
+
+**Examples:**
+
+The following table provides examples of CLI options and the corresponding environment variable to which you can define a value:
+
+| Command Option          | Environment Variable           | Use Case   |
+| ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--user`                | `ZOWE_OPT_USER`                | Define your mainframe username to an environment variable to avoid specifying it on all commands or profiles.                           |
+| `--reject-unauthorized` | `ZOWE_OPT_REJECT_UNAUTHORIZED` | Define a value of `true` to the `--reject-unauthorized` flag when you always require the flag and do not want to specify it on all commands or profiles. |

--- a/docs/user-guide/cli-using-using-environment-variables.md
+++ b/docs/user-guide/cli-using-using-environment-variables.md
@@ -1,0 +1,13 @@
+# Using environment variables
+
+You can define environment variables to execute commands more efficiently. Store a value such as your password in an environment variable, then issue commands without specifying your password every time. The term environment can refer to your operating system, container environment, or automation server such as Jenkins.
+You might want to assign a variable in the following scenarios:
+
+* **Store a value that is commonly used.**
+
+    For example, you might want to specify your mainframe username as an environment variable. Now you can issue commands and omit the `--user` option, and Zowe CLI automatically uses the value that you defined in the environment variable.
+* **Override a value in existing profiles.**
+
+    For example, you might want to override a value that you previously defined in multiple profiles to avoid recreating each profile. Specify the new value as a variable to override the value in profiles.
+* **Secure credentials in an automation server or container**
+    You can set environment variables for use in scripts that run in your CI/CD pipeline. For example, can define environment variables in Jenkins so that your password is not seen in plaintext in logs. You can also define sensitive information in the Jenkins secure credential store.

--- a/docs/user-guide/cli-using-using-prompt-feature.md
+++ b/docs/user-guide/cli-using-using-prompt-feature.md
@@ -1,0 +1,5 @@
+# Using the prompt feature
+
+Zowe CLI has a command-line "prompt" feature that asks you to provide required option values. The CLI always prompts for host, port, username, and password if you do not supply them in commands or profile configuration.
+
+You can also manually enable the prompt for any option. This is helpful to mask sensitive information on the screen while you type. You can enable a one-time prompt, or choose to always prompt for a particular option.

--- a/docs/user-guide/cli-using-using-setting-environment-variables-in-automation-server.md
+++ b/docs/user-guide/cli-using-using-setting-environment-variables-in-automation-server.md
@@ -1,0 +1,6 @@
+# Setting environment variables in an automation server
+
+You can use environment variables in an automation server, such as Jenkins, to write more efficient scripts and make use of secure credential storage. Automation tools such as Jenkins automation server usually provide a mechanism for securely storing configuration (for example, credentials). In Jenkins, you can use withCredentials to expose credentials as an environment variable (ENV) or Groovy variable.
+
+You can either set environment variables using the `SET` command within your scripts, or navigate to **Manage Jenkins \> Configure System \> Global Properties** and define an environment variable in the Jenkins GUI. For example:
+![jenkins gui](../images/guides/CLI/envVarsJenkins.png)

--- a/docs/user-guide/cli-using-writing-scripts.md
+++ b/docs/user-guide/cli-using-writing-scripts.md
@@ -1,0 +1,75 @@
+# Writing scripts
+
+You can combine multiple Zowe CLI commands in bash or shell scripts to automate actions on z/OS. Implement scripts to enhance your development workflow, automate repetitive test or build tasks, and orchestrate mainframe actions from continuous integration/continuous deployment (CI/CD) tools such as Jenkins or TravisCI.
+
+**Note:** The type of script that you write depends on the programming languages that you use and the environment where the script is executed. The following is a general guide to Zowe CLI scripts. Refer to third-party documentation to learn more about scripting in general.
+
+**Follow these steps:**
+
+1. Create a new file on your computer with the extension .sh. For example, `testScript.sh`.
+
+    **Note:** On Mac and Linux, an extension is not required. To make the file executable, issue the command `chmod u+x testScript`.
+2. **(Mac and Linux only)** At the top of the file, specify the interpreter that your script requires. For example, type `#!/bin/sh` or `#!/bin/bash`.
+
+    **Note:** The command terminal that you use to execute the script depends on what you specify at the top of your script. Bash scripts require a bash interpreter (bash terminal), while shell scripts can be run from any terminal.
+3. Write a script using a series of Zowe CLI commands.
+
+    **Tip:** You can incorporate commands from other command-line tools in the same script. You might choose to "pipe" the output of one command into another command.
+4. From the appropriate command terminal, issue a command to execute the script. The command you use to execute script varies by operating system.
+
+The script runs and prints the output in your terminal. You can run scripts manually, or include them in your automated testing and delivery pipelines.
+
+### Sample script library
+
+Refer to the [Zowe CLI Sample Scripts repository](https://github.com/zowe/zowe-cli-sample-scripts) for examples that cover a wide range of scripting languages and use cases.
+
+### <span id="exampleOne">Example: Clean up Temporary Data Sets</span>
+
+The script in this example lists specified data sets, then loops through the list of data sets and deletes each file. You can use a similar script to clean up temporary data sets after use.
+
+**Note:** Run this script from a bash terminal.
+
+```
+#!/bin/bash
+set -e
+# Project cleanup script - deletes temporary project data sets
+# Obtain the list of temporary project data sets
+dslist=$(zowe files ls ds "my.project.ds*")
+# Delete each data set in the list
+IFS=$'\n'
+for ds in $dslist
+do
+     echo "Deleting Temporary Project Dataset: $ds"
+     zowe files delete ds "$ds" -f
+done
+```
+
+### <span id="exampleTwo">Example: Submit Jobs and Save Spool Output</span>
+
+The script in this example submits a job, waits for the job to enter output status, and saves the spool files to local files on your computer.
+
+**Note:** Run this script from a bash terminal.
+
+```
+#! /bin/env bash
+#submit our job
+jobid=$(zowe zos-jobs submit data-set "boech02.public.cntl(iefbr14)" --rff jobid --rft string)
+echo "Submitted our job, JOB ID is $jobid"
+#wait for job to go to output
+status="UNKNOWN"
+while [[ "$status" != "OUTPUT"]]; do
+    echo "Checking
+    status of job $jobid" status=$(zowe zos-jobs view job-status-by-jobid "$jobid" --rff status --rft string)
+    echo "Current status is $status"
+    sleep 5s
+done;
+echo "Job completed in OUTPUT status. Final result of job: "
+zowe zos-jobs view job-status-by-jobid "$jobid"
+# get a list of all of the spool files for our job now that it's in output
+spool_ids=$(zowe zos-jobs list spool-files-by-jobid "$jobid" --rff id --rft table)
+# save each spool ID to a custom file name
+while read -r id; do
+     zowe zos-jobs view spool-file-by-id "$jobid" "$id" > ./${jobid}_spool_${id}.txt
+     echo "Saved spool DD to ./${jobid}_spool_${id}.txt"
+done <<< "$spool_ids"
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -240,9 +240,21 @@ module.exports = {
             },
             "user-guide/cli-using-integrating-apiml",
             "user-guide/cli-using-working-certificates",
-            "user-guide/cli-using-completing-advanced-tasks",
           ],
         },
+        {
+          type: "category",
+          label: "Using environment variables",
+          items: [
+            "user-guide/cli-using-using-environment-variables",
+            "user-guide/cli-using-formatting-environment-variables",
+            "user-guide/cli-using-setting-environment-variables-in-automation-server",
+                                          ],
+        },
+        "user-guide/cli-using-using-prompt-feature",
+        "user-guide/cli-using-writing-scripts",
+      ],
+    },
         {
           type: "category",
           label: "Zowe CLI plug-ins",


### PR DESCRIPTION
Signed-off-by: anaxceron <ana.ceron@broadcom.com>

Restructured CLI documentation included in [Completing advanced tasks](https://docs.zowe.org/stable/user-guide/cli-using-completing-advanced-tasks) to the following hierarchy:

Using environment variables
- Using environment variables
- Formatting environment variables
- Setting environment variables in an automation server
Using the prompt feature
Writing scripts

