### PR TITLE
Fix links in API ML Using section after restructuring

### DIFF
--- a/docs/extend/extend-apiml/api-mediation-components-of-URL.md
+++ b/docs/extend/extend-apiml/api-mediation-components-of-URL.md
@@ -1,6 +1,6 @@
-# Components of URL
+# Components of a URL
 
-This page provides definitions and a diagram to make sure everyone is using the same terms. These terms are often overloaded. This page tries to follow the terms used in Swagger documentation.
+This page provides definitions and a diagram to make sure everyone is using the same terms. To maintain consistency of the structure of URLs, Zowe seeks to establish standards around URLs and the elements that make up a URL. This article presents the standard terminology used in Swagger documentation.
 
 ## Definitions
 
@@ -8,30 +8,37 @@ REST APIs have a _baseUrl_ to which the endpoint paths are appended. The base UR
 
 where:
 
-- **`baseUrl`** is an absolute URL prefix that is different for each instance of the service, or when the service is accessed via the API Gateway.
+- **`baseUrl`**  
+Specifies an absolute URL prefix that is different for each instance of the service, or when the service is accessed via the API Gateway.
 
-  The endpoint paths are relative paths that follow the documentation of the REST API.
+The endpoint paths are relative paths that follow the documentation of the REST API.
 
-- **`scheme`** is the transfer protocols used by the API. APIML supports the `http`, `https`, and WebSocket schemes - `ws` and `wss`.
+- **`scheme`**  
+Specifies the transfer protocols used by the API. API ML supports the `http`, `https`, and WebSocket schemes - `ws` and `wss`.
 
-- **`host`** is the domain name or IP address (IPv4) of the host that serves the API. It may include the port number if it is different from the scheme's default port (80 for HTTP and 443 for HTTPS). Note that this must be the host only, without a scheme or sub-paths.
+- **`host`**  
+Specifies the domain name or IP address (IPv4) of the host that serves the API. It may include the port number if it is different from the scheme's default port (80 for HTTP and 443 for HTTPS). Note that this must be the host only, without a scheme or sub-paths.
 
-- **`basePath`** is the URL prefix for all API paths, relative to the host root. It must start with a leading slash `/`. If basePath is not specified then all endpoint paths start at the host root.
+- **`basePath`**  
+Specifies the URL prefix for all API paths, relative to the host root. It must start with a leading slash `/`. If basePath is not specified then all endpoint paths start at the host root.
 
 When a service is accessed without the API Gateway then the format the `basePath` depends on the service. It can be empty or have several parts (e.g. `/fileMasterPlus/api/v1`).
 
-When a service is accessed via the API Gateway then the format of the URL is standardized in one of the following formats:
+When a service is accessed via the API Gateway, the format of the URL is standardized in one of the following formats:
 
 - Using `serviceId`, service type (`t`) and major version (`v`)
 - Using `serviceId` and service type (`t`)
 
 where:
 
-- **`serviceId`** is a unique name of the service that is set during the installation of the service.
+- **`serviceId`**  
+Specifies a unique name of the service that is set during the installation of the service.
 
-- **`t`** is the type of the service. It can be `api`, `ui`, or `ws`
+- **`t`**  
+Specifies the type of the service. It can be `api`, `ui`, or `ws`
 
-- **`v`** is the major version the REST API.
+- **`v`**  
+Specifies the major version the REST API.
 
   **Example:** `v1`, `v2`. It is optional since some existing services can have versioning in the endpoint path.
 
@@ -90,4 +97,4 @@ scheme        host          basePath    endpointPath
 
 ### Resources
 
