### PR TITLE
Add API ML bugfix for 2.10 release notes

### DIFF
--- a/docs/getting-started/release-notes/v2_10_0.md
+++ b/docs/getting-started/release-notes/v2_10_0.md
@@ -14,8 +14,6 @@ Zowe Version 2.10.0 contains the enhancements that are described in the followin
 
 ### Zowe Application Framework
 
-### Zowe API Mediation Layer
-
 ### Zowe CLI
 
 #### Zowe CLI (Core)
@@ -43,6 +41,7 @@ Zowe Version 2.10.0 contains the bug fixes that are described in the following t
 
 ### Zowe API Mediation Layer
 
+* The client is provided with information about an expired password. ([c4dc217](https://github.com/zowe/api-layer/commit/c4dc217)), closes [#2969](https://github.com/zowe/api-layer/issues/2969))
 ### Zowe CLI
 
 #### Zowe CLI (Core)

--- a/docs/getting-started/release-notes/v2_10_0.md
+++ b/docs/getting-started/release-notes/v2_10_0.md
@@ -41,7 +41,7 @@ Zowe Version 2.10.0 contains the bug fixes that are described in the following t
 
 ### Zowe API Mediation Layer
 
-* The client is provided with information about an expired password. ([c4dc217](https://github.com/zowe/api-layer/commit/c4dc217)), closes [#2969](https://github.com/zowe/api-layer/issues/2969))
+* The client is provided with information about an expired password. ([c4dc217](https://github.com/zowe/api-layer/commit/c4dc217), closes [#2969](https://github.com/zowe/api-layer/issues/2969))
 ### Zowe CLI
 
 #### Zowe CLI (Core)


### PR DESCRIPTION
API ML has only one bugfix to announce for the 2.10 release notes.

