### PR TITLE
removed deleted APIML article from sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -318,7 +318,6 @@ module.exports = {
             "user-guide/api-mediation/api-catalog-configuration",
             "user-guide/api-mediation/api-gateway-configuration",
             "user-guide/api-mediation/discovery-service-configuration",
-            "user-guide/api-mediation/api-mediation-internal-configuration",
             "extend/extend-apiml/api-mediation-passtickets",
           ],
         },


### PR DESCRIPTION
Removed APIML article that was deleted in [PR 2622](https://github.com/zowe/docs-site/pull/2622/files#diff-9a6a0fdafefb0eecffb77784bc94f5ad984062167b8bcb7c4a899c90f6f567e8) from the Zowe Docs sidebar. The article (user-guide/api-mediation/api-mediation-internal-configuration) was causing an error in our Zowe v 2.7 doc prep.