### PR TITLE
re-add API ML release notes for 2.12

### DIFF
--- a/docs/getting-started/release-notes/v2_12_0.md
+++ b/docs/getting-started/release-notes/v2_12_0.md
@@ -6,9 +6,23 @@ See [New features and enhancements](#new-features-and-enhancements) for a full l
 
 **Download v2.12.0 build**: Want to try new features as soon as possible? You can download the v2.12.0 build from [Zowe.org](https://www.zowe.org/download.html).
 
+### Zowe API Mediation Layer
+
+* Added a Central API ML registry endpoint to the Cloud Gateway to access an aggregated view of all services from all domains. ([#3076](https://github.com/zowe/api-layer/issues/3076))
+* It is now possible to forward the client certificate from Central Gateway to Domain Gateway in the request header. ([#3046](https://github.com/zowe/api-layer/issues/3046))
+* You can now register the Gateway to an additional Discovery service. Clients outside of the API ML cluster can now know about other gateways to facilitate routing to clusters and domains. ([#3068](https://github.com/zowe/api-layer/issues/3068) and [#3044](https://github.com/zowe/api-layer/issues/3044))
+* You can now verify service SSO support from API ML. ([#3054](https://github.com/zowe/api-layer/issues/3054)) 
+
 ## Bug fixes
 
 Zowe Version 2.12.0 contains the bug fixes that are described in the following topics.
+
+### Zowe API Mediation Layer
+
+* Fixed normalization of `baseUrl` in ZAAS client. ([#3123](https://github.com/zowe/api-layer/issues/3123))
+* Added the JVM heap configuration to `zowe.yaml`. ([#3087](https://github.com/zowe/api-layer/issues/3087))
+* Fixed an error preventing the Catalog UI to load when a service does not have a required parameter. ([#3050](https://github.com/zowe/api-layer/issues/3050))
+* Fixed a navigation issue in the Catalog when using the browser back button. ([#3135](https://github.com/zowe/api-layer/issues/2998))
 
 ### Zowe CLI
 


### PR DESCRIPTION
THe API ML release notes for 2.12 were accidentally deleated from docs-staging. This PR re-adds these release notes.
