### PR TITLE
remove duplicate file ref of Configure the Zowe APIs

### DIFF
--- a/versioned_sidebars/version-v2.6.x-sidebars.json
+++ b/versioned_sidebars/version-v2.6.x-sidebars.json
@@ -674,10 +674,6 @@
           "items": [
             {
               "type": "doc",
-              "id": "version-v2.6.x/user-guide/configure-data-sets-jobs-api"
-            },
-            {
-              "type": "doc",
               "id": "version-v2.6.x/user-guide/api-mediation/api-catalog-configuration"
             },
             {


### PR DESCRIPTION
This PR removed the duplicate reference of Configuring the Zowe APIs in v2.6
![image](https://github.com/zowe/docs-site/assets/38347291/a2ee5d31-4706-43bf-aadc-82b9e08bcbf4)
