### PR TITLE
removing ZOWE_V3_ERR_FORMAT env variable doc

### DIFF
--- a/docs/user-guide/cli-configuringcli-ev.md
+++ b/docs/user-guide/cli-configuringcli-ev.md
@@ -47,9 +47,3 @@ By default, the CLI daemon mode binary creates or reuses a file in the user's ho
 | ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
 | All | `ZOWE_DAEMON_DIR` | Lets you override the complete path to the directory that will hold daemon files related to this user. The directory can contain the following files:<ul><li>`daemon.lock`</li><li>`daemon.sock`</li><li>`daemon_pid.json`</li></ul> | Any valid path on your computer | `<your_home_dir>/.zowe/daemon`<p>**Examples:**</p><ul><li>**Windows:** `%HOMEPATH%\.zowe\daemon`</li><li>**Linux:** `$HOME/.zowe/daemon`</li></ul> |
 | Windows (only) | `ZOWE_DAEMON_PIPE` | Lets you override the last two segments of the name of the communication pipe between the daemon executable (.exe) and the daemon. | Any valid path on your computer | `\\.\pipe\%USERNAME%\ZoweDaemon
-
-## Setting other environment variables
-
-| Platform | Environment Variable  | Description | Values | Default |
-| ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| All | `ZOWE_V3_ERR_FORMAT` | For Zowe V2, reformats the message displayed in REST request errors so problem details, and service response and diagnostic information, display in a reader friendly manner. In Zowe V3, this will be the only error format used and this environment variable will not be available.| TRUE, FALSE, blank | blank |


### PR DESCRIPTION
**This update applies only to Zowe V3 doc in Zowe Docs.**

Updating V3 doc to match work in [CLI PR 1859](https://github.com/zowe/zowe-cli/pull/1859)/[CLI Issue 1792](https://docs.zowe.org/stable/user-guide/cli-configuringcli-ev):
- removed mention of ZOWE_V3_ERR_FORMAT env variable from [Configuring Zowe CLI environment variables](https://docs.zowe.org/stable/user-guide/cli-configuringcli-ev)
- could **not** remove doc of `bright` command b/c the command is only documented in the typedoc and not in the Zowe Docs doc content. (There is no mention of "bright" or "Brightside" pertaining to the command in the Zowe Docs doc content.)