### PR TITLE
removing duplicate article from sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -314,7 +314,6 @@ module.exports = {
         "user-guide/mvd-configuration",
         "user-guide/cli-configuringcli-ev",
         "user-guide/cli-configuringcli-evfile",
-        "user-guide/configure-data-sets-jobs-api",
         {
           type: "category",
           label: "API Mediation Layer",


### PR DESCRIPTION
Removing a second instance of the **Configuring the Zowe APIs** article from the sidebar. The article appears twice and it should appear only once.