### PR TITLE
Add apiml bug fixes for previous 1.28.x versions

### DIFF
--- a/versioned_docs/version-v1.28.x/getting-started/release-notes/v1_28_3.md
+++ b/versioned_docs/version-v1.28.x/getting-started/release-notes/v1_28_3.md
@@ -10,6 +10,10 @@ See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 
 Zowe Version 1.28.3 contains the bug fixes that are described in the following topics.
 
+### API Mediation Layer
+
+- Prevented null pointer exception in Swagger UI when buffer is missing. ([#2857](https://github.com/zowe/api-layer/issues/2857)) 
+
 ### Zowe CLI
 
 #### Zowe CLI (Core)

--- a/versioned_docs/version-v1.28.x/getting-started/release-notes/v1_28_4.md
+++ b/versioned_docs/version-v1.28.x/getting-started/release-notes/v1_28_4.md
@@ -9,6 +9,12 @@ See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 ## Bug fixes
 
 Zowe Version 1.28.4 contains the bug fixes that are described in the following topics.
+
+### Zowe API Mediation Layer
+
+- Mitigated storing passwords in the memory (v1). ([#2862](https://github.com/zowe/api-layer/issues/2862))
+
+- Corrected the position of the align button in Swagger UI. ([#2861](https://github.com/zowe/api-layer/issues/2861))
 ### Zowe CLI
 
 #### Zowe CLI (Core)


### PR DESCRIPTION
This PR addresses an oversite to include bug fixes for API ML from versions 1.28.3 and 1.28.4.
