### PR TITLE
master to main updates, typos

### DIFF
--- a/docs/extend/extend-ze/ze-extensions.md
+++ b/docs/extend/extend-ze/ze-extensions.md
@@ -1,3 +1,3 @@
 # Extending Zowe Explorer
 
-You can extend the possibilities of Zowe Explorer by creating you own extensions. For more information on how to create your own Zowe Explorer extension, see [Extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Extending.md).
+You can extend the possibilities of Zowe Explorer by creating you own extensions. For more information on how to create your own Zowe Explorer extension, see [Extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Extending.md).

--- a/docs/getting-started/zowe_faq.md
+++ b/docs/getting-started/zowe_faq.md
@@ -366,7 +366,7 @@ You can also watch [Getting Started with Zowe Explorer](https://www.youtube.com/
 
 <summary></summary>
 
-You can use Zowe Explorer either in [VSCode](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe) or in Theia. For more information about Zowe Explorer in Theia, see [the Theia Readme](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Theia.md).
+You can use Zowe Explorer either in [VSCode](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe) or in Theia. For more information about Zowe Explorer in Theia, see [the Theia Readme](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Theia.md).
 
 </details>
 
@@ -427,6 +427,6 @@ As a developer, you may contribute to Zowe Explorer in the following ways:
 
 - Fix bugs in Zowe Explorer, submit enhancement requests via GitHub issues, and raise your ideas with the community in Slack.
 
-   Note: For more information, see [Extending Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Extending.md).
+   Note: For more information, see [Extending Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Extending.md).
 
 </details>

--- a/docs/user-guide/cli-using-using-environment-variables.md
+++ b/docs/user-guide/cli-using-using-environment-variables.md
@@ -14,6 +14,6 @@ You may want to assign a variable in the following scenarios:
 * **Override a value in existing profiles.**
 
     For example, you might want to override a value that you previously defined in multiple profiles to avoid recreating each profile. Specify the new value as a variable to override the value in profiles.
-* **Secure credentials in an automation server or container**
+* **Secure credentials in an automation server or container.**
     
     You can set environment variables for use in scripts that run in your CI/CD pipeline. For example, can define environment variables in Jenkins so that your password is not seen in plaintext in logs. You can also define sensitive information in the Jenkins secure credential store.

--- a/docs/user-guide/ze-ftp.md
+++ b/docs/user-guide/ze-ftp.md
@@ -2,7 +2,7 @@
 
 Zowe Explorer FTP extension adds the FTP protocol to the [Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe) VS Code extension, allowing you to use [z/OS FTP Plug-in for Zowe CLI](https://github.com/zowe/zowe-cli-ftp-plugin) profiles to connect and interact with z/OS USS.
 
-This VS Code extension also serves as a [source code example](https://github.com/zowe/vscode-extension-for-zowe/tree/master/packages/zowe-explorer-ftp-extension) demonstrating how to use the [Zowe Explorer Extensibility API](https://github.com/zowe/vscode-extension-for-zowe/tree/master/packages/zowe-explorer-api) to create VS Code extensions that extend the Zowe Explorer VS Code extensions with new capabilities.
+This VS Code extension also serves as a [source code example](https://github.com/zowe/vscode-extension-for-zowe/tree/main/packages/zowe-explorer-ftp-extension) demonstrating how to use the [Zowe Explorer Extensibility API](https://github.com/zowe/vscode-extension-for-zowe/tree/main/packages/zowe-explorer-api) to create VS Code extensions that extend the Zowe Explorer VS Code extensions with new capabilities.
 
 ## Prerequisites
 
@@ -125,4 +125,4 @@ Zowe Explorer's FTP extension is now part of the [Zowe Explorer monorepo on Gith
 
 To file issues, use the [Zowe Explorer issue list](https://github.com/zowe/vscode-extension-for-zowe/issues).
 
-For [instructions on how to build](https://github.com/zowe/vscode-extension-for-zowe/tree/master/packages/zowe-explorer-ftp-extension/docs/README.md) the extension, see the `docs` sub-folder.
+For [instructions on how to build](https://github.com/zowe/vscode-extension-for-zowe/tree/main/packages/zowe-explorer-ftp-extension/docs/README.md) the extension, see the `docs` sub-folder.

--- a/docs/user-guide/ze-install.md
+++ b/docs/user-guide/ze-install.md
@@ -1,6 +1,6 @@
 # Visual Studio Code (VS Code) Extension for Zowe
 
-<img src="https://codecov.io/gh/zowe/vscode-extension-for-zowe/branch/master/graph/badge.svg" alt="codecov" scope="external"/>
+<img src="https://codecov.io/gh/zowe/vscode-extension-for-zowe/branch/main/graph/badge.svg" alt="codecov" scope="external"/>
 <img src="https://img.shields.io/badge/chat-on%20Slack-blue" alt="slack" scope="external"/>
 
 The Zowe Explorer extension for Visual Studio Code (VS Code) modernizes the way developers and system administrators interact with z/OS mainframes, and lets you interact with data sets, USS files and jobs. Install the extension directly to [VSCode](https://code.visualstudio.com/) to enable the extension within the GUI. Working with data sets and USS files from VSCode can be more convenient than using 3270 emulators, and complements your Zowe CLI experience. The extension provides the following benefits:
@@ -46,7 +46,7 @@ Use the following steps to install Zowe Explorer:
 
 The extension is now installed and available for use.
 
-* **Note:** For information about how to install the extension from a `VSIX` file and run system tests on the extension, see the [Developer README](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README.md).
+* **Note:** For information about how to install the extension from a `VSIX` file and run system tests on the extension, see the [Developer README](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README.md).
 
 You can also watch the following videos to learn how to get started with Zowe Explorer, and work with data sets.
 
@@ -89,6 +89,6 @@ Configure Zowe Explorer in the settings file of the extension. To access the ext
 
 In this section you can find useful links and other relevant to Zowe Explorer information that can improve your experience with the extension.
 
-* For information about how to develop for Eclipse Theia, see [Theia README](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Theia.md).
-* For information about how to create a VSCode extension for Zowe Explorer, see [VSCode extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Extending.md).
+* For information about how to develop for Eclipse Theia, see [Theia README](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Theia.md).
+* For information about how to create a VSCode extension for Zowe Explorer, see [VSCode extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Extending.md).
 * Visit the **#zowe-explorer** channel on [Slack](https://openmainframeproject.slack.com/) for questions and general guidance.

--- a/sidebars.js
+++ b/sidebars.js
@@ -173,6 +173,7 @@ module.exports = {
       type: "category",
       label: "Installing Zowe Explorer",
       items: [
+        "getting-started/user-roadmap-zowe-explorer",
         "user-guide/ze-install",
         "user-guide/ze-profiles",
       ],


### PR DESCRIPTION
Signed-off-by: anaxceron <ana.ceron@broadcom.com>

- Changed mentions of "master" to "main" in Explorer file names used in Zowe Docs
- Fixed minor consistency deviation in [Using environment variables](https://docs.zowe.org/stable/user-guide/cli-using-using-environment-variables/)
- Added [Information Roadmap for Zowe Explorer](https://docs.zowe.org/stable/getting-started/user-roadmap-zowe-explorer/) to the sidebar ToC

