### PR TITLE
Update system requirements doc to reflect current zOS

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -32,13 +32,15 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.4 and Version 2.5
+- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x](https://www.ibm.com/support/pages/zos23x)
+   **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 
-- zFS volume has at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- zFS volume has at least 1200 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -48,11 +50,11 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v16.x or v18.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
-  **Note:** If you are a software vendor building extensions for Zowe, when using Node.js v14.x or later, it is highly recommended that plug-ins used are tagged. For more information, see [Tagging on z/OS](../extend/extend-desktop/mvd-buildingplugins.md#tagging-plugin-files-on-z-os).
+  **Note:** If you are a software vendor building extensions for Zowe it is highly recommended that plug-ins used are tagged. For more information, see [Tagging on z/OS](../extend/extend-desktop/mvd-buildingplugins.md#tagging-plugin-files-on-z-os).
 
 ### Java 
 
@@ -60,7 +62,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -182,12 +184,18 @@ Zowe requires ACF2 APAR LU01316 to be applied when using the ACF2 security manag
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Each of the above components can be enabled or disabled to optimize your resource consumption according to your use cases.
+Zowe can use more memory if there are extensions installed.
+

--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -32,9 +32,9 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4 and Version 2.5
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x](https://www.ibm.com/support/pages/zos23x)
 
 - zFS volume has at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
 

--- a/versioned_docs/version-v1.28.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v1.28.x/user-guide/systemrequirements-zos.md
@@ -27,7 +27,7 @@ Be sure your z/OS system meets the following prerequisites.
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.4, 2.5
+- z/OS version is in active support, such as Version 2.4 and 2.5
 
    **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 

--- a/versioned_docs/version-v1.28.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v1.28.x/user-guide/systemrequirements-zos.md
@@ -177,7 +177,7 @@ Requirements:
 
 ## Memory requirements
 
-Zowe's components have following memory requiremets:
+Zowe's components have following memory requirements:
 
 Component name | Category | Average memory usage
 ---|---|---

--- a/versioned_docs/version-v1.28.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v1.28.x/user-guide/systemrequirements-zos.md
@@ -27,13 +27,13 @@ Be sure your z/OS system meets the following prerequisites.
 
 ### z/OS
 
-- z/OS version in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4, 2.5
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- zFS volume with at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+- zFS volume has at least 1000 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Or, you want to install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -43,7 +43,7 @@ Be sure your z/OS system meets the following prerequisites.
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2) or v16.x
+- Node.js v16.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
@@ -55,7 +55,7 @@ Be sure your z/OS system meets the following prerequisites.
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+(Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -177,12 +177,16 @@ Requirements:
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Zowe can use more memory if there are extensions installed.

--- a/versioned_docs/version-v2.10.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.10.x/user-guide/systemrequirements-zos.md
@@ -32,13 +32,15 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4 and 2.5.
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 
-- zFS volume has at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- zFS volume has at least 1200 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -48,11 +50,11 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v16.x or v18.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
-  **Note:** If you are a software vendor building extensions for Zowe, when using Node.js v14.x or later, it is highly recommended that plug-ins used are tagged. For more information, see [Tagging on z/OS](../extend/extend-desktop/mvd-buildingplugins.md#tagging-plugin-files-on-z-os).
+  **Note:** If you are a software vendor building extensions for Zowe it is highly recommended that plug-ins used are tagged. For more information, see [Tagging on z/OS](../extend/extend-desktop/mvd-buildingplugins.md#tagging-plugin-files-on-z-os).
 
 ### Java 
 
@@ -60,7 +62,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -141,6 +143,7 @@ The Zowe Desktop is powered by the Application Framework which has server prereq
 - [Application Framework on Docker prerequisites](#docker-requirements-host)
 
 The Zowe Desktop runs inside of a browser. No browser extensions or plugins are required.
+
 The Zowe Desktop supports Google Chrome, Mozilla Firefox, Apple Safari and Microsoft Edge releases that are at most 1 year old, except when the newest release is older. For Firefox, both the regular and Extended Support Release (ESR) versions are supported under this rule.
 
 If you do not see your browser listed here, please contact the Zowe community so that it can be validated and included.
@@ -181,12 +184,18 @@ Zowe requires ACF2 APAR LU01316 to be applied when using the ACF2 security manag
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Each of the above components can be enabled or disabled to optimize your resource consumption according to your use cases.
+Zowe can use more memory if there are extensions installed.
+

--- a/versioned_docs/version-v2.10.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.10.x/user-guide/systemrequirements-zos.md
@@ -184,7 +184,7 @@ Zowe requires ACF2 APAR LU01316 to be applied when using the ACF2 security manag
 
 ## Memory requirements
 
-Zowe's components have following memory requiremets:
+Zowe's components have following memory requirements:
 
 Component name | Category | Average memory usage
 ---|---|---

--- a/versioned_docs/version-v2.5.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.5.x/user-guide/systemrequirements-zos.md
@@ -28,13 +28,15 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 
-- zFS volume with at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- zFS volume has at least 1200 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Or, you want to install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -44,7 +46,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v16.x or v18.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
@@ -56,7 +58,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -171,12 +173,17 @@ Requirements:
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Each of the above components can be enabled or disabled to optimize your resource consumption according to your use cases.
+Zowe can use more memory if there are extensions installed.

--- a/versioned_docs/version-v2.5.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.5.x/user-guide/systemrequirements-zos.md
@@ -173,7 +173,7 @@ Requirements:
 
 ## Memory requirements
 
-Zowe's components have following memory requiremets:
+Zowe's components have following memory requirements:
 
 Component name | Category | Average memory usage
 ---|---|---

--- a/versioned_docs/version-v2.5.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.5.x/user-guide/systemrequirements-zos.md
@@ -28,7 +28,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
+- z/OS version is in active support, such as Version 2.4 and 2.5.
 
    **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 

--- a/versioned_docs/version-v2.6.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.6.x/user-guide/systemrequirements-zos.md
@@ -28,13 +28,15 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 
-- zFS volume with at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- zFS volume has at least 1200 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Or, you want to install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -44,7 +46,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v16.x or v18.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
@@ -56,7 +58,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -171,12 +173,17 @@ Requirements:
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Each of the above components can be enabled or disabled to optimize your resource consumption according to your use cases.
+Zowe can use more memory if there are extensions installed.

--- a/versioned_docs/version-v2.6.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.6.x/user-guide/systemrequirements-zos.md
@@ -173,7 +173,7 @@ Requirements:
 
 ## Memory requirements
 
-Zowe's components have following memory requiremets:
+Zowe's components have following memory requirements:
 
 Component name | Category | Average memory usage
 ---|---|---

--- a/versioned_docs/version-v2.6.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.6.x/user-guide/systemrequirements-zos.md
@@ -28,7 +28,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
+- z/OS version is in active support, such as Version 2.4 and 2.5.
 
    **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 

--- a/versioned_docs/version-v2.7.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.7.x/user-guide/systemrequirements-zos.md
@@ -28,13 +28,15 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 
-- zFS volume with at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- zFS volume has at least 1200 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Or, you want to install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -44,7 +46,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v16.x or v18.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
@@ -56,7 +58,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -171,12 +173,17 @@ Requirements:
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Each of the above components can be enabled or disabled to optimize your resource consumption according to your use cases.
+Zowe can use more memory if there are extensions installed.

--- a/versioned_docs/version-v2.7.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.7.x/user-guide/systemrequirements-zos.md
@@ -173,7 +173,7 @@ Requirements:
 
 ## Memory requirements
 
-Zowe's components have following memory requiremets:
+Zowe's components have following memory requirements:
 
 Component name | Category | Average memory usage
 ---|---|---

--- a/versioned_docs/version-v2.7.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.7.x/user-guide/systemrequirements-zos.md
@@ -28,7 +28,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
+- z/OS version is in active support, such as Version 2.4 and 2.5.
 
    **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 

--- a/versioned_docs/version-v2.8.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.8.x/user-guide/systemrequirements-zos.md
@@ -28,13 +28,15 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 
-- zFS volume has at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- zFS volume has at least 1200 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -44,7 +46,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v16.x or v18.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
@@ -56,7 +58,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -174,12 +176,17 @@ Zowe requires ACF2 APAR LU01316 to be applied when using the ACF2 security manag
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Each of the above components can be enabled or disabled to optimize your resource consumption according to your use cases.
+Zowe can use more memory if there are extensions installed.

--- a/versioned_docs/version-v2.8.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.8.x/user-guide/systemrequirements-zos.md
@@ -28,7 +28,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
+- z/OS version is in active support, such as Version 2.4 and 2.5.
 
    **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 

--- a/versioned_docs/version-v2.8.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.8.x/user-guide/systemrequirements-zos.md
@@ -176,7 +176,7 @@ Zowe requires ACF2 APAR LU01316 to be applied when using the ACF2 security manag
 
 ## Memory requirements
 
-Zowe's components have following memory requiremets:
+Zowe's components have following memory requirements:
 
 Component name | Category | Average memory usage
 ---|---|---

--- a/versioned_docs/version-v2.9.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.9.x/user-guide/systemrequirements-zos.md
@@ -28,13 +28,15 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.3 and Version 2.4
+- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-   **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
+   **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 
-- zFS volume has at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+   **Note:** z/OS V2.3 reached end of support on 30 September 2022. For more information, see the z/OS v2.3 lifecycle details [https://www.ibm.com/support/pages/zos23x-withdrawal-notification](https://www.ibm.com/support/pages/zos23x-withdrawal-notification)
 
-- (Optional, recommended) z/OS OpenSSH V2.2.0 or later
+- zFS volume has at least 1200 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+
+- (Optional, recommended) z/OS OpenSSH
   
   Some features of Zowe require SSH, such as the Desktop's SSH terminal. Install and manage Zowe via SSH, as an alternative to OMVS over TN3270. 
 
@@ -44,7 +46,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### Node.js
 
-- Node.js v14.x (except v14.17.2), or v16.x
+- Node.js v16.x or v18.x
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Installing Node.js on z/OS](install-nodejs-zos.md).
   
@@ -56,7 +58,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OSMF (Optional) 
 
-- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.2, Version 2.3 or Version 2.4.
+- (Optional, recommended) IBM z/OS Management Facility (z/OSMF) Version 2.4, Version 2.5 or Version 3.1.
 
   z/OSMF is included with z/OS so does not need to be separately installed.  If z/OSMF is present, Zowe will detect this when it is configured and use z/OSMF for the following purposes:
 
@@ -174,12 +176,17 @@ Zowe requires ACF2 APAR LU01316 to be applied when using the ACF2 security manag
 
 ## Memory requirements
 
-Zowe API ML components have following memory requiremets:
+Zowe's components have following memory requiremets:
 
-Component name | Memory usage
----|---
-Gateway service | 256MB
-Discovery service | 256MB
-API Catalog | 512MB
-Metrics service | 512MB
-Caching service | 512MB
+Component name | Category | Average memory usage
+---|---|---
+Gateway service | API Mediation Layer | 512MB
+Discovery service | API Mediation Layer |  512MB
+API Catalog | API Mediation Layer |  512MB
+Metrics service | API Mediation Layer |  512MB
+Caching service | API Mediation Layer |  512MB
+ZSS | Application Framework | 32MB
+App Server | Application Framework | 350MB
+
+Each of the above components can be enabled or disabled to optimize your resource consumption according to your use cases.
+Zowe can use more memory if there are extensions installed.

--- a/versioned_docs/version-v2.9.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.9.x/user-guide/systemrequirements-zos.md
@@ -28,7 +28,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 ### z/OS
 
-- z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
+- z/OS version is in active support, such as Version 2.4 and 2.5.
 
    **Note:** Zowe Version 2.11 or higher is required when using z/OS Version 3.1
 

--- a/versioned_docs/version-v2.9.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.9.x/user-guide/systemrequirements-zos.md
@@ -176,7 +176,7 @@ Zowe requires ACF2 APAR LU01316 to be applied when using the ACF2 security manag
 
 ## Memory requirements
 
-Zowe's components have following memory requiremets:
+Zowe's components have following memory requirements:
 
 Component name | Category | Average memory usage
 ---|---|---


### PR DESCRIPTION
According to the way our docs claim support for zOS, it appears we no longer support zOS 2.3 as it has entered the same state as 2.2, last year. This update reflects the reality.