### PR TITLE
Move usage of the Personal Access Tokens

### DIFF
--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -27,6 +27,7 @@ Follow the procedures in the following sections to customize Gateway parameters 
   * [Routed instance header](#routed-instance-header)
   * [Distributed load balancer cache](#distributed-load-balancer-cache)
   * [Replace or remove catalog with another service](#replace-or-remove-catalog-with-another-service)
+  * [Personal Access Token](#personal-access-token)
   * [API Mediation Layer as a standalone component](#api-mediation-layer-as-a-standalone-component)
   * [SAF resource checking](#saf-resource-checking)
 
@@ -368,6 +369,19 @@ Use the following procedure to change or replace the Catalog service.
 
     - Set the value to `none` to remove the Catalog service.
     - Set the value to the ID of the service that is onboarded to the API Mediation Layer. 
+
+## Personal Access Token
+
+By default the API Mediation Layer doesn't provide the ability to use personal access tokens. Learn more about
+the functionality in [Personal Access Tokens](user-guide/api-mediation/api-mediation-personal-access-token/)
+
+Use the following procedure to enable the personal access tokens.
+
+**Follow these steps:**
+
+1. Open the file `zowe.yaml`.
+2. Find or add the property with value `components.gateway.apiml.security.personalAccessToken.enabled: true`.
+3. Restart Zowe.
 
 ## API Mediation Layer as a standalone component
 

--- a/docs/user-guide/api-mediation/api-gateway-configuration.md
+++ b/docs/user-guide/api-mediation/api-gateway-configuration.md
@@ -372,15 +372,15 @@ Use the following procedure to change or replace the Catalog service.
 
 ## Personal Access Token
 
-By default the API Mediation Layer doesn't provide the ability to use personal access tokens. Learn more about
-the functionality in [Personal Access Tokens](user-guide/api-mediation/api-mediation-personal-access-token/)
+By default the API Mediation Layer does not provide the ability to use personal access tokens. For more information about about
+this functionality, see [Personal Access Tokens](user-guide/api-mediation/api-mediation-personal-access-token/).
 
-Use the following procedure to enable the personal access tokens.
+Use the following procedure to enable personal access tokens.
 
 **Follow these steps:**
 
 1. Open the file `zowe.yaml`.
-2. Find or add the property with value `components.gateway.apiml.security.personalAccessToken.enabled: true`.
+2. Find or add the property with the value `components.gateway.apiml.security.personalAccessToken.enabled: true`.
 3. Restart Zowe.
 
 ## API Mediation Layer as a standalone component

--- a/docs/user-guide/api-mediation/api-mediation-personal-access-token.md
+++ b/docs/user-guide/api-mediation/api-mediation-personal-access-token.md
@@ -1,9 +1,9 @@
 # Personal Access Token
 
-You can use the API ML to generate, validate, and invalidate a **Personal Access Token (PAT)** that can enable access to tools such as VCS without having to use credentials of a specific person. The use of PAT also does not require storing mainframe credentials, as part of the automation configuration, on a server during  application development on z/OS.
-Additionally, using a PAT makes it possible to limit access when using a token to specific services and users by means of token revocation. 
+You can use the API ML to generate, validate, and invalidate a **Personal Access Token (PAT)** that can enable access to tools such as VCS without having to use credentials of a specific person. The use of PAT also does not require storing mainframe credentials as part of the automation configuration on a server during  application development on z/OS.
+Additionally, using a PAT makes it possible to limit access to specific services and users by means of token revocation when using a token. 
 
-To enable the functionality on your Zowe instance follow the [configuration guide](api-gateway-configuration#personal-access-token).
+To enable this functionality on your Zowe instance, see the [configuration guide](api-gateway-configuration#personal-access-token).
 
 Gateway APIs are available to both users as well as security administrators.
 APIs for users can accomplish the following functions:
@@ -29,7 +29,8 @@ A user can create the Personal Access Token by calling the following REST API en
 
 `POST /auth/access-token/generate`  
 
-The full path of the `/auth/access-token/generate` endpoint appears as `https://{gatewayUrl}:{gatewayPort}/gateway/api/v1/auth/access-token/generate`.
+The full path of the `/auth/access-token/generate` endpoint appears as:  
+`https://{gatewayUrl}:{gatewayPort}/gateway/api/v1/auth/access-token/generate`.
 
 The request requires the body in the following format:
 

--- a/docs/user-guide/api-mediation/api-mediation-personal-access-token.md
+++ b/docs/user-guide/api-mediation/api-mediation-personal-access-token.md
@@ -1,7 +1,9 @@
 # Personal Access Token
 
 You can use the API ML to generate, validate, and invalidate a **Personal Access Token (PAT)** that can enable access to tools such as VCS without having to use credentials of a specific person. The use of PAT also does not require storing mainframe credentials, as part of the automation configuration, on a server during  application development on z/OS.
-Additionally, using a PAT makes it possible to limit access when using a token to specific services and users by means of token revocation.
+Additionally, using a PAT makes it possible to limit access when using a token to specific services and users by means of token revocation. 
+
+To enable the functionality on your Zowe instance follow the [configuration guide](api-gateway-configuration#personal-access-token).
 
 Gateway APIs are available to both users as well as security administrators.
 APIs for users can accomplish the following functions:

--- a/sidebars.js
+++ b/sidebars.js
@@ -306,7 +306,6 @@ module.exports = {
             "user-guide/api-mediation/discovery-service-configuration",
             "user-guide/api-mediation/api-mediation-internal-configuration",
             "extend/extend-apiml/api-mediation-passtickets",
-            "user-guide/api-mediation/api-mediation-personal-access-token",
           ],
         },
       ],
@@ -344,6 +343,7 @@ module.exports = {
         "extend/extend-apiml/api-mediation-routing",
         "extend/extend-apiml/service-information",
         "extend/extend-apiml/websocket",
+        "user-guide/api-mediation/api-mediation-personal-access-token",
       ],
     },
     {


### PR DESCRIPTION
Add configuration documentation

The Personal Access Tokens documentation was hidden in installation section and there was no information on how do you enable the tokens on your instance. 


Signed-off-by: Jakub Balhar <jakub@balhar.net>


