### PR TITLE
Language and formatting fixes to Certificates docs

### DIFF
--- a/docs/user-guide/certificate-configuration-scenarios.md
+++ b/docs/user-guide/certificate-configuration-scenarios.md
@@ -1,6 +1,6 @@
 # Certificate configuration scenarios 
 
-As a system programmer, review the five scenarios for configuring Zowe for automatic certificate setup. Examples are provided for each scenario.
+As a system programmer, review the five scenarios for configuring Zowe for automatic certificate setup. Examples of the zowe.yaml filw are provided for each scenario.
 
 Zowe servers require both a keystore to store the certificates and a truststore to validate certificates.
 
@@ -12,18 +12,18 @@ Zowe can then automate the certificate setup via the `zwe init certificate` comm
 
 
 **Note:**  
-Automated generation of certificates is an option, but is not required. If you already have a keystore that contains a valid certificate`*`, and the  corresponding private key of the certificate, along with a truststore which validates the certificate and any other certificates you expect to encounter, then you also have the option of directly defining the parameter `zowe.certificate` which specifies the location of each of these certificates and their storage objects. Note that this parameter should not be confused with the parameter `zowe.setup.certificate`.
+Automated generation of certificates is an option, but is not required. If you already have a keystore that contains a valid certificate*, and the  corresponding private key of the certificate, along with a truststore which validates the certificate and any other certificates you expect to encounter, then you also have the option to directly define the parameter `zowe.certificate` which specifies the location of each of these certificates and their storage objects. Note that this parameter should not be confused with the parameter `zowe.setup.certificate`.
 
-## `*` What is a valid certificate in Zowe?
+## <b>*</b> What is a valid certificate in Zowe?
 
-A valid certificate for use in Zowe is one that:
+A valid certificate for use in Zowe has the following qualities:
 
-* A certificate that does not contain the _Extended Key Usage_ section.
-* A certificate that contains the _Extended Key Usage_ section and also includes the **Server** and **Client** authentication fields.
+* The certificate does not contain the _Extended Key Usage_ section.
+* The certificate contains the _Extended Key Usage_ section and also includes the **Server** and **Client** authentication fields.
 
 ## Considerations for certificate scenario selection
 
-When configuring Zowe for certificates, consider the scenario that best suits your use case:
+Consider the scenario that best suits your use case:
 
 * Do you pla to use a file-based (PKCS12) certificates, or z/OS keyrings?
 * Do you plan to enable Zowe to create self-signed certificates, or will Zowe be using pre-made certificates which you are providing?

--- a/docs/user-guide/certificates-configuration-questionnaire.md
+++ b/docs/user-guide/certificates-configuration-questionnaire.md
@@ -1,8 +1,9 @@
 # Zowe certificates configuration questionnaire
 
-To properly configure Zowe to use certificates for server-side component installation review the various certificate setup options presented in this article. 
+To properly configure Zowe to use certificates for server-side component installation, review the  certificate setup options presented in this article. 
 Understanding these options makes it possible to select the best certificate configuration scenario that fits your Zowe deployment use case. 
-Review the Configure Zowe Certificates diagram and answer the questions in the questionnaire at the end of this article.
+
+Review the Configure Zowe Certificates diagram and answer the questions presented in the questionnaire at the end of this article.
 
 **Important:**
 If you know that you will be using certificates in a production deployment environment, and that you will be using an external certificate authority (CA), we recommend you consult with your organization's security administrator before you start certificate configuration.
@@ -13,7 +14,7 @@ Before determining which scenario best suits your use case, it is practical to h
 - [Zowe certificates overview](../getting-started/zowe-certificates-overview)
 
 
-The numerated decision blocks (the yellow diamonds) in the following diagram correspond to the questions in the questionnaire.
+The numerated decision blocks (yellow diamonds) in the following diagram correspond to the questions in the questionnaire.
 Follow this sequence of questions to determine which certificate configuration scenario best suits your certificate use case.
 
 ![Certificates configuration decision tree](../images/install/certificates-config-scenarios.png)
@@ -30,7 +31,7 @@ Each of the following certificate configuration scenarios are available in the a
 Answer each question and find which scenarios are relevant for the selected option:
 
 **Question 1:** What is your target deployment environment?  
-Depending on your target environment type (DEV/TEST or PROD), you can create your certificates (self-signed option), acquire a new ones from a trusted CA, or use existing certificates.
+Depending on your target environment type (DEV/TEST or PROD), you can create your certificates (self-signed option), acquire new ones from a trusted CA, or use existing certificates.
 
 **Question 2:** Do you need to use a certificate signed by the CA of the company or by an external CA?  
 If you plan to use Zowe generated self-signed certificates and your target environment is production, we strongly recommend that you acquire new certificates from your trusted CA.
