### PR TITLE
removing duplicate article from sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -158,7 +158,6 @@ module.exports = {
                   label: "Configuring certificates",
                   link: {type:"doc", id:"user-guide/configure-certificates"},
                   items: [
-                    "user-guide/configure-certificates",
                     "user-guide/certificates-configuration-questionnaire",
                     "user-guide/certificate-configuration-scenarios",
                     "user-guide/import-certificates",


### PR DESCRIPTION
Removing a duplicate of the [Zowe certificate configuration overview](https://docs.zowe.org/stable/user-guide/configure-certificates) article from the sidebar so that we can generate a PDF of the Zowe v2.11 site