### PR TITLE
Fix links to API ML security

### DIFF
--- a/docs/extend/extend-apiml/api-mediation-passtickets.md
+++ b/docs/extend/extend-apiml/api-mediation-passtickets.md
@@ -5,7 +5,7 @@ For more information, see [Authentication with PassTickets](authentication-for-a
 
 ## Overview
 API clients can use either a Zowe JWT token or client certificate to access an API service even if the API service itself does not support the JWT token or client certificate.
-The Zowe JWT token is available through the API Gateway [authentication endpoint](../extend-apiml/api-mediation-security.md#authentication-for-api-ml-services).
+The Zowe JWT token is available through the API Gateway [authentication endpoint](../extend-apiml/authentication-for-apiml-services).
 
 When an API client provides a valid Zowe JWT token or client certificate to the API ML, the API Gateway then generates a valid PassTicket for any API service that supports PassTickets.
 The API Gateway then uses the PassTicket to access that API service.

--- a/docs/extend/extend-apiml/api-mediation-sso.md
+++ b/docs/extend/extend-apiml/api-mediation-sso.md
@@ -45,7 +45,7 @@ This section describes the requirements that an API service needs to satisfy to 
 * The API service can validate the token and extract information about the user ID by calling the ZAAS `/query` endpoint. 
 * The alternative is to validate the signature of the JWT token using the public key of the token issuer (e.g. the API ML Gateway). The API service needs to have the API ML Gateway certificate along with the full CA certification chain in the API service truststore. 
 
-**Note:** The REST API of ZAAS can easily be called from a Java application using the [ZAAS Client](api-mediation-security.md#zaas-client).
+**Note:** The REST API of ZAAS can easily be called from a Java application using the [ZAAS Client](zaas-client.md)
 
 ### Existing services that cannot be modified
 
@@ -55,7 +55,7 @@ If you have a service that cannot be changed to adopt the Zowe authentication to
 
 ## Further resources
 
-* [Authentication Methods](api-mediation-security.md#Supported-authentication-methods)
+* [Authentication Methods](./authentication-for-apiml-services/#supported-authentication-methods)
 * [User guide for SSO in Zowe CLI ](https://docs.zowe.org/stable/user-guide/cli-usingcli#accessing-multiple-services-with-sso)
 * [System requirements for using web tokens for SSO in Zlux and ZSS](https://docs.zowe.org/stable/user-guide/systemrequirements#using-web-tokens-for-sso-on-zlux-and-zss)
 * [Certificate configuration for the usage of web tokens for SSO in Zlux and ZSS](https://docs.zowe.org/stable/user-guide/configure-certificates#using-web-tokens-for-sso-on-zlux-and-zss) 

--- a/docs/extend/extend-apiml/certificate-management-in-zowe-apiml.md
+++ b/docs/extend/extend-apiml/certificate-management-in-zowe-apiml.md
@@ -231,3 +231,57 @@ In this example, you receive a similar response:
 The message has the key `apiml.common.tlsError`, and message number `AML0105`. The content explains details about the message.
 
 If you receive this message, import the certificate of your service or the CA that signed it to the truststore of the API Mediation Layer as described previously.
+
+## API ML truststore and keystore
+
+A _keystore_ is a repository of security certificates consisting of either authorization certificates or public key certificates with corresponding private keys (PK), used in TLS encryption. A _keystore_ can be stored in Java specific format (JKS) or use the standard format (PKCS12). The Zowe API ML uses PKCS12 to enable the keystores to be used
+by other technologies in Zowe (Node.js).
+## API ML SAF Keyring
+
+As an alternative to using a keystore and truststore, API ML can read certificates from a SAF keyring. The user running the API ML must have rights to access the keyring. From the java perspective, the keyring behaves as the `JCERACFKS` keystore. The path to the keyring is specified as `safkeyring:////user_id/key_ring_id`. The content of SAF keyring is equivalent to the combined contents of the keystore and the truststore.
+
+**Note:** When using JCEFACFKS as the keystore type, ensure that you define the class to handle the RACF keyring using the `-D` options to specify the `java.protocol.handler.pkgs property`:
+
+    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider
+
+The elements in the following list, which apply to the API ML SAF Keyring, have these corresponding characteristics:
+
+**The API ML local certificate authority (CA)**
+
+- The API ML local CA contains a local CA certificate and a private key that needs to be securely stored.
+- The API ML local certificate authority is used to sign certificates of services.
+- The API ML local CA certificate is trusted by API services and clients.
+
+**The API ML keystore or API ML SAF Keyring**
+
+- Server certificate of the Gateway (with PK). This can be signed by the local CA or an external CA.
+- Server certificate of the Discovery Service (with PK). This can be signed by the local CA.
+- Server certificate of the Catalog (with PK). This can be signed by the local CA.
+- Private asymmetric key for the JWT token, alias `jwtsecret`. The public key is exported to the `localhost.keystore.jwtsecret.cer` directory.
+- The API ML keystore is used by API ML services.
+
+**The API ML truststore or API ML SAF Keyring**
+
+- Local CA public certificate.
+- External CA public certificate (optional).
+- Can contain self-signed certificates of API Services that are not signed by the local or external CA.
+- Used by API ML services.
+
+**Zowe core services**
+
+- Services can use the same keystore and truststore or the same keyring as APIML for simpler installation and management.
+- When using a keystore and truststore, services have to have rights to access and read them on the filesystem.
+- When using a keyring, the user of the service must have authorization to read the keyring from the security system.
+- Alternatively, services can have individual stores for higher security.
+
+**API service keystore or SAF keyring** (for each service)
+
+- The API service keystore contains a server and client certificate signed by the local CA.
+
+**API service truststore or SAF keyring** (for each service)
+
+- (Optional) The API service truststore contains a local CA and external CA certificates.
+
+**Client certificates**
+
+- A client certificate is a certificate that is used for validation of the HTTPS client. The client certificate of a Discovery Service client can be the same certificate as the server certificate of the services which the Discovery Service client uses.

--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -56,7 +56,7 @@
 
 * **customMetadata.apiml.gatewayAuthEndpoint**
 
-  Specifies the Gateway authentication endpoint used by the ZAAS Client configuration. The default value is `/api/v1/gateway/auth`. For more information about ZAAS Client, see [ZAAS Client](api-mediation-security.md#zaas-client).
+  Specifies the Gateway authentication endpoint used by the ZAAS Client configuration. The default value is `/api/v1/gateway/auth`. For more information about ZAAS Client, see [ZAAS Client](zaas-client.md)
 
   **Note:** If you use the Spring enabler, use the following parameter name:
 

--- a/docs/extend/extend-apiml/onboard-overview.md
+++ b/docs/extend/extend-apiml/onboard-overview.md
@@ -23,7 +23,7 @@ Meet the following prerequisites before you onboard your service:
   
 - A certificate that is trusted by Zowe and certificate(s) to trust Zowe services
 
-  Zowe uses secured communication over TLSv1.2. As such, the protocol version and the certificate is required. For more information, see [API Mediation Layer security setup](api-mediation-security.md#certificate-management-in-zowe-api-mediation-layer) and [Zowe API ML TLS requirements](api-mediation-security.md#Zowe-API-ML-TLS-requirements).
+  Zowe uses secured communication over TLSv1.2. As such, the protocol version and the certificate is required. For more information, see [API Mediation Layer security setup](api-mediation-security.md#certificate-management-in-zowe-api-mediation-layer) and [Zowe API ML TLS requirements](zowe-api-mediation-layer-security-overview.md/#zowe-api-ml-tls-requirements)
 
 - A REST API-enabled service that you want to onboard
 

--- a/docs/extend/extend-apiml/onboard-plain-java-enabler.md
+++ b/docs/extend/extend-apiml/onboard-plain-java-enabler.md
@@ -536,7 +536,7 @@ where:
 
 ### Authentication parameters
 
-These parameters are not required. Default values are used when parameters are not specified. For more information, see [Authentication Parameters for Onboarding REST API Services](api-mediation-security#authentication-parameters).
+These parameters are not required. Default values are used when parameters are not specified. For more information, see [Authentication Parameters for Onboarding REST API Services](authentication-for-apiml-services.md/#authentication-parameters).
     
 ### API Security
 
@@ -573,7 +573,7 @@ TLS/SSL configuration consists of the following parameters:
 
 * **keyStore**
 
-  This parameter specifies the keystore file used to store the private key. When using keyring, the value should be set to the SAF keyring location. For information about required certificates, see [Zowe API ML TLS requirements](api-mediation-security#zowe-api-ml-tls-requirements).
+  This parameter specifies the keystore file used to store the private key. When using keyring, the value should be set to the SAF keyring location. For information about required certificates, see [Zowe API ML TLS requirements](zowe-api-mediation-layer-security-overview.md/#zowe-api-ml-tls-requirements).
 
   If you have an issue with loading the keystore file in your environment, try to provide the absolute path to the keystore file. The sample keystore file for local deployment is in [api-layer repository](https://github.com/zowe/api-layer/tree/master/keystore/localhost)
 
@@ -587,7 +587,7 @@ TLS/SSL configuration consists of the following parameters:
 
 * **trustStore**
 
-  This parameter specifies the truststore file used to keep other parties public keys and certificates. When using keyring, this value should be set to the SAF keyring location. For information about required certificates, see [Zowe API ML TLS requirements](api-mediation-security#zowe-api-ml-tls-requirements).
+  This parameter specifies the truststore file used to keep other parties public keys and certificates. When using keyring, this value should be set to the SAF keyring location. For information about required certificates, see [Zowe API ML TLS requirements](./zowe-api-mediation-layer-security-overview.md/#zowe-api-ml-tls-requirements).
 
   If you have an issue with loading the truststore file in your environment, try to provide the absolute path to the truststore file. The sample truststore file for local deployment is in [api-layer repository](https://github.com/zowe/api-layer/tree/master/keystore/localhost)
 

--- a/docs/extend/extend-apiml/onboard-plain-java-enabler.md
+++ b/docs/extend/extend-apiml/onboard-plain-java-enabler.md
@@ -547,7 +547,7 @@ The Zowe API ML Discovery Service communicates with its clients in secure Https 
 Client services need to configure several TLS/SSL parameters in order to communicate with the API ML Discovery service.
 When an enabler is used to onboard a service, the configuration is provided in the `ssl` section/group in the same _YAML_ file that is used to configure the Eureka parameters and the service metadata.
 
-For more information about API ML security, see [API ML security](api-mediation-security).
+For more information about API ML security, see [API ML security overview](zowe-api-mediation-layer-security-overview.md).
 
 TLS/SSL configuration consists of the following parameters:
 

--- a/docs/extend/extend-apiml/onboard-plain-java-enabler.md
+++ b/docs/extend/extend-apiml/onboard-plain-java-enabler.md
@@ -604,7 +604,7 @@ TLS/SSL configuration consists of the following parameters:
 ### SAF Keyring configuration
 
 You can choose to use SAF keyring instead of keystore and truststore for storing certificates.
-For information about required certificates, see [Zowe API ML TLS requirements](api-mediation-security#zowe-api-ml-tls-requirements). For information about running Java on z/OS with keyring, see [SAF Keyring](api-mediation-security#api-ml-saf-keyring). Make sure that the enabler can access and read the keyring. Please refer to documentation of your security system for details.
+For information about required certificates, see [Zowe API ML TLS requirements](./zowe-api-mediation-layer-security-overview.md/#zowe-api-ml-tls-requirements). For information about running Java on z/OS with keyring, see [SAF Keyring](./certificate-management-in-zowe-apiml.md) Make sure that the enabler can access and read the keyring. Please refer to documentation of your security system for details.
 
 The following example shows enabler configuration with keyrings.
 

--- a/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
+++ b/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
@@ -314,7 +314,7 @@ A property notation provided in the format `-Dproperty.key=PROPERTY_VALUE` can b
 in any of the YAML configuration files.
 
 ### Authentication properties
-These parameters are not required. If a parameter is not specified, a default value is used. See [Authentication Parameters for Onboarding REST API Services](../extend-apiml/api-mediation-security.md#authentication-parameters) for more details.
+These parameters are not required. If a parameter is not specified, a default value is used. See [Authentication Parameters for Onboarding REST API Services](./authentication-for-apiml-services.md/#authentication-parameters) for more details.
 
 ### API ML Onboarding Configuration Sample
 
@@ -440,7 +440,7 @@ logging:
 ### SAF Keyring configuration
 
 You can choose to use a SAF keyring instead of keystore and truststore for storing certificates.
-For information about required certificates, see [Zowe API ML TLS requirements](api-mediation-security.md#zowe-api-ml-tls-requirements). For information about running Java on z/OS with a keyring, see [SAF Keyring](api-mediation-security.md#API-ML-SAF-Keyring). Make sure that the enabler can access and read the keyring. Please refer to documentation of your security system for details.
+For information about required certificates, see [Zowe API ML TLS requirements](./zowe-api-mediation-layer-security-overview.md/#zowe-api-ml-tls-requirements). For information about running Java on z/OS with a keyring, see [SAF Keyring](./certificate-management-in-zowe-apiml.md). Make sure that the enabler can access and read the keyring. Please refer to documentation of your security system for details.
 
 The following example shows enabler configuration with keyrings: 
 ```

--- a/docs/user-guide/cli-using-working-certificates.md
+++ b/docs/user-guide/cli-using-working-certificates.md
@@ -6,7 +6,7 @@ System Administrators can configure the server with a certificate signed by a Ce
 **Related information:**
 - [Using certificates with z/OS client/server applications](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.icha700/icha700_Using_certificates_with_z_OS_client_server_applications.htm) in the IBM Knowledge Center.
 - [Configuring the z/OSMF key ring and certificate](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.izua300/izuconfig_KeyringAndCertificate.htm) in the IBM Knowledge Center.
-- [Certificate management in Zowe API Mediation Layer](../extend/extend-apiml/api-mediation-security.md#certificate-management-in-zowe-api-mediation-layer)
+- [Certificate management in Zowe API Mediation Layer](../extend/extend-apiml/certificate-management-in-zowe-apiml.md)
 - [Mozilla Included CA Certificate List](https://wiki.mozilla.org/CA/Included_Certificates)
 ## Extend trusted certificates on client
 If your organization uses self-signed certificates in the certificate chain (rather than a CA trusted by Mozilla), you can download the certificate to your computer add it to the local list of trusted certificates. Provide the certificate locally using the `NODE_EXTRA_CA_CERTS` environment variable. Organizations might want to configure all client computers to trust the self-signed certificate.

--- a/docs/user-guide/configure-certificates-keystore.md
+++ b/docs/user-guide/configure-certificates-keystore.md
@@ -106,7 +106,7 @@ When using a self-signed certificate, you will be challenged by your browser whe
 
 ### Manually import a certificate authority into a web browser
 
-To avoid the browser untrusted CA challenge, you can import Zowe's certificates into the browser to avoid untrusted network traffic challenges. For more information, see [Import the local CA certificate to your browser](../extend/extend-apiml/api-mediation-security.md#import-the-local-ca-certificate-to-your-browser). 
+To avoid the browser untrusted CA challenge, you can import Zowe's certificates into the browser to avoid untrusted network traffic challenges. For more information, see [Import the local CA certificate to your browser](../extend/extend-apiml/certificate-management-in-zowe-apiml.md/#import-the-local-ca-certificate-to-your-browser).
 
 To avoid requiring each browser to trust the CA that signed the Zowe certificate, you can use a public certificate authority such as _Symantec_, _Comodo_, _Let's Encrypt_, or _GoDaddy_to create a certificate. These certificates are trusted by all browsers and most REST API clients. This option, however, requires a manual process to request a certificate and may incur a cost payable to the publicly trusted CA.
 


### PR DESCRIPTION
This PR fixes broken links to the deprecated api-mediation-security.md. links are redirected to current .md files.
This PR also returns the following sections which were lost during chunking:

- API ML truststore and keystore
- API ML SAF Keyring