### PR TITLE
fixing broken links

### DIFF
--- a/docs/extend/extend-cli/cli-devTutorials.md
+++ b/docs/extend/extend-cli/cli-devTutorials.md
@@ -24,7 +24,7 @@ Follow these tutorials to get started working with the sample plug-in:
 5. [Implementing user profiles:](cli-implement-profiles.md) Implement user profiles with the plug-in.
 
 ### Plug-in development overview
-At a high level, a plug-in must have `imperative-framework` configuration [(sample here)](https://github.com/zowe/zowe-cli-sample-plugin/blob/master/src/imperative.ts).  This configuration is discovered by  `imperative-framework` through the [package.json](https://github.com/zowe/zowe-cli-sample-plugin/blob/master/package.json) `imperative` key.
+At a high level, a plug-in must have `imperative-framework` configuration [(sample here)](https://github.com/zowe/zowe-cli-sample-plugin/blob/master/src/pluginDef.ts).  This configuration is discovered by  `imperative-framework` through the [package.json](https://github.com/zowe/zowe-cli-sample-plugin/blob/master/package.json) `imperative` key.
 
 A Zowe CLI plug-in will minimally contain the following:
 1. Programmatic API: Node.js programmatic APIs to be called by your handler or other Node.js applications.

--- a/docs/extend/extend-ze/ze-extensions.md
+++ b/docs/extend/extend-ze/ze-extensions.md
@@ -1,3 +1,3 @@
 # Extending Zowe Explorer
 
-You can extend the possibilities of Zowe Explorer by creating you own extensions. For more information on how to create your own Zowe Explorer extension, see [Extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Extending.md).
+You can extend the possibilities of Zowe Explorer by creating you own extensions. For more information on how to create your own Zowe Explorer extension, see [Extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/wiki/Extending-Zowe-Explorer).

--- a/docs/extend/extend-zowe-overview.md
+++ b/docs/extend/extend-zowe-overview.md
@@ -65,7 +65,7 @@ The Zowe Desktop is an angular application that allows native plug-ins to be bui
 
 Zowe Explorer provides extension APIs that assist third party extenders to create extensions that access Zowe Explorer resource entities to enrich the user experience. There are many ways Zowe Explorer can be extended to support many different use cases. 
 
-For the kinds of extensions that are supported and how to get started with extending Zowe Explorer, see [Extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Extending.md).
+For the kinds of extensions that are supported and how to get started with extending Zowe Explorer, see [Extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/wiki/Extending-Zowe-Explorer).
 
 ## Sample extensions
 

--- a/docs/getting-started/user-roadmap-zowe-explorer.md
+++ b/docs/getting-started/user-roadmap-zowe-explorer.md
@@ -53,7 +53,7 @@ The following definition of skill levels about Zowe Explorer helps you find the 
 
 > Zowe skill level: Advanced
 
-* [**Extend Zowe Explorer**](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Extending.md)
+* [**Extend Zowe Explorer**](https://github.com/zowe/vscode-extension-for-zowe/wiki/Extending-Zowe-Explorer)
 
    Learn how to create extensions for Zowe Explorer to introduce new functionalities.
 
@@ -69,7 +69,7 @@ The following definition of skill levels about Zowe Explorer helps you find the 
 
    The GitHub repository of contains the source code of Zowe Explorer and other Zowe Explorer-related extensions. Check out the landing page README in the repository to find out how to contribute to the extension.
 
-* [**Developing for Eclipse Theia**](https://github.com/zowe/vscode-extension-for-zowe/blob/master/docs/README-Theia.md)
+* [**Developing for Eclipse Theia**](https://github.com/zowe/vscode-extension-for-zowe/wiki/Developing-for-Theia)
 
    This article contains information on how to develop for Eclipse Theia.
 

--- a/docs/getting-started/zowe_faq.md
+++ b/docs/getting-started/zowe_faq.md
@@ -366,7 +366,7 @@ You can also watch [Getting Started with Zowe Explorer](https://www.youtube.com/
 
 <summary></summary>
 
-You can use Zowe Explorer either in [VSCode](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe) or in Theia. For more information about Zowe Explorer in Theia, see [the Theia Readme](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Theia.md).
+You can use Zowe Explorer either in [VSCode](https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe) or in Theia. For more information about Zowe Explorer in Theia, see [Developing for Theia](https://github.com/zowe/vscode-extension-for-zowe/wiki/Developing-for-Theia).
 
 </details>
 
@@ -427,7 +427,7 @@ As a developer, you may contribute to Zowe Explorer in the following ways:
 
 - Fix bugs in Zowe Explorer, submit enhancement requests via GitHub issues, and raise your ideas with the community in Slack.
 
-   Note: For more information, see [Extending Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Extending.md).
+   Note: For more information, see [Extending Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/wiki/Extending-Zowe-Explorer).
 
 </details>
 

--- a/docs/user-guide/ze-install.md
+++ b/docs/user-guide/ze-install.md
@@ -47,7 +47,7 @@ Use the following steps to install Zowe Explorer:
 
 The extension is now installed and available for use.
 
-* **Note:** For information about how to install the extension from a `VSIX` file and run system tests on the extension, see the [Developer README](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README.md).
+* **Note:** For information about how to install the extension from a `VSIX` file and run system tests on the extension, see the [Developer README](https://github.com/zowe/vscode-extension-for-zowe#build-locally).
 
 You can also watch the following videos to learn how to get started with Zowe Explorer, and work with data sets.
 
@@ -133,7 +133,7 @@ To configure confirmation settings for submitting a job, follow these steps:
 
 In this section you can find useful links and other information relevant to Zowe Explorer that can improve your experience with the extension.
 
-- For information about how to develop for Eclipse Theia, see [Theia README](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Theia.md).
-- For information about how to create a VSCode extension for Zowe Explorer, see [VSCode extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/docs/README-Extending.md).
+- For information about how to develop for Eclipse Theia, see [Theia README](https://github.com/zowe/vscode-extension-for-zowe/wiki/Developing-for-Theia).
+- For information about how to create a VSCode extension for Zowe Explorer, see [VSCode extensions for Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/wiki/Extending-Zowe-Explorer).
 
 - Visit the **#zowe-explorer** channel on [Slack](https://openmainframeproject.slack.com/) for questions and general guidance.


### PR DESCRIPTION
Fixing broken links as a result of moving ZE content to the ZE wiki. Fixing other links found in Link Checker