-- https://swagger.io/docs/specification/2-0/api-host-and-base-path/
+- For more information, see the documentation for [swagger specifications](https://swagger.io/docs/specification/2-0/api-host-and-base-path/) in the Swagger product documentation.

--- a/docs/user-guide/api-mediation/api-mediation-caching-service.md
+++ b/docs/user-guide/api-mediation/api-mediation-caching-service.md
@@ -6,7 +6,9 @@ As an API developer, you can use the Caching Service as a storage solution to en
 
 - Using InMemory
 
-**Note:** In the current implementation of the Caching Service, VSAM is required for the storage of key/value pairs for production, as VSAM is a native z/OS solution for storing key/value pairs.
+:::note
+In the current implementation of the Caching Service, VSAM is required for the storage of key/value pairs for production, as VSAM is a native z/OS solution for storing key/value pairs.
+:::
 
 The Caching Service is available only for internal Zowe applications, and is not exposed to the internet. The Caching service supports a hot-reload scenario in which a client service requests all available service data. 
 
@@ -108,9 +110,10 @@ This parameter specifies service behavior when the limit of records is reached. 
   * **removeOldest**  
   removes the oldest item in the cache when the service reaches the configured maximum number
 
-:::note**Notes:**
-- For more information about how to configure the Caching Service in the `application.yml`, see: [Add API Onboarding Configuration](../extend-apiml/onboard-spring-boot-enabler.md).
-- When using VSAM, ensure that you set the additional configuration parameters. For more information about setting these parameters, see [Using VSAM as a storage solution through the Caching Service](./api-mediation-vsam.md).
+:::note
+- For more information about how to configure the Caching Service in the `application.yml`, see
+ [Add API Onboarding Configuration](../../extend/extend-apiml/onboard-spring-boot-enabler).
+- When using VSAM, ensure that you set the additional configuration parameters. For more information about setting these parameters, see [Using VSAM as a storage solution through the Caching Service](../../extend/extend-apiml/api-mediation-vsam).
 :::
 
 ## Authentication

--- a/docs/user-guide/obtaining-information-about-api-services.md
+++ b/docs/user-guide/obtaining-information-about-api-services.md
@@ -20,13 +20,13 @@ This article provides further detail about each of these use cases.
 
 The _API ID_ uniquely identifies the API in the API ML. The API ID can be used to locate the same APIs that are provided by different service instances. The API developer defines this ID.
 
-For more information about _baseUrl_ or _basePath_, see [Components of URL](api-mediation-components-of-URL.md).
+For more information about _baseUrl_ or _basePath_, see [Components of URL](../extend/extend-apiml/api-mediation-components-of-URL).
 
 ## Protecting Service Information
 
 Information about API services is considered sensitive as it contains partial information about the internal topology of the mainframe system. As such, this information should be made accessible only by authorized users and services.
 
-Access to this information requires authentication using mainframe credentials, as well as verification of access to resources through SAF. The resource class and resource is defined in the `ZWESECUR` job. Dor more information about `ZWESECUR` job, see [Configuring the z/OS system for Zowe](../../user-guide/configure-zos-system.md).
+Access to this information requires authentication using mainframe credentials, as well as verification of access to resources through SAF. The resource class and resource is defined in the `ZWESECUR` job. Dor more information about `ZWESECUR` job, see [Configuring the z/OS system for Zowe](./configure-zos-system)
 
 The security administrator needs to permit READ access to the `APIML.SERVICES` resource in the `ZOWE` resource class to access the information about API services.
 
@@ -50,7 +50,7 @@ RECKEY APIML ADD(SERVICES SERVICE(READ) ROLE(user) ALLOW)
 F ACF2,REBUILD(ZWE)
 ```
 
-The API Gateway can be configured to check for SAF resource authorization in several ways. For more information, see [SAF Resource Checking](../../user-guide/api-mediation/configuration-saf-resource-checking)
+The API Gateway can be configured to check for SAF resource authorization in several ways. For more information, see [SAF Resource Checking](./api-mediation/configuration-saf-resource-checking).
 
 ## Using API Endpoints
 

--- a/docs/user-guide/obtaining-information-about-api-services.md
+++ b/docs/user-guide/obtaining-information-about-api-services.md
@@ -20,13 +20,13 @@ This article provides further detail about each of these use cases.
 
 The _API ID_ uniquely identifies the API in the API ML. The API ID can be used to locate the same APIs that are provided by different service instances. The API developer defines this ID.
 
-For more information about _baseUrl_ or _basePath_, see [Components of URL](../extend/extend-apiml/api-mediation-components-of-URL).
+For more information about _baseUrl_ or _basePath_, see [Components of a URL](../extend/extend-apiml/api-mediation-components-of-URL).
 
 ## Protecting Service Information
 
 Information about API services is considered sensitive as it contains partial information about the internal topology of the mainframe system. As such, this information should be made accessible only by authorized users and services.
 
-Access to this information requires authentication using mainframe credentials, as well as verification of access to resources through SAF. The resource class and resource is defined in the `ZWESECUR` job. Dor more information about `ZWESECUR` job, see [Configuring the z/OS system for Zowe](./configure-zos-system)
+Access to this information requires authentication using mainframe credentials, as well as verification of access to resources through SAF. The resource class and resource is defined in the `ZWESECUR` job. Dor more information about `ZWESECUR` job, see [Addresing z/OS requrements for Zowe](./configure-zos-system).
 
 The security administrator needs to permit READ access to the `APIML.SERVICES` resource in the `ZOWE` resource class to access the information about API services.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -494,8 +494,8 @@ module.exports = {
             {
               type: "category",
               label: "Using the Caching Service",
+              link: {type:"doc", id:"user-guide/api-mediation/api-mediation-caching-service"},
               items: [
-                "user-guide/api-mediation/api-mediation-caching-service",
               ],
             },
             {


### PR DESCRIPTION
Describe your pull request here: This PR fixes a couple broken links resulting from changing file paths in the restructuring of the Using API ML section

List the file(s) included in this PR: obtaining-information-about-api-services.md, and api-mediation-caching-service.md

After creating the PR, follow the instructions in the comments.
