### PR TITLE
fixing broken link

### DIFF
--- a/docs/user-guide/cli-using-command-precedence.md
+++ b/docs/user-guide/cli-using-command-precedence.md
@@ -1,0 +1,23 @@
+# How command precedence works
+
+You can provide your mainframe connection details (username, password, etc.) to Zowe CLI in several ways. Zowe CLI abides by a *command option order of precedence* that provides flexibility when issuing commands and writing scripts.
+
+When you issue a command, the CLI *searches* for your command arguments in the following order:
+
+1. **Options** that you specify on individual commands.
+2. **Environment variables** that you define in the computer's operating system. 
+
+    For more information, see [Using environment variables](../user-guide/cli-using-using-environment-variables).
+3. **Service profiles** that you create (i.e. z/OSMF profile or another mainframe service).
+4. **Base profiles** that you create.
+
+    These can contain credentials for use with multiple services and/or an API ML login token.
+5. **Default option value**.
+
+## Command precedence in action
+
+If you omit an option from the command line, Zowe CLI searches for an **environment variable** that contains a value for the option. If no environment variable exists, the CLI checks your **service profiles** for the value. If necessary, the CLI then searches **base profiles**, which provide values to service profiles to avoid specifying the same options (such as a username and password) in multiple service profiles.
+
+:::note
+If you do not provide a value using one of these methods, the default value is used. If a required option value is not located, a syntax error message such as `Missing Positional Argument` or `Missing Option` displays. 
+:::

--- a/docs/user-guide/cli-using-using-profiles-v1.md
+++ b/docs/user-guide/cli-using-using-profiles-v1.md
@@ -72,7 +72,7 @@ If you have multiple LPARs and want to share option values only between services
 
 ## Profile best practices
 
-According to [order of precedence](https://docs.zowe.org/v1.28.x/user-guide/cli-usingcli/#how-command-precedence-works), base profiles are used as a fallback for service profiles. This means that after you create a base profile, you might need to update your service profiles to remove username, password, host, and port. Otherwise, commands will use the information stored in your service profile and will ignore your base profile definition.
+According to [order of precedence](../user-guide/cli-using-command-precedence.md), base profiles are used as a fallback for service profiles. This means that after you create a base profile, you might need to update your service profiles to remove username, password, host, and port. Otherwise, commands will use the information stored in your service profile and will ignore your base profile definition.
 
 ## Testing connections to z/OSMF
 

--- a/docs/user-guide/cli-using-using-profiles-v1.md
+++ b/docs/user-guide/cli-using-using-profiles-v1.md
@@ -72,7 +72,7 @@ If you have multiple LPARs and want to share option values only between services
 
 ## Profile best practices
 
-According to [order of precedence](#how-command-precedence-works), base profiles are used as a fallback for service profiles. This means that after you create a base profile, you might need to update your service profiles to remove username, password, host, and port. Otherwise, commands will use the information stored in your service profile and will ignore your base profile definition.
+According to [order of precedence](https://docs.zowe.org/v1.28.x/user-guide/cli-usingcli/#how-command-precedence-works), base profiles are used as a fallback for service profiles. This means that after you create a base profile, you might need to update your service profiles to remove username, password, host, and port. Otherwise, commands will use the information stored in your service profile and will ignore your base profile definition.
 
 ## Testing connections to z/OSMF
 

--- a/docs/user-guide/cli-using-usingcli.md
+++ b/docs/user-guide/cli-using-usingcli.md
@@ -6,6 +6,10 @@ You can use the CLI interactively from a command window on any computer on which
 
 **Tip:** If you want to use the CLI together with a screen reader to provide accessibility, we recommend using the Mac™ Terminal application enabled for Accessibility through [System Preferences > Accessibility](https://support.apple.com/zh-sg/guide/terminal/trml1020/mac). On Windows™, adjust the Properties settings in Command Prompt. For other operating systems, or for alternative terminals, check the specification for the terminal to ensure that it meets accessibility requirements.
 
+## Profile best practices
+
+According to [order of precedence](https://docs.zowe.org/v1.28.x/user-guide/cli-usingcli/#how-command-precedence-works), base profiles are used as a fallback for service profiles. This means that after you create a base profile, you might need to update your service profiles to remove username, password, host, and port information. Otherwise, commands will use the information stored in your service profile and will ignore your base profile definition.
+
 ## Supported CPU architectures, operating systems and package/resource managers
 
 Zowe CLI supports the following CPU architectures:

--- a/docs/user-guide/cli-using-usingcli.md
+++ b/docs/user-guide/cli-using-usingcli.md
@@ -6,10 +6,6 @@ You can use the CLI interactively from a command window on any computer on which
 
 **Tip:** If you want to use the CLI together with a screen reader to provide accessibility, we recommend using the Mac™ Terminal application enabled for Accessibility through [System Preferences > Accessibility](https://support.apple.com/zh-sg/guide/terminal/trml1020/mac). On Windows™, adjust the Properties settings in Command Prompt. For other operating systems, or for alternative terminals, check the specification for the terminal to ensure that it meets accessibility requirements.
 
-## Profile best practices
-
-According to [order of precedence](https://docs.zowe.org/v1.28.x/user-guide/cli-usingcli/#how-command-precedence-works), base profiles are used as a fallback for service profiles. This means that after you create a base profile, you might need to update your service profiles to remove username, password, host, and port information. Otherwise, commands will use the information stored in your service profile and will ignore your base profile definition.
-
 ## Supported CPU architectures, operating systems and package/resource managers
 
 Zowe CLI supports the following CPU architectures:

--- a/sidebars.js
+++ b/sidebars.js
@@ -404,6 +404,7 @@ module.exports = {
           items: [
             "user-guide/cli-using-usingcli",
             "user-guide/cli-using-displaying-help",
+            "user-guide/cli-using-command-precedence",
             "user-guide/cli-using-understanding-core-command-groups",
             "user-guide/cli-using-issuing-first-command",
             {


### PR DESCRIPTION
Fixing broken link in [Using V1 profiles](https://docs.zowe.org/stable/user-guide/cli-using-using-profiles-v1#profile-best-practices) called out in [Issue 2946](https://github.com/zowe/docs-site/issues/2946)