### PR TITLE
fixing incorrect commands

### DIFF
--- a/docs/user-guide/cli-using-integrating-apiml.md
+++ b/docs/user-guide/cli-using-integrating-apiml.md
@@ -36,7 +36,7 @@ To request a token and log in to API ML:
      If you use the  `--show-token` option with the log-in command, you must manually supply the token on each command using the `--token-value` option. For example:
 
      ```
-     zowe plugins list --base-path "ibmzosmf/api/v1" --token-value "123"
+     zowe auth login apiml --base-path "ibmzosmf/api/v1" --token-value "123"
      ```
 
 **Notes:**
@@ -95,7 +95,7 @@ To specify a base path with Zowe V2 profiles:
     For example:
 
     ```
-    zowe plugins list --base-path "ibmzosmf/api/v1"
+    zowe config set --base-path "ibmzosmf/api/v1"
     ```
 
 ### Specifying a base path with Zowe V1 profiles
@@ -124,7 +124,7 @@ To specify a base path with Zowe V1 profiles:
     For example:
 
     ```
-    zowe plugins list --base-path "ibmzosmf/api/v1"
+    zowe profiles create --base-path "ibmzosmf/api/v1"
     ```
 
 ## Accessing multiple services with SSO

--- a/docs/user-guide/cli-using-integrating-apiml.md
+++ b/docs/user-guide/cli-using-integrating-apiml.md
@@ -52,7 +52,7 @@ Log out to prompt the API ML token to expire and remove it from your base profil
 To log out of the API ML:
 
 ```
-zowe auth logout
+zowe auth logout apiml
 ```
 
 This causes the token to expire. Log in again to obtain a new token.
@@ -92,12 +92,6 @@ To specify a base path with Zowe V2 profiles:
 
     Commands issued with this profile are routed through the layer to access an appropriate z/OSMF instance.
 
-    For example:
-
-    ```
-    zowe config set --base-path "ibmzosmf/api/v1"
-    ```
-
 ### Specifying a base path with Zowe V1 profiles
 
 To specify a base path with Zowe V1 profiles:
@@ -121,11 +115,6 @@ To specify a base path with Zowe V1 profiles:
     ```
     Commands issued with this profile are routed through the layer to access an appropriate z/OSMF instance.
 
-    For example:
-
-    ```
-    zowe profiles create --base-path "ibmzosmf/api/v1"
-    ```
 
 ## Accessing multiple services with SSO
 


### PR DESCRIPTION
Fixing incorrect commands in [Integrating with API Mediation Layer](https://docs.zowe.org/stable/user-guide/cli-using-integrating-apiml)