### PR TITLE
(master) Fix Doc website out of date search results + non-working v2.1-2.4 search results

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -164,9 +164,10 @@ module.exports = {
       copyright: `© Open Mainframe Project. a Linux Foundation Project. All Rights Reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page. Please refer to Marketing and Branding Guidelines for name usage guidelines. Linux is a registered trademark of Linus Torvalds. Privacy Policy and Terms of Use`,
     },
     algolia: {
-      apiKey: "59ff39ed48d0820010c7e09fc4b677bf",
+      apiKey: "65cba55ab266253898f7ad088e57be78",
       indexName: "zowe",
       contextualSearch: true,
+      appId: "1AB1S8E42B"
     },
     colorMode: {
       defaultMode: "light",

--- a/src/components/SearchHeader/SearchHeader.js
+++ b/src/components/SearchHeader/SearchHeader.js
@@ -6,7 +6,7 @@ function SearchHeader() {
   const facetFilters = useAlgoliaContextualFacetFilters();
   return (
     <DocSearch
-    apiKey="59ff39ed48d0820010c7e09fc4b677bf"
+    apiKey="65cba55ab266253898f7ad088e57be78"
     indexName="zowe"
     searchParameters={{
       facetFilters


### PR DESCRIPTION
Signed-off-by: Leanid Astrakou <LeanyIA@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
1) fixes current Doc website out of date search results (for example: configuration manager is not searchable) and
2) fixes search results for v2.1 --> v2.4 not working
by update indexing keys to match our up-to-date working Algolia Zowe index

:heart:Thank you!

