### PR TITLE
Setting latest_version to 2.13.0 and displaying getting_started on the sidebar

### DIFF
--- a/docs/whats-new/release-notes/v2_13_0.md
+++ b/docs/whats-new/release-notes/v2_13_0.md
@@ -1,0 +1,138 @@
+# Version 2.13.0 (December 2023)
+
+Welcome to the Zowe Version 2.13.0 release!
+
+See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
+
+**Download v2.13.0 build**: Want to try new features as soon as possible? You can download the v2.13.0 build from [Zowe.org](https://www.zowe.org/download.html).
+
+## New features and enhancements
+
+Zowe Version 2.13.0 contains the enhancements that are described in the following topics.
+
+### Zowe installation and packaging
+- Added utility `getesm` into `bin/utils`. It tells you which `ESM` your system is using. ([#3662](https://github.com/zowe/zowe-install-packaging/issues/3662))
+
+### Zowe Application Framework
+
+#### ZLUX App Server
+- Updated schema to allow `cipher` customization in `IANA` format. ([#284](https://github.com/zowe/zlux-app-server/pull/284))
+- Updated schema to allow `curve` customization. ([#284](https://github.com/zowe/zlux-app-server/pull/284))
+- Updated defaults to read `TLS` settings and `IP` settings from the `zowe.network.server` attribute of `Zowe.yaml`. ([#284](https://github.com/zowe/zlux-app-server/pull/284)) 
+
+#### ZLUX Server Framework
+- Added support for using `zowe.network` and `components.app-server.zowe.network` to set listener IP and TLS properties including `max and min version`, `ciphers`, and `ECDH curves`. ([#511](https://github.com/zowe/zlux-server-framework/pull/511)) 
+
+#### Zowe Common C
+- Added support for using `zowe.network` and `components.zss.zowe.network` to set `TLS` version properties. ([#411](https://github.com/zowe/zowe-common-c/pull/411)
+
+#### ZSS
+- Added support for using `zowe.network` and `components.zss.zowe.network` to set listener `IP` and `TLS` version properties. ([#659](https://github.com/zowe/zss/pull/659))
+- Added support for using `zowe.network` and `components.zss.zowe.network` to set `cipher` suites.
+- Changed pattern matching for keyrings to allow more types of keyrings in the future. ([#581](https://github.com/zowe/zss/pull/581))
+- Consolidated `JWK warnings` into improved `ZWES1606W message`. ([#663](https://github.com/zowe/zss/pull/663)) 
+
+### Zowe API Mediation Layer
+* CORS is now enabled in default mode with AT-TLS profile. This configuration allows for AT-TLS to allow all origins by default. ([#3221](https://github.com/zowe/api-layer/issues/3221))
+* Zowe authentication scheme has been added to the Cloud Gateway. ([#3214](https://github.com/zowe/api-layer/issues/3214))
+* The endpoint `/zaas/zoweJwt` has been added to provide Zowe JWT token for Spring Cloud Gateway. ([#3199](https://github.com/zowe/api-layer/issues/3199))
+* The endpoint `/zaas/zosmf` has been added to provide z/OSMF JWT/LTPA2 token for Spring Cloud Gateway. ([#3153](https://github.com/zowe/api-layer/issues/3153))
+* The endpoint `/zaas/safIdt` has been added to provide the SAF IDT token for Spring Cloud Gateway. ([#3220](https://github.com/zowe/api-layer/issues/3220))
+* z/OSMF scheme in Spring Cloud Gateway is now supported. ([#3190](https://github.com/zowe/api-layer/issues/3190))
+* Fixes have been applied for Azure JWKS reader. ([#3200](https://github.com/zowe/api-layer/issues/3200))
+* Additional Discovery Service registration by Spring Cloud Gateway is now supported. ([#3181](https://github.com/zowe/api-layer/issues/3181))
+* Gateway additional registrations HA ([#3127](https://github.com/zowe/api-layer/issues/3127))
+* Fetch JWK from OIDC providers. This feature implements a mechanism and new properties in OIDC to configure the JWK keys location obtained according to documentation from the authorization server's metadata. ([#3137](https://github.com/zowe/api-layer/issues/3137))
+
+### Zowe CLI
+
+#### Zowe CLI (Core)
+- Incorporated all source code from the `zowe/imperative` Github repository into the `zowe/zowe-cli` repository for a more streamlined code architecture. This change should have no user impact. ([#1821](https://github.com/zowe/zowe-cli/pull/1821))
+- Deprecated `getDataSet` in the `zosfiles` command group utility functions. `getDataSet` will be removed in Zowe V3. Use `zosfiles` SDK's `ZosFilesUtils.getDataSetFromName` command instead. ([#1696](https://github.com/zowe/zowe-cli/issues/1696))
+
+#### z/OS FTP Plug-in for Zowe CLI
+- Added a step to check the validity of a USS file path for the `upload` and `stdin-to-uss-file` commands. ([#145](https://github.com/zowe/zowe-cli-ftp-plugin/pull/145))
+
+### Zowe Explorer
+
+#### Zowe Explorer (Core)
+- See the [Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/zowe-explorer/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer API
+- See the [Zowe Explorer API](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/zowe-explorer-api/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer FTP Extension
+- See the [Zowe Explorer FTP Extension](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/zowe-explorer-ftp-extension/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer ESLint Plug-in
+- See the [Zowe Explorer ESLint Plug-in](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/eslint-plugin-zowe-explorer/CHANGELOG.md) changelog for updates included in this release.
+
+## Bug fixes
+
+Zowe Version 2.13.0 contains the bug fixes that are described in the following topics.
+
+### Zowe installation and packaging
+- Users were not able to use zOSMF workflows because the workflow files were not encoded in ASCII format. In this release, the workflow files in the Zowe PAX are encoded in ASCII format. ([#3591](https://github.com/zowe/zowe-install-packaging/issues/3591)).
+
+### Zowe API Mediation Layer
+#### ZSS
+- Corrected build environment file's use of IP address to github.com. ([3660](https://github.com/zowe/zss/issues/660)) 
+
+- Fixed signing the outgoing call from Cloud Gateway where necessary. ([#3203](https://github.com/zowe/api-layer/issues/3203)) 
+- Fixed AT-TLS support by fixing the AT-TLS filter setup, adding a debug message for AT-TLS support mode initialization, disabling routing to the Discovery service from the Gateway, and updating dsl in the security chain setup. ([#3186](https://github.com/zowe/api-layer/issues/3186))
+- Fixed read public key from keyring. ([#3212](https://github.com/zowe/api-layer/issues/3212))
+- Updated bean definitions for noop cache mode. ([#3197](https://github.com/zowe/api-layer/issues/3197)) 
+- Changed ehCache storage location. This fix uses the correct environment variable to avoid a resource lock when reading the cache directory in HA setup. ([#3184](https://github.com/zowe/api-layer/issues/3184))
+- Fixed qualifier for the JWT clock. ([#3180](https://github.com/zowe/api-layer/pull/3180))
+- Set HTTP client timeouts. ([#3174](https://github.com/zowe/api-layer/issues/3174)) 
+- Made style updates for Catalog UI and Caching Fix for static file distribution in API Catalog. ([#3168](https://github.com/zowe/api-layer/issues/3168))
+- Gateway additional registration fixes. ([#3172](https://github.com/zowe/api-layer/issues/3172))
+- Set defaults in the cloud-gateway-service application.yml. ([#3167](https://github.com/zowe/api-layer/issues/3167))
+- Added Qualifier for clock to avoid conflict in extension. ([#3166](https://github.com/zowe/api-layer/pull/3166))
+- Enhanced error handling in the UI. ([#3158](https://github.com/zowe/api-layer/issues/3158))
+- Fixed context path from the application property in the mock catalog controller. ([#3159](https://github.com/zowe/api-layer/issues/3159))
+
+### Zowe CLI
+#### Zowe CLI Imperative Framework
+
+- Added missing `npm-shrinkwrap.json` file to `package.json`. ([#1978](https://github.com/zowe/zowe-cli/pull/1978))
+- Added missing z/OSMF connection options to the z/OS `logs` command group. ([#1842](https://github.com/zowe/zowe-cli/pull/1842))
+- Removed out-of-date `Perf-Timing` performance timing package to improve Zowe CLI maintainability. ([#1830](https://github.com/zowe/zowe-cli/pull/1830))
+- Fixed behavior where a specified directory name was being lowercased on non-PDS data sets when downloading all data sets. ([#1722](https://github.com/zowe/zowe-cli/issues/1722))
+- Fixed bug where encoding is not passed to the `Download USS Directory` API. ([#1825](https://github.com/zowe/zowe-cli/issues/1825))
+
+#### Zowe CLI Imperative Framework
+- Fixed `AbstactRestClient` command failing to return when streaming a large data set or USS file. ([#1805](https://github.com/zowe/zowe-cli/issues/1805), [#1813](https://github.com/zowe/zowe-cli/issues/1813), [#1824](https://github.com/zowe/zowe-cli/issues/1824))
+
+#### DB2 Plug-in for Zowe CLI
+- Added missing `npm-shrinkwrap.json` file to `package.json`. ([#137](https://github.com/zowe/zowe-cli-db2-plugin/pull/137))
+- Updated `ibm_db` dependency for technical currency. ([#134](https://github.com/zowe/zowe-cli-db2-plugin/pull/134/files))
+
+#### z/OS FTP Plug-in for Zowe CLI
+- Added missing `npm-shrinkwrap.json` file to `package.json`. ([#147](https://github.com/zowe/zowe-cli-ftp-plugin/pull/147))
+- Provided new utility function to check file names for valid characters. ([#143](https://github.com/zowe/zowe-cli-ftp-plugin/issues/143))
+
+### Zowe Explorer
+#### Zowe Explorer (Core)
+
+- See the [Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/zowe-explorer/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer API
+- See the [Zowe Explorer API](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/zowe-explorer-api/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer FTP Extension
+- See the [Zowe Explorer FTP Extension](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/zowe-explorer-ftp-extension/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer ESLint Plug-in
+- See the [Zowe Explorer ESLint Plug-in](https://github.com/zowe/vscode-extension-for-zowe/blob/main/packages/eslint-plugin-zowe-explorer/CHANGELOG.md) changelog for updates included in this release.
+
+### Vulnerabilities fixed
+
+Zowe discloses fixed vulnerabilities in a timely manner giving you sufficient time to plan your upgrades. Zowe does not disclose the vulnerabilities fixed in the latest release as we respect the need for at least 45 days to decide when and how you upgrade Zowe. When a new release is published, Zowe publishes the vulnerabilities fixed in the previous release. For more information about the Zowe security policy, see the [Security page](https://www.zowe.org/security.html) on the Zowe website.
+
+The following security issues were fixed by the Zowe security group in version 2.12.
+
+- CVE-2023-33201 (BDSA-2023-1625)
+- CVE-2022-25883
+- CVE-2023-34034 (BDSA-2023-1825)
+- CVE-2023-38286 (BDSA-2023-1804)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,4 @@
-const LATEST_VERSION = "v2.12.x";
+const LATEST_VERSION = "v2.13.x";
 const versionsArray = require("./versions.json");
 
 module.exports = {

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,6 +8,7 @@ module.exports = {
       className: "ToCheadercolor",
       link: {type:"doc", id:"whats-new/release-notes/release-notes-overview"},
       items: [
+        "whats-new/release-notes/v2_13_0",
         "whats-new/release-notes/v2_12_0",
         "whats-new/release-notes/v2_11_0",
         "whats-new/release-notes/v2_10_0",


### PR DESCRIPTION
Brings docs live and corrects tags to display current version.