### PR TITLE
fixing broken links in High Avail Overview page

### DIFF
--- a/versioned_docs/version-v2.1.x/user-guide/zowe-ha-overview.md
+++ b/versioned_docs/version-v2.1.x/user-guide/zowe-ha-overview.md
@@ -4,10 +4,15 @@ Zowe has high availability feature built-in. This doc guides you through the con
 
 ## Enable high availability when Zowe runs in Sysplex
 
-- Sysplex is required to make sure multiple Zowe instances can work together. Check [Configuring Sysplex for high availability](./configure-sysplex) for more details.
-- z/OSMF is an optional prerequisite of Zowe. If your Zowe instance works with z/OSMF, it's recommended to [configure z/OSMF for high availability in Sysplex](./systemrequirements-zosmf-ha).
+- Sysplex is required to make sure multiple Zowe instances can work together. Check [Configuring Sysplex for high availability](../user-guide/configure-sysplex) for more details.
+- z/OSMF is an optional prerequisite of Zowe. If your Zowe instance works with z/OSMF, it's recommended to [configure z/OSMF for high availability in Sysplex](../user-guide/systemrequirements-zosmf-ha).
 - The `haInstances` section must be defined in the Zowe YAML configuration. Check [Zowe YAML Configuration File Reference](../appendix/zowe-yaml-configuration.md) for more details.
-- Zowe caching service is required to convert stateful component to stateless component. Check [Configuring the Caching Service for HA](./configure-caching-service-ha) for details.
+- Zowe caching service is required to convert stateful component to stateless component. Check [Configuring the Caching Service for HA](../user-guide/configure-caching-service-ha) for details.
+
+
+(../user-guide/cli-using-using-profiles.md#base-profiles).
+
+
 
 ### Known limitations
 
@@ -18,5 +23,5 @@ Zowe has high availability feature built-in. This doc guides you through the con
 
 If you deploy Zowe into Kubernetes, all components can also achieve high availability if you enable more than one replicas for each component.
 
-- [HorizontalPodAutoscaler](./k8s-config#horizontalpodautoscaler) is recommanded to let Kubernetes scales the component based on workdload.
-- [PodDisruptionBudget](./k8s-config#poddisruptionbudget) is recommended to let Kubernetes automatically handles disruptions like upgrade.
+- [HorizontalPodAutoscaler](../user-guide/k8s-config#horizontalpodautoscaler) is recommanded to let Kubernetes scales the component based on workdload.
+- [PodDisruptionBudget](../user-guide/k8s-config#poddisruptionbudget) is recommended to let Kubernetes automatically handles disruptions like upgrade.


### PR DESCRIPTION
Fixed broken links in [Overview](https://docs.zowe.org/stable/user-guide/zowe-ha-overview) page for High Availability per comment made in zowe-doc Slack channel by Jakub Balhar

