### PR TITLE
server return codes explanation

### DIFF
--- a/docs/troubleshoot/app-framework/app-return-codes.md
+++ b/docs/troubleshoot/app-framework/app-return-codes.md
@@ -1,0 +1,11 @@
+# app-server Return Codes
+
+If the app-server abnormally ends with a return code, this may originate from the app-server itself or from the programs involved in starting the server. [Return codes from the startup process are documented here](../servers/return-codes), while the app-server specific codes are listed below.
+
+| Return code | Explanation |
+|-------------|-------------|
+| 2           | Generic cause, check logs for more information. |
+| 3           | Insufficient authentication configuration. The server found no authentication plugins, or all of the plugins found failed to load, or no plugins were found for the specific default auth type requested, or the entire auth configuration was missing. More specific error messages will be found in the logs. |
+| 4           | The server encountered an error when reading the PFX file requested in the HTTPS configuration. ZWED0070W in the logs will explain the error in more detail. |
+| 5           | The server could not establish networking for one of several possible reasons, and a ZWED error message in the logs will explain the error in more detail. |
+| 7           | The configuration requested loading a z/OS keyring when not running on z/OS. The error ZWED0145E is also logged. |

--- a/docs/troubleshoot/servers/return-codes.md
+++ b/docs/troubleshoot/servers/return-codes.md
@@ -1,0 +1,13 @@
+# Diagnosing Return Codes
+
+If one of the Zowe servers ends abnormally with a return code, then this return code may be used as a clue to determine the cause of the failure. The meaning of a return code depends upon which program generated it; many return codes can originate from operating system utilities rather than from Zowe itself, but some may originate from Zowe too. Knowing which program generated the return code is important to finding the relevant documentation on the code. For example, if you tried to run the `app-server` and received a return code from a failure, it could have originated from, in order of execution, the Launcher, shell code and shell utilities such as `cat` or `mkdir`, `zwe`, and finally the app-server itself.
+
+Return codes that can arise from any of the servers due to the chain of events that start Zowe may be found in the following documentation:
+
+* [Zowe launcher error codes](../launcher/launcher-error-codes)
+* The z/OS shell and programs called from the shell such as `cat`, `mkdir`, `node` or `java`:
+    * Return codes ("errno"): https://www.ibm.com/docs/en/zos/2.5.0?topic=codes-return-errnos
+    * Reason codes ("errnojr"): https://www.ibm.com/docs/en/zos/2.5.0?topic=codes-reason-errnojrs
+* `zwe` error codes are documented specific to each `zwe` subcommand visible within the `--help` option of `zwe` or [on the zwe reference page](../../appendix/zwe_server_command_reference/zwe/zwe). Searching for "ZWEL" plus your error code in the search bar of the documentation website will likely bring you to the appropriate page.
+
+Error codes for the specific Zowe servers may be found in their own troubleshooting sections.

--- a/sidebars.js
+++ b/sidebars.js
@@ -585,6 +585,7 @@ module.exports = {
         "troubleshoot/servers/must-gather",
         "troubleshoot/verify-fingerprint",
         "troubleshoot/k8s-troubleshoot",
+        "troubleshoot/servers/return-codes",
         //"troubleshoot/troubleshoot-zos-certificate",
         {
           type: "category",
@@ -601,6 +602,7 @@ module.exports = {
             "troubleshoot/app-framework/app-troubleshoot",
             "troubleshoot/app-framework/app-mustgather",
             "troubleshoot/app-framework/app-issue",
+            "troubleshoot/app-framework/app-return-codes",
             "troubleshoot/app-framework/zss-error-codes",
           ],
         },
@@ -612,7 +614,6 @@ module.exports = {
             "troubleshoot/launcher/launcher-error-codes"
           ],
         },
-        "troubleshoot/verify-fingerprint",
       ],
     },
     {


### PR DESCRIPTION
This adds 2 new documents.
1 page which explains how to find the meaning of generic return codes NOT originating from Zowe servers, but instead from system utilities or Zowe startup programs.
Then it adds another page on app-server specific return codes.

I also found the verify-fingerprint page to be duplicated on the troubleshoot section so fixed that too.