### PR TITLE
Add node v18 support to documentation

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -44,7 +44,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v14.x (except v14.17.2), v16.x, or v18.2 (except v18.12.1)
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../docs/contribute/contributing.md) to this repository.

- [x] If the changes in this PR is part of the next future release, make this pull request against the **docs-staging** branch which will be published at the next release boundary. If the changes in this PR are part of the current release, use the default base branch, **master**. For more information about branches, see https://github.com/zowe/docs-site/tree/master#understanding-the-doc-branches. 

This PR just updates the system requirements for zos section to note that node v18 is supported, with the exception of v18.12.1

This PR goes with a code PR which enforces that as well, https://github.com/zowe/zowe-install-packaging/pull/3485
