### PR TITLE
ZIS load module typo fix

### DIFF
--- a/docs/user-guide/configure-xmem-server.md
+++ b/docs/user-guide/configure-xmem-server.md
@@ -168,11 +168,11 @@ The cross memory `ZWESISTC` task starts and stops the `ZWESASTC` task as needed.
 You can start the cross memory server using the command `/S ZWESISTC` once the following steps have been completed.
 
 - JCL members STC - `ZWESISTC` and `ZWESASTC` are copied from `SZWESAMP` installation PDS to a PDS on the JES concatenation path.
-- The PDSE Load Library `SZWEAUTH` is APF-authorized, or Load modules `ZWESI00` and `ZWESAUX` are copied to an existing APF Auth LoadLib.
+- The PDSE Load Library `SZWEAUTH` is APF-authorized, or Load modules `ZWESIS01` and `ZWESAUX` are copied to an existing APF Auth LoadLib.
 - The JCL member `ZWESISTC` DD statements are updated to point to the location of `ZWESIS01` and `ZWESIP00`. 
 - The load modules `ZWESIS01` and `ZWESAUX` must run in key 4 and be non-swappable by adding a PPT entry to the SCHEDxx member of the system PARMLIB 
 ```
-PPT PGMNAME(ZWESI00) KEY(4) NOSWAP
+PPT PGMNAME(ZWESIS01) KEY(4) NOSWAP
 PPT PGMNAME(ZWESAUX) KEY(4) NOSWAP
 ```
 

--- a/docs/user-guide/zos-components-installation-checklist.md
+++ b/docs/user-guide/zos-components-installation-checklist.md
@@ -57,7 +57,7 @@ To start Zowe without the desktop (for example to launch just the API Mediation 
 
 | Task | Results | Time Estimate |  
 |--------------------|----|------|
-| [Configure the Zowe cross memory server (ZIS)](./configure-xmem-server.md) | * JCL member `ZWESLSTC` is copied from `SZWESAMP` installation PDS to a PDS on the JES concatenation path. <br /> * The PDSE Load Library `SZWEAUTH` is APF-authorized, or the load module `ZWESI00` is copied to an existing APF Auth LoadLib.<br /> * The JCL member `ZWESLSTC DD` statements are updated to point to the location of `ZWESI00` and `ZWESIP00`. | 30 minutes 
+| [Configure the Zowe cross memory server (ZIS)](./configure-xmem-server.md) | * JCL member `ZWESISTC` is copied from `SZWESAMP` installation PDS to a PDS on the JES concatenation path. <br /> * The PDSE Load Library `SZWEAUTH` is APF-authorized, or the load module `ZWESIS01` is copied to an existing APF Auth LoadLib.<br /> * The JCL member `ZWESISTC DD` statements are updated to point to the location of `ZWESIS01` and `ZWESIP00`. | 30 minutes 
 
 ## Configuring High Availability (optional)
 


### PR DESCRIPTION
Fix for the cross memory server (ZIS) load module name ZWESI00 -> ZWESIS01