### PR TITLE
Update configure-certificates-keyring.md

### DIFF
--- a/docs/user-guide/configure-certificates-keyring.md
+++ b/docs/user-guide/configure-certificates-keyring.md
@@ -89,7 +89,7 @@ zowe:
     truststore:
       type: JCERACFKS
       file: safkeyring://ZWESVUSR/ZoweKeyring
-      password:
+      password: 'password'
 
 ```
 

--- a/docs/user-guide/configure-certificates-keyring.md
+++ b/docs/user-guide/configure-certificates-keyring.md
@@ -89,10 +89,7 @@ zowe:
     truststore:
       type: JCERACFKS
       file: safkeyring://ZWESVUSR/ZoweKeyring
-      password: "password"
-    pem:
-      key:
-      certificate:
-      certificateAuthorities: safkeyring:////ZWESVUSR/ZoweKeyring&localca
+      password:
+
 ```
 


### PR DESCRIPTION
Removed PEM section since its not required in 2.9.0. Removed password value in truststore, also not required.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [ ] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 
      
- [ ] If this PR relates to GitHub issues in `docs-site` or other repositories, please list in Description, prefixed with **close**, **fix** or **resolve** keywords.

### Description (including links to related git issues)
Please describe your pull request.

:heart:Thank you!

