### PR TITLE
Document RAUDITX optional resource in the resource table

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -24,7 +24,7 @@ All Zowe server components can be installed on a z/OS environment, while some ca
   - [Memory requirements](#memory-requirements)
 ## z/OS system requirements
 
-Be sure your z/OS system meets the following prerequisites.
+Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
@@ -90,7 +90,7 @@ The task starts a USS environment using `BPXBATSL` that executes the core Zowe D
 | FACILITY | `IRR.RUSERMAP` | READ | To allow Zowe to [map an X.509 client certificate to a z/OS identity](./configure-zos-system.md#configure-main-zowe-server-to-use-identity-mapping) | 
 | FACILITY | `BPX.JOBNAME` | READ | To allow z/OS address spaces for unix processes to be renamed for [ease of identification](./configure-zos-system.md#configure-address-space-job-naming) |
 | FACILITY | `IRR.RADMIN.LISTUSER` | READ | To allow Zowe to obtain information about OMVS segment of the user profile using `LISTUSER` TSO command |
-| FACILITY | `IRR.RAUDITX` | READ | **Optional** To allow the Mediation Layer to issue SMF 83 records about activity of Personal Access Tokens. [See here for more info](./api-mediation/api-mediation-smf) |
+| FACILITY | `IRR.RAUDITX` | READ | **Optional** To allow API Mediation Layer to issue SMF 83 records about activity of Personal Access Tokens. [See here for more info](./api-mediation/api-mediation-smf) |
 | APPL     | 'OMVSAPPL' | READ | **Optional** To allow Zowe Desktop vendor extensions the ability to use single-sign on.  |
 
 

--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -90,7 +90,7 @@ The task starts a USS environment using `BPXBATSL` that executes the core Zowe D
 | FACILITY | `IRR.RUSERMAP` | READ | To allow Zowe to [map an X.509 client certificate to a z/OS identity](./configure-zos-system.md#configure-main-zowe-server-to-use-identity-mapping) | 
 | FACILITY | `BPX.JOBNAME` | READ | To allow z/OS address spaces for unix processes to be renamed for [ease of identification](./configure-zos-system.md#configure-address-space-job-naming) |
 | FACILITY | `IRR.RADMIN.LISTUSER` | READ | To allow Zowe to obtain information about OMVS segment of the user profile using `LISTUSER` TSO command |
-| FACILITY | `IRR.RAUDITX` | READ | **Optional** To allow the Mediation Layer to issue SMF 83 records about activity of Personal Access Tokens. [See here for more info](./api-mediation/api-mediation-smf)
+| FACILITY | `IRR.RAUDITX` | READ | **Optional** To allow the Mediation Layer to issue SMF 83 records about activity of Personal Access Tokens. [See here for more info](./api-mediation/api-mediation-smf) |
 | APPL     | 'OMVSAPPL' | READ | **Optional** To allow Zowe Desktop vendor extensions the ability to use single-sign on.  |
 
 

--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -90,7 +90,9 @@ The task starts a USS environment using `BPXBATSL` that executes the core Zowe D
 | FACILITY | `IRR.RUSERMAP` | READ | To allow Zowe to [map an X.509 client certificate to a z/OS identity](./configure-zos-system.md#configure-main-zowe-server-to-use-identity-mapping) | 
 | FACILITY | `BPX.JOBNAME` | READ | To allow z/OS address spaces for unix processes to be renamed for [ease of identification](./configure-zos-system.md#configure-address-space-job-naming) |
 | FACILITY | `IRR.RADMIN.LISTUSER` | READ | To allow Zowe to obtain information about OMVS segment of the user profile using `LISTUSER` TSO command |
-| APPL     | 'OMVSAPPL' | READ | **Optional** To allow Zowe Desktop vendor extensions the ability to use single-sign on.  
+| FACILITY | `IRR.RAUDITX` | READ | **Optional** To allow the Mediation Layer to issue SMF 83 records about activity of Personal Access Tokens. [See here for more info](./api-mediation/api-mediation-smf)
+| APPL     | 'OMVSAPPL' | READ | **Optional** To allow Zowe Desktop vendor extensions the ability to use single-sign on.  |
+
 
 ### ZWESIUSR
 


### PR DESCRIPTION
https://github.com/zowe/zowe-install-packaging/pull/3198 and its associated documentation adds an optional requirement for a resource to write SMF records.  This is listed in the documentation, but not in the easy-to-find table. So, I added it to the table and linked the table to the prior documentation.