### PR TITLE
Remove CCS prereq from Install with z/OSMF 

### DIFF
--- a/docs/user-guide/install-zowe-pswi-address-requirements.md
+++ b/docs/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.  
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/_version-v1.26.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/_version-v1.26.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel. 
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/version-v1.27.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/version-v1.27.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.  
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/version-v1.28.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/version-v1.28.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel. 
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/version-v2.3.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/version-v2.3.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel. 
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/version-v2.4.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/version-v2.4.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel. 
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/version-v2.5.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/version-v2.5.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel. 
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/version-v2.6.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/version-v2.6.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel. 
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator

--- a/versioned_docs/version-v2.7.x/user-guide/install-zowe-pswi-address-requirements.md
+++ b/versioned_docs/version-v2.7.x/user-guide/install-zowe-pswi-address-requirements.md
@@ -1,10 +1,6 @@
 # Address z/OSMF Requirements
 
-Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel.
-
-* **Apply required maintenance for Common Components and Services for z/OS (CCS) Version 15.0 (SO12499)**  
-    * **Role**: Systems programmer
-    * The CCS PTF installs load module stubs for select IBM products into your installed CCS library hlq.ZWE0CALL. If you are prompted during installation for the data set name of a load library for an IBM product that is not installed, specify your installed hlq.ZWE0CALL data set name.  
+Before you install Zowe using IBM z/OSMF, address the following installation and security requirements. Your systems programmers and security administrators can complete these tasks in parallel. 
 
 * **Configure z/OSMF**
     * **Role**: Systems programmer, security administrator, domain administrator


### PR DESCRIPTION
The CCS requirement is not applicable for installing with z/OSMF

