### PR TITLE
remove CCS requirement from z/OSMF Install of z/OS Components

### DIFF
--- a/docs/user-guide/install-zowe-pswi-address-requirements.md
+++ b/docs/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.  
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator


### PR DESCRIPTION
This requirement is no longer applicable to installation of z/OS components

