### PR TITLE
Fix Netlify preview missing for fork PRs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,4 +1,4 @@
-name: Netlify
+name: Build docs site
 
 on:
   push:
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-    name: Build and deploy
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -24,8 +23,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
@@ -46,6 +43,8 @@ jobs:
         run: npm run build
 
       - name: Deploy to Netlify
+        id: deploy
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: nwtgck/actions-netlify@v2
         with:
           publish-dir: build
@@ -58,3 +57,11 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Upload Build Artifact
+        if: ${{ steps.deploy.conclusion == 'skipped' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-pr-${{ github.event.pull_request.number }}
+          path: build
+          retention-days: 1

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -62,7 +62,7 @@ jobs:
         if: ${{ steps.deploy.conclusion == 'skipped' }}
         run: |
           echo "PR_NUMBER=${{ github.event.pull_request.number }}" > build/.env
-          tar -czf build.tar.gz build
+          tar --zstd -cf build.tar.zst build
 
       - name: Upload Build Artifact
         if: ${{ steps.deploy.conclusion == 'skipped' }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -69,5 +69,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: preview-build
-          path: build.tar.gz
+          path: build.tar.zst
           retention-days: 1

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -58,10 +58,14 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
+      - name: Compress Build Archive
+        if: ${{ steps.deploy.conclusion == 'skipped' }}
+        run: tar -czf build.tar.gz build
+
       - name: Upload Build Artifact
         if: ${{ steps.deploy.conclusion == 'skipped' }}
         uses: actions/upload-artifact@v3
         with:
           name: build-pr-${{ github.event.pull_request.number }}
-          path: build
+          path: build.tar.gz
           retention-days: 1

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -60,12 +60,14 @@ jobs:
 
       - name: Compress Build Archive
         if: ${{ steps.deploy.conclusion == 'skipped' }}
-        run: tar -czf build.tar.gz build
+        run: |
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}" > build/.env
+          tar -czf build.tar.gz build
 
       - name: Upload Build Artifact
         if: ${{ steps.deploy.conclusion == 'skipped' }}
         uses: actions/upload-artifact@v3
         with:
-          name: build-pr-${{ github.event.pull_request.number }}
+          name: preview-build
           path: build.tar.gz
           retention-days: 1

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,55 @@
+name: Deploy to Netlify
+
+on:
+  workflow_run:
+    workflows: ["Build docs site"]
+    types: [completed]
+    branches-ignore:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Find Current PR
+        id: find-pr
+        uses: jwalton/gh-find-current-pr@v1
+        with:
+          state: open
+          sha: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download Build Artifact
+        id: download-artifact
+        if: ${{ steps.find-pr.outputs.number }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-docs.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: build-pr-${{ steps.find-pr.outputs.number }}
+          path: build
+          if_no_artifact_found: warn
+
+      - name: Deploy to Netlify
+        id: deploy
+        if: ${{ steps.download-artifact.outputs.found_artifact }}
+        uses: nwtgck/actions-netlify@v2
+        with:
+          publish-dir: build
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Comment on PR
+        if: ${{ steps.deploy.conclusion == 'success' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.find-pr.outputs.number }}
+          message: |
+            🚀 Deployed on ${{ steps.deploy.outputs.deploy-url }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,26 +12,20 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: Find Current PR
-        id: find-pr
-        uses: jwalton/gh-find-current-pr@v1
-        with:
-          state: open
-          sha: ${{ github.event.workflow_run.head_sha }}
-
       - name: Download Build Artifact
         id: download-artifact
-        if: ${{ steps.find-pr.outputs.number }}
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: build-docs.yml
           run_id: ${{ github.event.workflow_run.id }}
-          name: build-pr-${{ steps.find-pr.outputs.number }}
+          name: preview-build
           if_no_artifact_found: warn
 
       - name: Extract Build Archive
         if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
-        run: tar -xzf build.tar.gz && rm build.tar.gz
+        run: |
+          tar -xzf build.tar.gz && rm build.tar.gz
+          cat build/.env >> "$GITHUB_ENV" && rm build/.env
 
       - name: Deploy to Netlify
         id: deploy
@@ -52,6 +46,6 @@ jobs:
         if: ${{ steps.deploy.outputs.deploy-url }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ steps.find-pr.outputs.number }}
+          number: ${{ env.PR_NUMBER }}
           message: |
             🚀 Deployed on ${{ steps.deploy.outputs.deploy-url }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -38,6 +38,7 @@ jobs:
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: false
           enable-commit-comment: false
+          # enable-github-deployment: false
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
@@ -49,3 +50,13 @@ jobs:
           number: ${{ env.PR_NUMBER }}
           message: |
             🚀 Deployed on ${{ steps.deploy.outputs.deploy-url }}
+
+      - name: Set Commit Status
+        if: ${{ always() && steps.download-artifact.outputs.found_artifact == 'true' }}
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+          targetUrl: ${{ steps.deploy.outputs.deploy-url }}
+          description: Netlify deployment
+          context: Netlify

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Deploy to Netlify
         id: deploy
-        if: ${{ steps.download-artifact.outputs.found_artifact }}
+        if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
         uses: nwtgck/actions-netlify@v2
         with:
           publish-dir: build
@@ -47,7 +47,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - name: Comment on PR
-        if: ${{ steps.deploy.conclusion == 'success' }}
+        if: ${{ steps.deploy.outputs.deploy-url }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ steps.find-pr.outputs.number }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,11 +4,10 @@ on:
   workflow_run:
     workflows: ["Build docs site"]
     types: [completed]
-    branches-ignore:
-      - master
 
 jobs:
-  build:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -28,8 +27,11 @@ jobs:
           workflow: build-docs.yml
           run_id: ${{ github.event.workflow_run.id }}
           name: build-pr-${{ steps.find-pr.outputs.number }}
-          path: build
           if_no_artifact_found: warn
+
+      - name: Extract Build Archive
+        if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
+        run: tar -xzf build.tar.gz && rm build.tar.gz
 
       - name: Deploy to Netlify
         id: deploy

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Extract Build Archive
         if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
         run: |
-          tar -xzf build.tar.gz && rm build.tar.gz
+          tar -xf build.tar.zst && rm build.tar.zst
           cat build/.env >> "$GITHUB_ENV" && rm build/.env
 
       - name: Deploy to Netlify


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
This PR enables Netlify previews for fork PRs by triggering a separate deploy workflow after the build completes. This workflow has access to repository secrets such as the Netlify auth token. Because the docs build has to be uploaded from the first workflow and download by the second one, builds for fork PRs will take on average 7-10 minutes longer than other builds.