### PR TITLE
Add missing appserver error codes to sidebar in versions where present

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -667,6 +667,7 @@ module.exports = {
             "troubleshoot/app-framework/app-mustgather",
             "troubleshoot/app-framework/app-issue",
             "troubleshoot/app-framework/app-return-codes",
+            "troubleshoot/app-framework/appserver-error-codes",
             "troubleshoot/app-framework/zss-error-codes",
             "troubleshoot/app-framework/zis-error-codes",
           ],

--- a/versioned_sidebars/version-v2.7.x-sidebars.json
+++ b/versioned_sidebars/version-v2.7.x-sidebars.json
@@ -1476,6 +1476,10 @@
             },
             {
               "type": "doc",
+              "id": "version-v2.7.x/troubleshoot/app-framework/appserver-error-codes"
+            },
+            {
+              "type": "doc",
               "id": "version-v2.7.x/troubleshoot/app-framework/zss-error-codes"
             }
           ]

--- a/versioned_sidebars/version-v2.8.x-sidebars.json
+++ b/versioned_sidebars/version-v2.8.x-sidebars.json
@@ -1480,6 +1480,10 @@
             },
             {
               "type": "doc",
+              "id": "version-v2.8.x/troubleshoot/app-framework/appserver-error-codes"
+            },
+            {
+              "type": "doc",
               "id": "version-v2.8.x/troubleshoot/app-framework/zss-error-codes"
             }
           ]


### PR DESCRIPTION
There's a page with hundreds of message IDs and descriptions of what to do when you see them, but it was missing from the sidebar. It was added in v2.7 so I updated the versioned docs to add it all the way back to then.