### PR TITLE
changing references of vNext

### DIFF
--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -73,20 +73,20 @@ Use the following procedure to install Zowe CLI from a local package:
 
 1. Meet the [prerequisites](#prerequisites) for installing Zowe CLI.
 
-2. Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe vNext CLI Core** button.
+2. Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<vNext\> CLI Core** button.
 
 3. Read the End User License Agreement for Zowe and click **I agree** to download the core package.
 
-    `zowe-cli-package-next-2022MMDD.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
+    `zowe-cli-package-<vNext>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
 
 4. **(Optional)** Meet the [prerequisites](#prerequisites) for installing Zowe CLI plug-ins.
-5. **(Optional)** Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe vNext CLI Plugins** button to download the plugins.
+5. **(Optional)** Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<vNext\> CLI Plugins** button to download the plug-ins.
 
 6. **(Optional)** Read the End User License Agreement for Zowe plug-ins and click **I agree** to download the plugins package.
 
-    `zowe-cli-plugins-next-2022MMDD.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
+    `zowe-cli-plugins-next-<vNext>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
 
-7. Unzip the contents of `zowe-cli-package-next-2021MMDD.zip` (and optionally `zowe-cli-plugins-2021MMDD.zip`) to a working directory.
+7. Unzip the contents of `zowe-cli-package-<vNext>.zip` (and optionally `zowe-cli-plugins-<vNext>.zip`) to a working directory.
 
 8. To install Zowe CLI Core, open a command-line window and issue the following commands to the working directory that you used in Step 7:
 
@@ -94,7 +94,11 @@ Use the following procedure to install Zowe CLI from a local package:
    npm install -g zowe-cli.tgz
    ```
 
-   **Note:** If an `EACCESS` error displays, see [Resolving EACCESS permissions errors when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) in the npm documentation.
+   :::note
+   
+   If an `EACCESS` error displays, see [Resolving EACCESS permissions errors when installing packages globally](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) in the npm documentation.
+
+   :::
 
 9. **(Optional)** To install Zowe CLI plug-ins, issue the following command to the working directory that you used in Step 7: 
 

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -73,20 +73,20 @@ Use the following procedure to install Zowe CLI from a local package:
 
 1. Meet the [prerequisites](#prerequisites) for installing Zowe CLI.
 
-2. Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<X.X.X\> CLI Core** button.
+2. Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<X.Y.Z\> CLI Core** button.
 
 3. Read the End User License Agreement for Zowe and click **I agree** to download the core package.
 
-    `zowe-cli-package-<X.X.X>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
+    `zowe-cli-package-<X.Y.Z>.zip` is downloaded to your computer.
 
 4. **(Optional)** Meet the [prerequisites](#prerequisites) for installing Zowe CLI plug-ins.
-5. **(Optional)** Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<X.X.X\> CLI Plugins** button to download the plug-ins.
+5. **(Optional)** Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<X.Y.Z\> CLI Plugins** button to download the plug-ins.
 
 6. **(Optional)** Read the End User License Agreement for Zowe plug-ins and click **I agree** to download the plugins package.
 
-    `zowe-cli-plugins-next-<X.X.X>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
+    `zowe-cli-plugins-next-<X.Y.Z>.zip` is downloaded to your computer.
 
-7. Unzip the contents of `zowe-cli-package-<X.X.X>.zip` (and optionally `zowe-cli-plugins-<X.X.X>.zip`) to a working directory.
+7. Unzip the contents of `zowe-cli-package-<X.Y.Z>.zip` (and optionally `zowe-cli-plugins-<X.Y.Z>.zip`) to a working directory.
 
 8. To install Zowe CLI Core, open a command-line window and issue the following commands to the working directory that you used in Step 7:
 

--- a/docs/user-guide/cli-installcli.md
+++ b/docs/user-guide/cli-installcli.md
@@ -73,20 +73,20 @@ Use the following procedure to install Zowe CLI from a local package:
 
 1. Meet the [prerequisites](#prerequisites) for installing Zowe CLI.
 
-2. Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<vNext\> CLI Core** button.
+2. Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<X.X.X\> CLI Core** button.
 
 3. Read the End User License Agreement for Zowe and click **I agree** to download the core package.
 
-    `zowe-cli-package-<vNext>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
+    `zowe-cli-package-<X.X.X>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
 
 4. **(Optional)** Meet the [prerequisites](#prerequisites) for installing Zowe CLI plug-ins.
-5. **(Optional)** Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<vNext\> CLI Plugins** button to download the plug-ins.
+5. **(Optional)** Navigate to [Download Zowe](https://www.zowe.org/download.html) and click the **Zowe \<X.X.X\> CLI Plugins** button to download the plug-ins.
 
 6. **(Optional)** Read the End User License Agreement for Zowe plug-ins and click **I agree** to download the plugins package.
 
-    `zowe-cli-plugins-next-<vNext>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
+    `zowe-cli-plugins-next-<X.X.X>.zip` is downloaded to your computer (where MMDD indicates the month and day of the build).
 
-7. Unzip the contents of `zowe-cli-package-<vNext>.zip` (and optionally `zowe-cli-plugins-<vNext>.zip`) to a working directory.
+7. Unzip the contents of `zowe-cli-package-<X.X.X>.zip` (and optionally `zowe-cli-plugins-<X.X.X>.zip`) to a working directory.
 
 8. To install Zowe CLI Core, open a command-line window and issue the following commands to the working directory that you used in Step 7:
 


### PR DESCRIPTION
Describe your pull request here: Adding angle brackets to vNext to emphasize that vNext is a variable that could change depending on the latest Zowe release.

List the file(s) included in this PR: cli-installcli.md

After creating the PR, follow the instructions in the comments.
