### PR TITLE
minor edits to v2.7 release notes and Doc Squad Release handbook

### DIFF
--- a/docs/contribute/guidelines-code/documentation.md
+++ b/docs/contribute/guidelines-code/documentation.md
@@ -35,7 +35,7 @@ Principles of operation and end-user guides (configuration, troubleshooting) sho
 
 Provide a readme.md file for developers (overview, build, test) as well as end-user documentation for your plug-in on Zowe Docs site. 
 
-For more information, see the CLI [documentation contribution guidelines](https://github.com/zowe/zowe-cli/blob/conformance/CONTRIBUTING.md#documentation-guidelines).
+For more information, see the CLI [documentation contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md#documentation-guidelines).
 
 ### Core CLI Imperative CLI Framework
 

--- a/docs/extend/extend-cli/cli-developing-a-plugin.md
+++ b/docs/extend/extend-cli/cli-developing-a-plugin.md
@@ -276,7 +276,7 @@ Follow these steps:
 
 Before you test your new command, confirm that you are able to connect to the mainframe.
 
-In order for the client-side API to reach the mainframe (to fetch data sets), Zowe CLI needs a z/OSMF profile for access. See [Using profiles](https://docs.zowe.org/stable/user-guide/cli-using-using-profiles/) for information. 
+In order for the client-side API to reach the mainframe (to fetch data sets), Zowe CLI needs a z/OSMF profile for access. See [Team configurations](https://docs.zowe.org/stable/user-guide/cli-using-using-team-profiles/) for information. 
 
 Once the connection between Zowe CLI and z/OSMF is confirmed, build and install the plug-in before running it for the first time.
 

--- a/docs/extend/extend-cli/cli-extending-a-plugin.md
+++ b/docs/extend/extend-cli/cli-extending-a-plugin.md
@@ -73,7 +73,7 @@ and to call a REST API. See the [Imperative CLI Framework documentation](https:/
 
 #### Exporting interface and programmatic API for other Node.js applications
 
-Update [zowe-cli-sample-plugin/src/index.ts](https://github.com/zowe/zowe-cli-sample-plugin/src/index.ts) to contain the following:
+Update [zowe-cli-sample-plugin/src/index.ts](https://github.com/zowe/zowe-cli-sample-plugin/blob/master/src/index.ts) to contain the following:
 
 ```typescript
 export * from "./api/doc/ITodo";

--- a/docs/getting-started/release-notes/v2_7_0.md
+++ b/docs/getting-started/release-notes/v2_7_0.md
@@ -159,4 +159,8 @@ The following security issues were fixed by the Zowe security group in version 2
 - BDSA-2022-2583
 - CVE-2022-40151 (BDSA-2022-2580)
 - CVE-2022-40152 (BDSA-2022-2582)
+- CVE-2022-3517
+- CVE-2022-37603 (BDSA-2022-3812)
+- CVE-2022-37601 (BDSA-2022-3814)
+- CVE-2022-37599 (BDSA-2022-3811)
 

--- a/docs/getting-started/zowe-resources.md
+++ b/docs/getting-started/zowe-resources.md
@@ -64,7 +64,7 @@ The [OMP Youtube channel](https://www.youtube.com/channel/UC-WTXQQtz2m5iTflJLK59
 
 **Trials**
 
-- [Zowe trial](https://www.openmainframeproject.org/projects/zowe/ztrial)
+- [Zowe trial](https://early-access.ibm.com/software/support/trial/cst/welcomepage.wss?siteId=936&tabId=2216&w=1&_ga=2.15671350.1464775468.1660748024-1918080361.1653724208)
 
    The Zowe trial hosted by IBM is a fully configured z/OS environment with Zowe preinstalled and set up along with a set of integrated easy-to-follow tutorials that walk you through the basics of Zowe and gives you hands-on experience of extending Zowe. This no-charge trial is available in two hours for three days. 
 

--- a/docs/user-guide/cli-using-test-zosmf-connection.md
+++ b/docs/user-guide/cli-using-test-zosmf-connection.md
@@ -4,7 +4,7 @@ Optionally, issue a command at any time to receive diagnostic information from t
 
 Refer to the following sections for instructions on how to connect to z/OSMF with different types of profiles.
 
-**Important!** By default, the server certificate is verified against a list of Certificate Authorities (CAs) trusted by Mozilla. This handshake ensures that the CLI can trust the server. You can append the flag `--ru false` to the following commands to bypass the certificate verification against CAs. If you use the `--ru false` flag, ensure that you understand the potential security risks of bypassing the certificate requirement at your site. For the most secure environment, system administrators configure a server keyring with a server certificate signed by a Certificate Authority (CA). For more information, see [Working with certificates](#working-with-certificates).
+**Important!** By default, the server certificate is verified against a list of Certificate Authorities (CAs) trusted by Mozilla. This handshake ensures that the CLI can trust the server. You can append the flag `--ru false` to the following commands to bypass the certificate verification against CAs. If you use the `--ru false` flag, ensure that you understand the potential security risks of bypassing the certificate requirement at your site. For the most secure environment, system administrators configure a server keyring with a server certificate signed by a Certificate Authority (CA). For more information, see [Working with certificates](../user-guide/cli-using-working-certificates).
 
 ### Without a profile
 
@@ -32,7 +32,7 @@ zowe zosmf check status --host <host> --port <port> --user <username> --pass <pa
 
 ### Default profile
 
-After you create a profile in a configuration (such as a [global team configuration file](../user-guide/initializing-team-configuration)), verify that you can use your *default profile* to communicate with z/OSMF:
+After you create a profile in a configuration (such as a [global team configuration file](../user-guide/cli-using-initializing-team-configuration)), verify that you can use your *default profile* to communicate with z/OSMF:
 
 ```
 zowe zosmf check status
@@ -40,7 +40,7 @@ zowe zosmf check status
 
 ### Specific profile
 
-After you create a specific profile in a configuration (such as a [global team configuration file](../user-guide/initializing-team-configuration)), verify that you can use a *specific profile* to communicate with z/OSMF:
+After you create a specific profile in a configuration (such as a [global team configuration file](../user-guide/cli-using-initializing-team-configuration)), verify that you can use a *specific profile* to communicate with z/OSMF:
 
 ```
 zowe zosmf check status --zosmf-profile <profile_name>

--- a/release-handbook/release_handbook.md
+++ b/release-handbook/release_handbook.md
@@ -2,16 +2,18 @@
 
 Learn how to handle the documentation for Zowe releases.
 
-- [Release communication](#release-communication)
+- [Release schedule](#release-schedule)
 - [Preparing documentation for a new release](#preparing-documentation-for-a-new-release)
     - [Before you begin](#before-you-begin)
     - [Part 1: Archive the previous release doc](#part-1-archive-the-previous-release-doc)
     - [Part 2: Bump the release version](#part-2-bump-the-release-version)
     - [Part 3: Prepare new release files](#part-3-prepare-new-release-files)
     - [What to do next](#what-to-do-next)
-- [Sycn changes between releases](#sycn-changes-between-releases)
+- [Sync changes between releases](#sync-changes-between-releases)
 - [Publish documentation for a new release](#publish-documentation-for-a-new-release)
-- [Remove archived version](#remove-archived-version)
+- [Removing archived version](#removing-archived-version)
+- [Zowe CLI: Update web help and type doc](#zowe-cli-update-web-help-and-type-doc)
+- [Updating TPSRs](#updating-tpsrs)
 
 ## Release schedule 
 
@@ -200,7 +202,7 @@ Done! The site setup for the new release version is now complete.
 
 Next, you must inform the squad and community that the branch for the vNext release is ready for doc changes. Post an announcement in the Slack channel [#zowe-doc](https://openmainframeproject.slack.com/archives/CC961JYMQ). 
 
-## Sycn changes between releases
+## Sync changes between releases
 
 Before the new release is published, you need to cherry-pick changes from the `master` branch periodically into the `docs-staging` branch to ensure that important changes are incorporated into the next release. The changes could include but are not limited to: 
 
@@ -228,9 +230,9 @@ Usually 2 days before the GA date, review the [release checklist](#release-check
 |--|--|--|
 |New version doc setup               | Right after a release is published |See the [Preparing documentation for a new release](#preparing-documentation-for-a-new-release) on the `docs-staging` branch |  
 |Relnotes: CHANGELOG update cutoff   | 3 days before GA | Doc squad to work with squads to complete review | 
-|Relnotes: Draft review              | 3 days before GA | First run of release notes. Squad leads review the draft. | 
+|Relnotes: Draft review              | 3 days before GA | First run of release notes. Squad leads review the draft. Post in #zowe-release Slack channel | 
 |Zowe CLI: Update web help and type doc |  | Zowe CLI squad
-|Update TPSR                         |  | Work with CICD squad. See [Updating TPSR](#updating-tpsr) for how-to. 
+|Update TPSRs                        |  | Work with CICD squad. See [Updating TPSR](#updating-tpsr) for how-to. 
 |Doc freeze, PR for publish ready    | 1 day before GA | All release PRs merged. Action: Inform CI/CD squad of the doc PR number. Add CICD members as a reviewer of the PR. 
 |Doc publish                         | GA day | Work with CICD squad to merge the doc PR. 
 |Doc validation                      | 1 hour within publish | Check that the doc site has been refreshed correctly. 
@@ -281,8 +283,10 @@ Note: Instructions use Visual Studio Code and GitHub Desktop. Replace version nu
 10. In GitHub Desktop, commit your updates to your branch.
 11. Merge your branch to `docs-staging`.
 
-## Updating TPSR
+## Updating TPSRs
 
-Pick up the latest licenses file from this location: https://zowe.jfrog.io/zowe/libs-release-local/org/zowe/licenses/. Open the release folder and download the `zowe_licenses_full.zip` file. 
+Pick up the latest licenses file from this location: https://zowe.jfrog.io/zowe/libs-release-local/org/zowe/licenses/. 
 
-Extract the file and copy the content into the placeholder TPSR document for the release in the /tpsr folder.
+1. Open the release folder and download the `zowe_licenses_full.zip` file. 
+
+2. Extract the file and copy the content into the placeholder TPSR document for the release in the /tpsr folder.


### PR DESCRIPTION
Minor changes including:
- Adding missing vulnerabilities fixed to Zowe v2.7 release notes
- Fixing links and spelling, updating lists in the [Release handbook](https://github.com/zowe/docs-site/blob/master/release-handbook/release_handbook.md)