### PR TITLE
Update sidebars.js for missing link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -502,6 +502,7 @@ module.exports = {
       items: [
         "extend/packaging-zos-extensions",
         "extend/server-schemas",
+        "extend/component-registries",
         "extend/lifecycling-with-zwesvstc",
         "extend/k8s-extend",
         "extend/k8s-conformance",


### PR DESCRIPTION
Added missing component registries page, https://docs.zowe.org/stable/extend/component-registries/ that currently cannot be found from the sidebar.