### PR TITLE
Add a link to ZIS message IDs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -664,6 +664,7 @@ module.exports = {
             "troubleshoot/app-framework/app-issue",
             "troubleshoot/app-framework/app-return-codes",
             "troubleshoot/app-framework/zss-error-codes",
+            "troubleshoot/app-framework/zis-error-codes",
           ],
         },
         {


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
This PR adds a link to the new page with ZIS message IDs. The messages themselves were added in https://github.com/zowe/docs-site/pull/2859.

:heart:Thank you!

