### PR TITLE
Fix infinite loop in "docs:pdf" script

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -610,7 +610,6 @@ module.exports = {
             "troubleshoot/launcher/launcher-error-codes"
           ],
         },
-        "troubleshoot/verify-fingerprint",
       ],
     },
     {


### PR DESCRIPTION
Thanks to @awharn for helping to debug and fix these issues 🙂 

* Fixes infinite loop in "docs:pdf" script caused by `sidebars.js` referencing the same article twice
* ~Restores file `api-mediation-security.md` that seems to have been accidentally removed causing broken links~
  Determined this file was removed intentionally, the broken links will be fixed in a subsequent PR
* ~Updates dependencies to fix some vulnerabilities~
  Reverted since it seemed to be making the Netlify build time out