### PR TITLE
Update Configure certs in Installation checklists and header fixes

### DIFF
--- a/docs/user-guide/generate-certificates.md
+++ b/docs/user-guide/generate-certificates.md
@@ -3,19 +3,19 @@
 
 If you do not have a certificate, follow the procedure that corresponds to the certificate type you choose to generate: 
 
-* [Create a PKCS12 certificate](#create-a-pkcs12-keystore)
-* [Create a JCERACFKS certificate](#create-a-jceracfks-certificate)
+* [Creating a PKCS12 certificate](#creating-a-pkcs12-keystore)
+* [Creating a JCERACFKS certificate](#creating-a-jceracfks-certificate)
 
 Both certificate types are self-signed certificates.
 
-## Create a PKCS12 keystore
+## Creating a PKCS12 keystore
 
 Follow these steps to generate a PKCS12 keystore:
 
 1. [Configure the PKCS12 setup section in zowe.yaml](#configure-the-pkcs12-setup-section-in-zoweyaml)
 2. [Run the command to generate a PKCS12 keystore](#run-the-command-to-generate-a-pkcs12-keystore)
 
-### Configuring the PKCS12 setup section in zowe.yaml
+### Configure the PKCS12 setup section in zowe.yaml
 
 To assist with updating `zowe.yaml`, see the example yaml for [scenario 1: Use a file-based (PKCS12) keystore with Zowe generated certificates](#certificate-configuration-scenarios.md/#scenario-1-use-a-pkcs12-keystore-with-zowe-generated-certificates) in the article Certificate configuration scenarios. 
 
@@ -65,7 +65,7 @@ zowe:
 
 **Tip:** To get the san IP address, run `ping dvipa.my-company.com` in your terminal. Please note that `dvipa.my-company.com` is an example address.
 
-### Running the command to generate a PKCS12 keystore
+### Run the command to generate a PKCS12 keystore
 
 After you configure the `zowe.yaml`, use the following procedure to generate the PKCS12 certificate.
 
@@ -147,7 +147,7 @@ The `zwe init certificate` command generates a certificate based on `zowe.yaml` 
 
 When using a Zowe-generated certificate, you will be challenged by your browser when logging in to Zowe to accept Zowe's untrusted certificate authority. Depending on the browser you are using, there are different ways to proceed. See next steps about how to [import the PKCS12 certificate to your brower](./import-certificates#import-your-pkcs12-certificate).
 
-## Create a JCERACFKS certificate
+## Creating a JCERACFKS certificate
 
 Use the following procedure to configure the `zowe.yaml` file for JCERACFKS certificates:
 

--- a/docs/user-guide/import-certificates.md
+++ b/docs/user-guide/import-certificates.md
@@ -2,12 +2,12 @@
 
 One option for using certificates in Zowe is to import and configure existing certificates. Use the procedure that applies to the type of certificate you wish to import.
 
-* [Import a file-based PKCS12 certificate](#import-an-existing-pkcs12-certificate)
-* [Import a JCERACFKS certificate](#import-an-existing-jceracfks-certificate)
+* [Importing a file-based PKCS12 certificate](#importing-an-existing-pkcs12-certificate)
+* [Importing a JCERACFKS certificate](#importing-an-existing-jceracfks-certificate)
 
-Additionally, you can [import a certificate stored in an MVS data set into a Zowe key ring](#import-a-certificate-stored-in-an-mvs-data-set-into-a-zowe-key-ring).
+Additionally, you can [import a certificate stored in an MVS data set into a Zowe key ring](#importing-a-certificate-stored-in-an-mvs-data-set-into-a-zowe-key-ring).
 
-## Import an existing PKCS12 certificate
+## Importing an existing PKCS12 certificate
 
 To import a PKCS12 certificate, it is first necessary to import a certificate authority (CA). There are two options for importing a CA:
 
@@ -131,7 +131,7 @@ Follow these steps to import `local_ca.cer` from the path `.../zowe/keystore/loc
 ```
 After successfully importing your local CA certificate on Linux, you can now [Import an existing PKCS12 certificate](#import-an-existing-pkcs12-certificate)
 
-## Import an existing JCERACFKS certificate
+## Importing an existing JCERACFKS certificate
 
 To import a JCERACFKS certificate, use the example yaml according to [Scenario 4: Use a z/OS keyring-based keystore and connect to an existing certificate](#certificate-configuration-scenarios.md/#scenario-4-use-a-zos-keyring-and-connect-to-an-existing-certificate) in the article Certificate configuration scenarios.
 
@@ -163,7 +163,7 @@ Due to the limitation of the RACDCERT command, the `importCertificateAuthorities
 
 You can now use your imported JCERACFKS certificate. See [next steps](#next-steps).
 
-## Import a certificate stored in an MVS data set into a Zowe key ring
+## Importing a certificate stored in an MVS data set into a Zowe key ring
 
 To import a certificate that is stored in a data set into a key ring, configure the zowe.yaml according to the example yaml in [Scenario 5: Use a z/OS keyring-based keystore and import a certificate stored in a data set](#certificate-configuration-scenarios/#scenario-5-use-a-zos-keyring-and-import-a-certificate-stored-in-a-data-set)
 

--- a/docs/user-guide/zos-components-installation-checklist-dev.md
+++ b/docs/user-guide/zos-components-installation-checklist-dev.md
@@ -28,7 +28,7 @@ Use one of the following installation options to install Zowe z/OS components.
 
 | Task | Results | Time Estimate |  
 |--------------------|----|------|
-| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Configure certificates](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md) to determine which scenario best applies to your use case.** <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
+| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Configure certificates](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md)** to determine which scenario best applies to your use case. <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
 
 ## Starting and Stopping Zowe  
 

--- a/docs/user-guide/zos-components-installation-checklist-dev.md
+++ b/docs/user-guide/zos-components-installation-checklist-dev.md
@@ -28,7 +28,7 @@ Use one of the following installation options to install Zowe z/OS components.
 
 | Task | Results | Time Estimate |  
 |--------------------|----|------|
-| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Use one of the following options:<br /> **Option 1: Use zwe command group** <br />* [Configure PKCS12 certificates](../user-guide/configure-certificates-keystore.md) <br />&nbsp;&nbsp;&nbsp;or<br />* [Configure JCERACFKS certificates in a key ring](../user-guide/configure-certificates-keyring.md) <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
+| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Configure certificates](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md) to determine which scenario best applies to your use case.** <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
 
 ## Starting and Stopping Zowe  
 

--- a/docs/user-guide/zos-components-installation-checklist-dev.md
+++ b/docs/user-guide/zos-components-installation-checklist-dev.md
@@ -28,7 +28,7 @@ Use one of the following installation options to install Zowe z/OS components.
 
 | Task | Results | Time Estimate |  
 |--------------------|----|------|
-| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Configure certificates](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md)** to determine which scenario best applies to your use case. <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
+| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Zowe certificate configuration overview](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md)** to determine which scenario best applies to your use case. <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
 
 ## Starting and Stopping Zowe  
 

--- a/docs/user-guide/zos-components-installation-checklist.md
+++ b/docs/user-guide/zos-components-installation-checklist.md
@@ -27,7 +27,7 @@ Use one of the following installation options to install Zowe z/OS components.
 
 | Task | Results | Time Estimate |  
 |--------------------|----|------|
-| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Use one of the following options:<br /> **Option 1: Use zwe command group** <br />* [Configure PKCS12 certificates](../user-guide/configure-certificates-keystore.md) <br />&nbsp;&nbsp;&nbsp;or<br />* [Configure JCERACFKS certificates in a key ring](../user-guide/configure-certificates-keyring.md) <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
+| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Configure certificates](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md)** to determine which scenario best applies to your use case. <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
 ## Configuring High Availability (optional)
 | Task | Results | Time Estimate |  
 |--------------------|----|------|

--- a/docs/user-guide/zos-components-installation-checklist.md
+++ b/docs/user-guide/zos-components-installation-checklist.md
@@ -27,7 +27,7 @@ Use one of the following installation options to install Zowe z/OS components.
 
 | Task | Results | Time Estimate |  
 |--------------------|----|------|
-| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Configure certificates](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md)** to determine which scenario best applies to your use case. <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
+| Zowe is able to use PKCS12 certificates or certificates held in a z/OS Keyring.<br /><br />Read the article [Zowe certificate configuration overview](../user-guide/configure-certificates.md). Then use one of the following options:<br /><br /> **Option 1: Review [certificate configuration scenarios](../user-guide/certificate-configuration-scenarios.md)** to determine which scenario best applies to your use case. <br /> Once you have imported or generated a certificate, see [Use certificates](../user-guide/use-certificates.md).  <br />**Option 2: [Set up Zowe certificates using workflows](../user-guide/certificates-setup.md)** | Your certificates are configured and stored securely|2 hours  
 ## Configuring High Availability (optional)
 | Task | Results | Time Estimate |  
 |--------------------|----|------|


### PR DESCRIPTION
This PR updates the content in the installation checklists with the current configure certificates articles and transforms some headers into gerunds as per the style guide

