### PR TITLE
Add clickable release notes overview topic

### DIFF
--- a/docs/getting-started/release-notes/introduction.md
+++ b/docs/getting-started/release-notes/introduction.md
@@ -1,0 +1,4 @@
+# Zowe release notes 
+
+Placeholder file for testing
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -21,6 +21,10 @@ module.exports = {
     {
       type: "category",
       label: "Release notes",
+      link: {
+        type: "doc",
+        id: "getting-started/release-notes/introduction",
+      },
       items: [
         "getting-started/release-notes/v2_4_0",
         "getting-started/release-notes/v2_3_1",
@@ -28,7 +32,7 @@ module.exports = {
         "getting-started/release-notes/v2_2_0",
         "getting-started/release-notes/v2_1_0",
         "getting-started/release-notes/v2_0_0",
-        "getting-started/zowe-office-hours"
+        "getting-started/zowe-office-hours",
       ],
     },
     {


### PR DESCRIPTION
Signed-off-by: nannanli <nannanli@cn.ibm.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Please describe your pull request.

This PR tests the clickable feature of the overview topic. Currently, the high level sections (or wrapper topic) are not clickable, making it incovnenient to summarize what's in the section. 
Here is an example of what we'd like to achieve: https://docusaurus.io/docs/markdown-features  (this is a parent topic and it's clickable topic with content) 

:heart:Thank you!

