### PR TITLE
Fix broken links in Advanced API ML configuration

### DIFF
--- a/docs/user-guide/api-mediation/configuration-cors.md
+++ b/docs/user-guide/api-mediation/configuration-cors.md
@@ -3,7 +3,7 @@
 :::info**Role:** system programmer
 :::
 
-As a system programmer, you can enable the Gateway to terminate CORS requests for itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled for Gateway routes `gateway/api/v1/**` and for individual services. After enabling the feature as stated in the following procedure, API Gateway endpoints start handling CORS requests. Individual services can control whether they want the Gateway to handle CORS for them through the [Custom Metadata](../../extend/extend-apiml/custom-metadata.md) parameters.
+As a system programmer, you can enable the Gateway to terminate CORS requests for itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled for Gateway routes `gateway/api/v1/**` and for individual services. After enabling the feature as stated in the following procedure, API Gateway endpoints start handling CORS requests. Individual services can control whether they want the Gateway to handle CORS for them through the [Custom Metadata](../../extend/extend-apiml/onboard-spring-boot-enabler/#custom-metadata) parameters.
 
 When the Gateway handles CORS on behalf of the service, the Gateway sanitizes the following defined headers from the communication (upstream and downstream) in the following comma -separated list:
 ```
@@ -12,15 +12,15 @@ Access-Control-Request-Method,Access-Control-Request-Headers,Access-Control-Allo
 
 The resulting request to the service is not a CORS request. No additional specification of the service is required. The list can be overridden by specifying a different comma-separated list in the property `components.gateway.apiml.service.ignoredHeadersWhenCorsEnabled` in `zowe.yaml`.
 
-Additionally, the Gateway handles the preflight requests on behalf of the service when CORS is enabled in [Custom Metadata](../../extend/extend-apiml/custom-metadata.md), replying with CORS headers:
+Additionally, the Gateway handles the preflight requests on behalf of the service when CORS is enabled in Custom Metadata, replying with CORS headers:
 - `Access-Control-Allow-Methods: GET,HEAD,POST,DELETE,PUT,OPTIONS`
 - `Access-Control-Allow-Headers: origin, x-requested-with`
 - `Access-Control-Allow-Credentials: true`
 - `Access-Control-Allow-Origin: *` 
 
-Alternatively, list the origins as configured by the service, associated with the value **customMetadata.apiml.corsAllowedOrigins** in [Custom Metadata](../extend/extend-apiml/custom-metadata).
+Alternatively, list the origins as configured by the service, associated with the value **customMetadata.apiml.corsAllowedOrigins** in Custom Metadata.
 
-If CORS is enabled for Gateway routes but not in [Custom Metadata](../extend/extend-apiml/custom-metadata), the Gateway does not set any of the previously listed CORS headers. As such, the Gateway rejects any CORS requests with an origin header for the Gateway routes.
+If CORS is enabled for Gateway routes but not in Custom Metadata, the Gateway does not set any of the previously listed CORS headers. As such, the Gateway rejects any CORS requests with an origin header for the Gateway routes.
 
 Use the following procedure to enable CORS handling.
      

--- a/docs/user-guide/api-mediation/configuration-customizing-management-of-apiml-load-limits.md
+++ b/docs/user-guide/api-mediation/configuration-customizing-management-of-apiml-load-limits.md
@@ -5,16 +5,11 @@
 
 As a system programmer, you can customize your configuration for how API ML manages both northbound and southbound load limits in single instances:
 
- * To change the number of concurrent connections per route passing through the API Gateway, see [Customizing connection limits](./connection-limits).
- * To change the global Gateway timeout value for the API ML instance, see [Customizing Gateway timeouts](./gateway-timeouts).
- * Also see the following properties in [API Gateway configuration parameters](./api-mediation/api-mediation-internal-configuration/#runtime-configuration): 
+ * To change the number of concurrent connections per route passing through the API Gateway, see [Customizing connection limits](./configuration-connection-limits).
+
+ * To change the global Gateway timeout value for the API ML instance, see [Customizing Gateway timeouts](./configuration-gateway-timeouts).
+
+ * Also see the following properties in API Gateway configuration parameters: 
     * `server.maxTotalConnections`
     * `server.maxConnectionsPerRoute`
 
-Review the following configuration customization options for how API ML manages load limits in high availability:
-
-* To customize the Gateway retry policy, see [Customizing Gateway retry policy](./gateway-retry-policy).
-
-* To configure a unique cookie name for each instance to prevent overwriting of the default cookie name in the case of multiple Zowe instances, or for more complex deployment strategies, see [Configuring a unique cookie name for a specific API ML instance](./unique-cookie-name-for-multiple-zowe-instances).
-* To distribute the load balancer cache between instances of the API Gateway, see [Distributing the load balancer cache](./distributed-load-balancer-cache).
-* To ..., see [Setting a consistent service ID](./configuration-set-consistent-service-id.md).

--- a/docs/user-guide/api-mediation/configuration-routing.md
+++ b/docs/user-guide/api-mediation/configuration-routing.md
@@ -3,21 +3,36 @@
 :::info**Roles:** system programmer, system administrator, security administrator
 :::
 
-The Zowe API Mediation Layer offers a range of routing configurations for enhanced functionality and security. You can customize your configuration for how API ML manages both northbound and southbound load limits in single instances, including changing the number of concurrent connections per route passing through the API Gateway, and changing the global Gateway timeout value for the API ML instance.
+The Zowe API Mediation Layer offers a range of routing configurations for enhanced functionality and security. 
 
-Customizing CORS enables the Gateway to handle Cross-Origin Resource Sharing requests, while settings for encoded slashes and unique cookie names cater to specific operational needs of onboarding applications and multiple Zowe instances. The Gateway retry policy, customizable through zowe.yaml, optimizes request handling, which can be especially useful in high availability scenarios.
+You can customize your configuration for how API ML manages both northbound and southbound load limits in single instances, including changing the number of concurrent connections per route passing through the API Gateway, and changing the global Gateway timeout value for the API ML instance.
+
+To change the number of concurrent connections per route passing through the API Gateway, see [Customizing connection limits](./configuration-connection-limits).
+
+To change the global Gateway timeout value for the API ML instance, see [Customizing Gateway timeouts](./configuration-gateway-timeouts).
+
+Also see the following properties in API Gateway configuration parameters: 
+* `server.maxTotalConnections`
+* `server.maxConnectionsPerRoute`
+
+Customizing CORS enables the Gateway to handle Cross-Origin Resource Sharing requests, while settings for encoded slashes and unique cookie names cater to specific operational needs of onboarding applications and multiple Zowe instances.
+
+For more information, see [Customizing Cross-Origin Resource Sharing (CORS)](./configuration-cors)
+
+To onboard applications which expose endpoints that expect encoded slashes, see [Using encoded slashes](./configuration-url-handling)
+
+The Gateway retry policy, customizable through zowe.yaml, optimizes request handling, which can be especially useful in high availability scenarios.
+
+To customize the Gateway retry policy, see [Customizing Gateway retry policy](./configuration-gateway-retry-policy).
 
 Additionally, API ML supports specific instance access and load balancer cache distribution, improving service identification and scalability. These configurations, including service ID adjustments for compatibility with Zowe v2, demonstrate Zowe's adaptability and robustness in API management.
 
-For details about specific configuration procedures, see the following links:
+To configure a unique cookie name for each instance to prevent overwriting of the default cookie name in the case of multiple Zowe instances, or for more complex deployment strategies, see [Configuring a unique cookie name for a specific API ML instance](./configuration-unique-cookie-name-for-multiple-zowe-instances).
 
-- [Customizing management of API ML load limits](./configuration-customizing-management-of-apiml-load-limits)
-    - [Customizing connection limits](./configuration-connection-limits)
-    - [Customizing Gateway timeouts](./configuration-gateway-timeouts)
-- [Customizing Cross-Origin Resource Sharing (CORS)](./configuration-cors)
-- [Using encoded slashes](./configuration-url-handling)
-- [Customizing Gateway retry policy](./configuration-gateway-retry-policy)
-- [Configuring a unique cookie name for a specific API ML instance](./configuration-unique-cookie-name-for-multiple-zowe-instances)
-- [Retrieving a specific service within your environment](./configuration-access-specific-instance-of-service)
-- [Distributing the load balancer cache](./configuration-distributed-load-balancer-cache)
-- [Setting a consistent service ID](./configuration-set-consistent-service-id)
+To determine which service instance is being called, you can customize the Gateway to output a routed instance header. For more information, see [Retrieving a specific service within your environment](./configuration-access-specific-instance-of-service).
+
+To distribute the load balancer cache between instances of the API Gateway, see [Distributing the load balancer cache](./configuration-distributed-load-balancer-cache).
+
+To modify the service ID to ensure compatibility of services that use a non-conformant organization prefix with Zowe v2, see [Setting a consistent service ID](./configuration-set-consistent-service-id).
+
+

--- a/docs/user-guide/api-mediation/configuration-set-consistent-service-id.md
+++ b/docs/user-guide/api-mediation/configuration-set-consistent-service-id.md
@@ -7,5 +7,5 @@ As an API service extender you can modify the service ID to ensure compatibility
 
 For more information, see the following parameter in the article Discovery Service configuration parameters:
 
-* **[components.discovery.apiml.discovery.serviceIdPrefixReplacer](./api-mediation/discovery-service-configuration/#api-ml-configuration)**  
+* **components.discovery.apiml.discovery.serviceIdPrefixReplacer**  
     This parameter is used to modify the service ID of a service instance, before it registers to API ML. Using this parameter ensures compatibility of services that use a non-conformant organization prefix with v2, based on Zowe v2 conformance.


### PR DESCRIPTION
Post release of 2.13, a few pages were found to have broken links in Advanced API ML configuration. This PR addresses those broken links.