### PR TITLE
Add new ways of personal access tokens usage.

### DIFF
--- a/docs/user-guide/api-mediation/api-mediation-personal-access-token.md
+++ b/docs/user-guide/api-mediation/api-mediation-personal-access-token.md
@@ -210,8 +210,32 @@ When eviction is successful, the response to the request is an empty body with a
 
 ## Use the Personal Access Token to authenticate
 
-There are two ways the API client can use the Personal Access Token to authenticate as part of the Single Sign On in which a service is specified in the scopes at the time when the token is issued:
+There are four ways the API client can use the Personal Access Token to authenticate as part of the Single Sign On in which a service is specified in the scopes at the time when the token is issued:
 
+* Using the `Authorization: Bearer` request header.
+
+  **Example:**
+
+    ```
+    GET /<allowed-service>/api/v1/request HTTP/1.1
+    Authorization: Bearer eyJhbGciOiJSUzI1NiJ9...
+    
+    HTTP/1.1 200
+    ...
+    ```
+  
+* Using a Secure HttpOnly cookie with the name `apimlAuthenticationToken`.
+
+  **Example:**
+
+    ```
+    GET /<allowed-service>/api/v1/request HTTP/1.1
+    Cookie: apimlAuthenticationToken=eyJhbGciOiJSUzI1NiJ9...
+    
+    HTTP/1.1 200
+    ...
+    ```
+  
 * Using a Secure HttpOnly cookie with the name `personalAccessToken`.
 
   **Example:**


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
We have unified the usage of the tokens APIML can accept in requests. So now the APIML is able to accept all tokens (zowe/zosmf JWT tokens, PAT tokens and newly the OIDC token) in the Authorization Bearer header and also in the standard apimlAuthnticationToken cookie. There is no need to send the PAT token in a special header or cookie but it is still supported.
 
:heart:Thank you!

