### PR TITLE
adding link for remote usage info; split content

### DIFF
--- a/docs/user-guide/ze-cics-usage-tips.md
+++ b/docs/user-guide/ze-cics-usage-tips.md
@@ -1,0 +1,9 @@
+# Usage tips
+
+The following tips can help you perform tasks more efficiently when working with the CICS extension:
+
+- All menu action commands available by right-clicking a profile or resource (excluding **Show Attributes**) can be applied to multiple items. To do this, select the multiple nodes of the same type before right-clicking and selecting the command.
+
+- To select multiple nodes, you can hold Ctrl/Cmd key while clicking resources. Or you can select the first item in a list of nodes then hold Shift and click both the last item to select a consecutive list of nodes.
+
+- Click the refresh icon at the top of the CICS view to reload the resources in every region.

--- a/docs/user-guide/ze-usage-tips.md
+++ b/docs/user-guide/ze-usage-tips.md
@@ -1,9 +1,29 @@
-# Usage tips
+# Usage Tips
 
-The following tips can help you perform tasks more efficiently when working with the CICS extension:
+Make the best use of Zowe Explorer with the following tips.
 
-- All menu action commands available by right-clicking a profile or resource (excluding **Show Attributes**) can be applied to multiple items. To do this, select the multiple nodes of the same type before right-clicking and selecting the command.
+## Data sets, USS, and jobs persistence settings
+You can store any data sets, USS files, or jobs permanently in the **Favorites** tab. Right-click on a data set, USS file, or job and click **Add Favorite**.
 
-- To select multiple nodes, you can hold Ctrl/Cmd key while clicking resources. Or you can select the first item in a list of nodes then hold Shift and click both the last item to select a consecutive list of nodes.
+## Identify syntax errors with a syntax highlighter
+Zowe Explorer supports a syntax highlighter for data sets. To enhance the experience of using the extension, you can download an extension that highlights syntax.
 
