### PR TITLE
Increase zowe size requirement statement

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -32,7 +32,7 @@ Be sure your z/OS system meets the following prerequisites:
 
    **Note:** z/OS V2.2 reached end of support on 30 September 2020. For more information, see the z/OS v2.2 lifecycle details [https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61](https://www.ibm.com/support/lifecycle/details?q45=Z497063S01245B61). 
 
-- zFS volume has at least 833 mb of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
+- zFS volume has at least 1500 MB of free space for Zowe server components, their keystore, instance configuration files and logs, and third-party plug-ins.
 
 - (Optional, recommended) z/OS OpenSSH V2.2.0 or later
   


### PR DESCRIPTION
Up for debate but here's my PR.
The requirements for zowe state you need a minimum of 833mb for zFS to fit Zowe on.

Extracted, zowe is about 510 MB right now, so fine.
But, I believe this number was supposed to include the archive + the extracted size, because without more than double the archive space, you can't extract Zowe.

That'd put us above 1000 MB as a minimum these days.
I think it's best to give growing room, and set this number as 1500 MB.

Also hate to be that guy but "mb" is a fictional unit of measurement "millibits", and I'm always surprised by the ways our users get confused, so let's avoid the issue.