### PR TITLE
Restrict SSR concurrency for Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,10 @@
   command = "npm run build"
   publish = "build"
 
+[build.environment]
+  DOCUSAURUS_SSR_CONCURRENCY = "5"
+  NODE_VERSION = "16"
+
 [[plugins]]
 package = "netlify-plugin-cache"
   [plugins.inputs]


### PR DESCRIPTION
This was recommended in https://github.com/zowe/docs-site/issues/2766#issuecomment-1501527472 and https://github.com/facebook/docusaurus/issues/4765#issuecomment-1361341991.
The default concurrency is 32 (see https://github.com/slorber/static-site-generator-webpack-plugin/pull/3) and this reduces it to 5.
Hopefully it buys us some time by reducing memory usage for our Netlify build - results seem promising so far.
However it's hard to be sure since the Out of Memory errors are transient and may occur again in the future.
If that happens, we have more long-term ideas to pursue as discussed in #2766 🙂 

Also uses Node.js 16 instead of 14 which reaches End of Life in a few weeks (see https://endoflife.date/nodejs).