### PR TITLE
Add descriptions of runtime components and add description of ZIS

### DIFF
--- a/docs/user-guide/install-zos.md
+++ b/docs/user-guide/install-zos.md
@@ -2,19 +2,29 @@
 
 Installation of Zowe&trade; server-side components on z/OS, consists of the following two parts: 
 
-* **The Zowe runtime**, which consists of the following components: 
-   - Zowe Application Framework
-   - Zowe API Mediation Layer
-   - Z Secure Services (ZSS)
+* [Zowe runtime](#zowe-runtime)
+* [Zowe Cross Memory Server (ZIS)](#)
 
-* **The Zowe Cross Memory Server (ZIS)**  
+## Zowe runtime
 
- An APF authorized server application that provides privileged services to Zowe in a secure manner.
+The Zowe runtime consists of the following three components: 
 
-:::note**Notes**
-* Zowe offers the possibility to run some of its Unix components in a container rather than under USS. For more information, see [Installing Zowe via a containerization build (PAX filw)](k8s-introduction.md).
-* Zowe also offers the option of configuration for high availability. For more information, see [Configuring high availability (optional)](zowe-ha-overview.md).
-:::
+- **Zowe Application Framework**  
+Zowe Application Framework modernizes and simplifies working on the mainframe via a web visual interface. Functionality is provided through apps and a desktop user experience called the Zowe Desktop. Base functionality includes apps to work with JES, MVS Data Sets, Unix System Services, as well as a 3270 Terminal, Virtual Terminal, and an Editor. 
+
+- **Zowe API Mediation Layer (API ML)**  
+Zowe API ML provides a reverse proxy and enables REST APIs by providing a single point of access for mainframe service REST APIs like MVS Data Sets, JES, as well as working with z/OSMF. Zowe API ML has dynamic discovery capability for these services and Gateway is also responsible for generating the authentication token used to provide single sign-on (SSO) functionality.
+
+- **Z System Services Server (ZSS)**  
+ZSS serves as one of the primary, authenticated back-ends that communicates with z/OS and works closely with ZIS  and provides Zowe with a number of APIs: z/OS Unix files and data sets, control of the plug-ins and services lifecycle, security management, etc. The Zowe Desktop especially delegates a number of its services to ZSS which it accesses through the default http port `7557`. ZSS is written in C and uses native calls to z/OS to provide its services.
+
+## The Zowe Cross Memory Server (ZIS)  
+
+After the installation of Zowe runtime, it is necessary to install the Zowe Cross Memory Server (ZIS)
+
+The Zowe Cross Memeory Server, also referred to as Zowe Interprocess Services (ZIS) is an APF authorized server application that provides privileged services to Zowe in a secure manner. For security reasons, it is not an HTTP server. Instead, this server has a trust relationship with ZSS.
+
+Other Zowe components can work through ZSS in order to handle z/OS data that would otherwise be unavailable or insecure to access from higher-level languages and software.
 
 ## Roles and responsibilities for server-side component installation
 


### PR DESCRIPTION
As part of Issue #2961 the components in Zowe runtime should be described in the intro. This PR adds these descriptions.  

