### PR TITLE
Auto-detect RC number in update typedoc script

### DIFF
--- a/scripts/updateTypedoc.sh
+++ b/scripts/updateTypedoc.sh
@@ -20,7 +20,8 @@ rm -rf typedoc
 rm -f zowe-nodejs-sdk-typedoc.zip
 
 # Download and extract new files
-curl -L -o zowe-nodejs-sdk-typedoc.zip https://zowe.jfrog.io/artifactory/libs-release-local/org/zowe/sdk/zowe-nodejs-sdk/$ZOWE_VERSION/zowe-nodejs-sdk-typedoc-$ZOWE_VERSION-RC2.zip
+filename=$(curl https://zowe.jfrog.io/artifactory/libs-release-local/org/zowe/sdk/zowe-nodejs-sdk/$ZOWE_VERSION/ | grep -o 'zowe-nodejs-sdk-typedoc-[^"<]\+' | tail -1)
+curl -L -o zowe-nodejs-sdk-typedoc.zip https://zowe.jfrog.io/artifactory/libs-release-local/org/zowe/sdk/zowe-nodejs-sdk/$ZOWE_VERSION/$filename
 unzip zowe-nodejs-sdk-typedoc.zip
 
 # Stage changes in Git


### PR DESCRIPTION
This PR enhances `scripts/updateTypedoc.sh` so that it auto-detects the latest RC number. Previously it had an RC number hardcoded and would fail if no bundle existed for that exact RC.

**How to Test**
Run the update typedoc script for Zowe 2.13.0 to verify that it downloads and extracts the RC2 zip file successfully.