@@ -53,5 +54,5 @@ For more information, see [Import and configure an existing certificate](./impor
 After you select your applicable certificate configuration scenario and review the certificate configurate sample in the article [Certificate configuration scenarios](./certificate-configuration-scenarios.md), you can continue to  [Configure Zowe Certificates](./configure-certificates).  
 
 **Tip:**
-If you encounter issues when configuring your certificate,sSee the [Troubleshooting the certificate configuration](../troubleshoot/troubleshoot-zos-certificate), to find resolution of errors you encounter when configuring the Zowe certificates.
+If you encounter issues when configuring your certificate, see [Troubleshooting the certificate configuration](../troubleshoot/troubleshoot-zos-certificate), to find resolution of errors you encounter when configuring Zowe certificates.
 

--- a/docs/user-guide/configure-certificates.md
+++ b/docs/user-guide/configure-certificates.md
@@ -1,13 +1,20 @@
 # Zowe certificate configuration overview
 
-As a system programmer, review this article to learn about the key concepts of Zowe certificates, and options for certificate configuration. 
+As a system programmer or security administrator, review this article to learn about the key concepts of Zowe certificates, and options for certificate configuration. 
 
-Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. Communication in Zowe can be between Zowe servers, or from Zowe to another server, or even between Zowe's servers and Zowe's client components.
+Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. Communication in Zowe can be between Zowe servers, from Zowe to another server, or even between Zowe's servers and Zowe's client components.
 
 Zowe's certificates are stored in its **keystore**. Verification of these certificates and any incoming certificates from other servers or clients is done by using certificates of certificate authorities (CAs) within Zowe's **truststore**.
 
-Zowe supports using either file-based (`PKCS12`) or z/OS key ring-based (when on z/OS) keystores and truststores, and can reuse compatible stores if they exist. Alternatively, Zowe can assist in creating the stores by either generating certificates or by allowing users to import their own compatible certificates via the `zwe init certificate` command. For key rings, one option for certificate setup is to copy the JCL `ZWEKRING` member of Zowe's SAMPLIB and customize its values. 
+Zowe supports using either file-based (`PKCS12`) or z/OS key ring-based (when on z/OS) keystores and truststores, and can reuse compatible stores if they exist. Zowe can assist in creating the stores by either generating certificates or by allowing users to import their own compatible certificates via the `zwe init certificate` command. 
 
+* [Certificate concepts](#certificate-concepts)
+* [Certificate verification](#certificate-verification)
+* [Zowe certificate requirements](#zowe-certificate-requirements)
+* [Certificate setup type](#certificate-setup-type)
+* [Next steps: Creating or importing certificates to Zowe](#next-steps-creating-or-importing-certificates-to-zowe)
+
+**Note:** If you are already familiar with certificate concepts and how Zowe uses certificates and are ready to get started, see the options under the section _Next steps: Creating or importing certificates to Zowe_ at the end of this article.
 ## Certificate concepts
 
 Before you get started with configuring certificates, it is useful to familiarize yourself with the following key concepts:
@@ -36,6 +43,8 @@ z/OS provides an interface to manage cryptographic objects in "key rings". As op
 
 Use of a z/OS keystore is the recommended option for storing certificates if system programmers are already familiar with the certificate operation and usage.
 Creating a key ring and connecting the certificate key pair requires elevated permissions. When the TSO user ID does not have the authority to manipulate key rings and users want to create a Zowe sandbox environment or for testing purposes, the USS keystore is a good alternative.
+
+One option for certificate setup for key rings is to copy the JCL `ZWEKRING` member of Zowe's SAMPLIB and customize its values. 
 
 ### Server certificate
 Servers need a certificate to identify themselves to clients. Every time that you go to an HTTPS website, for example, your browser checks the server certificate and its CA chain to verify that the server you reached is authentic.
@@ -113,15 +122,15 @@ A number of key ring scenarios are supported:
 
 Review the following options and choose which best applies to your use case:
 
-* If you would like to see which certificate configuration applies to your specific use case, see [Certificate configuration scenarios](./certificate-configuration-scenarios.md).
+* Take our [Certificates Configuration Questionnaire](./certificates-configuration-questionnaire) to assist with determining which configuration scenario and associated zowe.yaml format best suits your use case.
 
-* Take our [Certificates Confiquration Questionnaire](./certificates-configuration-questionnaire) to get aid and make decision for the configuration path.     
+* To review the various zowe.yaml files to see which certificate configuration applies to your specific use case, see [Certificate configuration scenarios](./certificate-configuration-scenarios.md).
 
 * If you have an existing certificate, you can import this certificate to the keystore. For more information, see [Import and configure an existing certificate](./import-certificates.md).
 
-* If you do not have an existing certificate, you can create one. For more information, see [Generate a certificate if you do not have a certificate](./generate-certificates.md).
+* If you do not have an existing certificate, you can create one. For more information, see [Generate a certificate](./generate-certificates.md).
 
-* When your certificate is already in the keystore, it is ready for use. For more information, see [Use certificates](./use-certificates.md).
+* When your certificate is already in the keystore, it is ready for use. For more information about how to use it, see [Use certificates](./use-certificates.md).
 
-* If you run into any error when configuring certificates, see the [Troubleshooting the certificate configuration](../troubleshoot/troubleshoot-zos-certificate.md).
+* If you run into any error when configuring certificates, see [Troubleshooting the certificate configuration](../troubleshoot/troubleshoot-zos-certificate.md).
 


### PR DESCRIPTION
This PR makes language and formatting fixes to the files under configuring certificates.