-- Click the refresh icon at the top of the CICS view to reload the resources in every region.
+## Configure the detected language of a file or data set
+
+You can configure Visual Studio Code to use a specific language for a particular file extension type. This prevents the language for a file or data set opened in Zowe Explorer to be detected incorrectly. To set file associations, see [Add a file extension to a language](https://code.visualstudio.com/docs/languages/overview#_add-a-file-extension-to-a-language).
+
+## Edit a profile
+You can edit existing profiles listed in the **Side Bar** by clicking the profile's **Edit** icon (next to the **Search** icon). The feature lets you modify the information inside your profile.
+
+## Delete a profile
+In Zowe V1, you can permanently delete profiles by right-clicking the profile and selecting the **Delete Profile** option. The feature deletes the profile from your `.zowe` folder. In Zowe V2, right-click the profile, and select **Delete Profile** to open the configuration file and manually delete the profile.
+
+:::tip
+Alternatively, you can delete a profile  by using the VS Code **Command Palette**. Press `F1` on your keyboard, then select the **Zowe Explorer: Delete a Profile Permanently** option. In Zowe V1, you select the profile to delete. In Zowe V2, the configuration file opens for you to delete the profile manually.
+:::
+
+## Hide a profile
+You can hide a profile from the **Side Bar** by right-clicking the profile and selecting the **Hide Profile** option. If necessary, add the profile back by clicking the **+** icon on the **DATA SETS**, **UNIX SYSTEM SERVICES (USS)**, or **JOBS** bar.
+
+## Open recent members
+Zowe Explorer lets you open a list of members you have previously worked on. You can access the list by pressing `Ctrl`+`Alt`+`R` or `Command`+`Alt`+`R`.

--- a/docs/user-guide/ze-usage.md
+++ b/docs/user-guide/ze-usage.md
@@ -13,44 +13,24 @@ Review this section to familiarize yourself with Zowe Explorer and make the best
    - [Ubuntu](https://ubuntu.com/) 20.04+
 - Windows 10+
 
-### Integrated development environments: 
+### Integrated development environments:
 
 - [VS Code](https://code.visualstudio.com/) 1.53.2+
 - [Eclipse Che](https://www.eclipse.org/che/)
 - [Red Hat CodeReady Workspaces](https://www.redhat.com/en/technologies/jboss-middleware/codeready-workspaces)
 - [Theia](https://theia-ide.org/) 1.18+
 
-   **Note:** Zowe Explorer is compatible with Theia 1.18.0 or higher. However, we recommend using a [Theia community release](https://theia-ide.org/releases/) as Zowe Explorer could experience possible unexpected behaviors with the latest Theia releases.
+   :::note
+   
+   Zowe Explorer is compatible with Theia 1.18.0 or higher. However, we recommend using a [Theia community release](https://theia-ide.org/releases/) as Zowe Explorer could experience possible unexpected behaviors with the latest Theia releases.
 
-## Usage Tips
+   :::
 
-Make the best use of Zowe Explorer with the following tips:
+## Using Zowe Explorer in remove environments
 
-### Data sets, USS, and jobs persistence settings
-You can store any data sets, USS files, or jobs permanently in the **Favorites** tab. Right-click on a data set, USS file, or job and click **Add Favorite**.
+As of Zowe Version 2.11, Zowe Explorer and the Zowe Explorer API no longer use `node-keytar`, which was used to manage mainframe credentials. This change might cause some users issues when trying to interact with remote environments.
 
-### Identify syntax errors with a syntax highlighter
-Zowe Explorer supports a syntax highlighter for data sets. To enhance the experience of using the extension, you can download an extension that highlights syntax.
-
-### Configure the detected language of a file or data set
-
-You can configure Visual Studio Code to use a specific language for a particular file extension type. This prevents the language for a file or data set opened in Zowe Explorer to be detected incorrectly. To set file associations, see [Add a file extension to a language](https://code.visualstudio.com/docs/languages/overview#_add-a-file-extension-to-a-language).
-
-### Edit a profile
-You can edit existing profiles listed in the **Side Bar** by clicking the profile's **Edit** icon (next to the **Search** icon). The feature lets you modify the information inside your profile.
-
-### Delete a profile
-In Zowe V1, you can permanently delete profiles by right-clicking the profile and selecting the **Delete Profile** option. The feature deletes the profile from your `.zowe` folder. In Zowe V2, right-click the profile, and select **Delete Profile** to open the configuration file and manually delete the profile.
-
-:::tip
-Alternatively, you can delete a profile  by using the VS Code **Command Palette**. Press `F1` on your keyboard, then select the **Zowe Explorer: Delete a Profile Permanently** option. In Zowe V1, you select the profile to delete. In Zowe V2, the configuration file opens for you to delete the profile manually.
-:::
-
-### Hide a profile
-You can hide a profile from the **Side Bar** by right-clicking the profile and selecting the **Hide Profile** option. If necessary, add the profile back by clicking the **+** icon on the **DATA SETS**, **UNIX SYSTEM SERVICES (USS)**, or **JOBS** bar.
-
-### Open recent members
-Zowe Explorer lets you open a list of members you have previously worked on. You can access the list by pressing `Ctrl`+`Alt`+`R` or `Command`+`Alt`+`R`.
+See [Usage in Remote Environments](https://github.com/zowe/vscode-extension-for-zowe/wiki/Usage-in-Remote-Environments) to learn more about how to resolve credential errors.
 
 ## Using a specific version of Zowe Explorer
 


### PR DESCRIPTION
Describe your pull request here: 

Adding link to information re: using ZE in remote environments in [Using Zowe Explorer](https://docs.zowe.org/stable/user-guide/ze-usage). Also removing Usage Tips section from [Using Zowe Explorer](https://docs.zowe.org/stable/user-guide/ze-usage) to its own article.

List the file(s) included in this PR: ze-usage.md, ze-usage-tips.md

After creating the PR, follow the instructions in the comments.
