### PR TITLE
Stop tracking specific browser versions

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -139,14 +139,6 @@ The Zowe Desktop is powered by the Application Framework which has server prereq
 The Zowe Desktop runs inside of a browser. No browser extensions or plugins are required.
 The Zowe Desktop supports Google Chrome, Mozilla Firefox, Apple Safari and Microsoft Edge releases that are at most 1 year old, except when the newest release is older.
 For Firefox, both the regular and Extended Support Release (ESR) versions are supported under this rule.
-
-Currently, the following browsers are supported:
-
-- Google Chrome V79 or later
-- Mozilla Firefox V68 or later
-- Safari V13 or later
-- Microsoft Edge 79
-
 If you do not see your browser listed here, please contact the Zowe community so that it can be validated and included.
 
 ## Feature requirements


### PR DESCRIPTION
Unless you'd like to volunteer for maintaining the specific list of browser versions Zowe supports which changes monthly, you should delete this part of the documentation as seen in my PR.

The problem being fixed:

The documentation clearly states
> The Zowe Desktop supports Google Chrome, Mozilla Firefox, Apple Safari and Microsoft Edge releases that are at most 1 year old, except when the newest release is older.

And then goes on to list:
> - Google Chrome V79 or later
> - Mozilla Firefox V68 or later
> - Safari V13 or later
> - Microsoft Edge 79

All of which are way more than 1 year old.
Why? Because someone thought it was a good idea to enumerate specific versions.
It's more like a maintenance nightmare.
It's highly unlikely people have browsers that are older than this, because the vast majority of people get auto-updated browsers monthly.

Let's avoid the maintenance headache and stick to the above statement of "1 year old"
Otherwise, this list is outdated and needs current and continued fixing.