### PR TITLE
fixed syntax for Require Roles admonitions

### DIFF
--- a/docs/extend/extend-apiml/api-mediation-message-service.md
+++ b/docs/extend/extend-apiml/api-mediation-message-service.md
@@ -13,7 +13,7 @@ API ML uses a customizable infrastructure to format both REST API error messages
 
 - Message `key` - a unique ID in the form of a dot-delimited string that describes the reason for the message. The `key` enables the UI or the console to show a meaningful and localized message. 
 
-    :::tip**Tips:**
+    :::tip Tips:
     - We recommend using the format `org.zowe.sample.apiservice.{TYPE}.greeting.empty` to define the message key. `{TYPE}` can be the api or log keyword. 
     - Use the message `key` and not the message `number`. The message `number` makes the code less readable, and increases the possibility of errors when renumbering values inside the `number`.
     :::

--- a/docs/extend/extend-apiml/api-mediation-oidc-authentication.md
+++ b/docs/extend/extend-apiml/api-mediation-oidc-authentication.md
@@ -164,7 +164,7 @@ curl --location 'https://"$HOSTNAME:$PORT"/gateway/api/v1/auth/oidc-token/valida
 An HTTP `200` code is returned if the validation passes. Failure to validate returns an HTTP `40x` error.
 :::
 
-:::note**Azure Entra ID OIDC notes:**
+:::note Azure Entra ID OIDC notes:
 API ML uses the `sub` claim of the ID Token to identify the user, and to map to the mainframe account. Note that the structure of the `sub` claim varies between the Azure token and the OKTA ID token:
 * The Azure token `sub` is an alphanumeric value.  
 For more information, see the topic _Use claims to reliably identify a user_ in the Microsoft Learn documentation.

--- a/docs/extend/extend-apiml/custom-metadata.md
+++ b/docs/extend/extend-apiml/custom-metadata.md
@@ -6,7 +6,7 @@ Additional metadata can be added to the instance information that is registered 
       
     When this parameter is set to `true`, the Gateway allows encoded characters to be part of URL requests redirected through the Gateway. The default setting of `false` is the recommended setting. Change this setting to `true` only if you expect certain encoded characters in your application's requests.
           
-    :::info**Important!**
+    :::info Important
     When the expected encoded character is an encoded slash or backslash (`%2F`, `%5C`), make sure the Gateway is also configured to allow encoded slashes. For  more information, see [Installing the Zowe runtime on z/OS](../../user-guide/install-zos.md).
     :::
 

--- a/docs/extend/extend-apiml/onboard-static-definition.md
+++ b/docs/extend/extend-apiml/onboard-static-definition.md
@@ -94,7 +94,7 @@ catalogUiTiles:
 
 In this example, a suitable name for the file is `petstore.yml`.
 
-:::note**Notes:**
+:::note Notes:
 
 * The filename does not need to follow specific naming conventions but it requires the `.yml` extension.
 * The file can contain one or more services defined under the `services:` node.
@@ -103,7 +103,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
 * The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
 
-:::tip**Tips:**
+:::tip Tips:
 
 * There are more examples of API definitions at this [link](https://github.com/zowe/api-layer/tree/master/config/local/api-defs).
 * For more details about how to use YAML format, see this [link](https://learnxinyminutes.com/docs/yaml/).
@@ -548,7 +548,7 @@ The `${zoweInstanceDir}` symbol is used in following instructions.
     
     - To place your YAML file within the instance directory, copy your YAML file to the `${zoweInstanceDir}/workspace/api-mediation/api-defs` directory. 
 
-    :::note**Notes:**
+    :::note Notes:
     - The `${zoweInstanceDir}/workspace/api-mediation/api-defs` directory is created the first time that Zowe starts. If you have not yet started Zowe, this directory might be missing.
     - The user ID `ZWESVUSR` that runs the Zowe started task must have permission to read the YAML file.
     :::  

--- a/docs/user-guide/address-browser-requirements.md
+++ b/docs/user-guide/address-browser-requirements.md
@@ -2,7 +2,7 @@
 
 Review the following browser requirements to avoid browser-specific issues when running particular server-side components.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Zowe Desktop requirements (client PC)

--- a/docs/user-guide/address-network-requirements.md
+++ b/docs/user-guide/address-network-requirements.md
@@ -3,7 +3,7 @@
 Review the following table during installation of Zowe server-side components to determine which TCP ports are required. 
 Values presented in the table are default values. You can change the values by updating variable values in the `zowe.yaml` file. 
 
-:::info**Required roles:** network administrator, system programmer
+:::info Required roles: network administrator, system programmer
 :::
 
 For more information about variable names in the following table, see the [Zowe YAML configuration file reference](../appendix/zowe-yaml-configuration.md) in the References section.

--- a/docs/user-guide/apf-authorize-load-library.md
+++ b/docs/user-guide/apf-authorize-load-library.md
@@ -2,7 +2,7 @@
 
 Review this article to learn how to perform APF authorization of Zowe load libraries to make privileged calls. Note that this procedure requires elevated permissions.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 Zowe contains load modules that require access to make privileged z/OS security manager calls. These load modules are held in two load libraries which must be APF authorized. The command `zwe init apfauth` reads the PDS names for the load libraries from `zowe.yaml` and performs the APF authority commands.  

--- a/docs/user-guide/api-mediation-sso.md
+++ b/docs/user-guide/api-mediation-sso.md
@@ -2,7 +2,7 @@
 
 You can extend Zowe and utilize Zowe Single-Sign-On (SSO) provided by Zowe API Mediation Layer (API ML) to enhance system security and improve the user experience. 
 
-:::info**Required roles:** system administrator, security administrator
+:::info Required roles: system administrator, security administrator
 :::
 
 This article provides an overview of the API ML single-sign-on feature, the principle participants in the SSO process, and links to detailed Zowe SSO documentation. Zowe Single-Sign-On is based on single-user authentication which produces an access token that represents the user in communication with z/OS services accessible through the API Mediation Layer. The access token is issued by the Zowe Authentication and Authorization Service (ZAAS), which is part of API ML. ZAAS issues an access token based on valid z/OS credentials. This token can be validated by any component participating in SSO. 

--- a/docs/user-guide/api-mediation-view-service-information-and-api-doc.md
+++ b/docs/user-guide/api-mediation-view-service-information-and-api-doc.md
@@ -16,7 +16,7 @@ Services that belong to the same product family are displayed on the same tile.
 2. Click the tile to view header information, the registered services under that family ID,
  and API documentation for that service.
 
-   :::note**Notes:**
+   :::note Notes:
    * The state of the service is indicated in the service tile on the dashboard page.
     If no instances of the service are currently running, the tile displays a message that no services are running.
    * At least one instance of a service must be started and registered with the Discovery Service for it to be visible
@@ -45,7 +45,7 @@ Services that belong to the same product family are displayed on the same tile.
 
    <img src={require("../images/api-mediation/expanded.png").default} alt="endpoint detail" width="500px"/>
 
-   :::note**Notes:**
+   :::note Notes:
    * If a lock icon is visible on the right side of the endpoint panel, the endpoint requires authentication.
    * The structure of the endpoint is displayed relative to the base URL.
    * The URL path of the abbreviated endpoint relative to the base URL is displayed in the following format:

--- a/docs/user-guide/api-mediation/api-mediation-jwt-token-refresh.md
+++ b/docs/user-guide/api-mediation/api-mediation-jwt-token-refresh.md
@@ -7,7 +7,7 @@ The refresh request requires the token in one of the following formats:
 - A cookie named `apimlAuthenticationToken`.
 - Bearer authentication
 
-:::note**Notes:**
+:::note Notes:
 - The endpoint is disabled by default. For more information, see [Enable JWT token endpoint](configuration-jwt.md#enable-jwt-token-refresh-endpoint).
 - The endpoint is protected by a client certificate.
   For more information, see the OpenAPI documentation of the API Mediation Layer in the API Catalog.

--- a/docs/user-guide/api-mediation/authenticating-with-personal-access-token.md
+++ b/docs/user-guide/api-mediation/authenticating-with-personal-access-token.md
@@ -1,6 +1,6 @@
 # Authenticating with a Personal Access Token
 
-:::info**Roles:** system programmer, security administrator
+:::info Roles: system programmer, security administrator
 :::
 
 You can use API Mediation Layer to generate, validate, and invalidate a **Personal Access Token (PAT)** that can enable access to tools such as VCS without having to use credentials of a specific person. The use of PAT does not require storing mainframe credentials as part of the automation configuration on a server during application development on z/OS.

--- a/docs/user-guide/api-mediation/configuration-access-specific-instance-of-service.md
+++ b/docs/user-guide/api-mediation/configuration-access-specific-instance-of-service.md
@@ -1,6 +1,6 @@
 # Retrieving a specific service within your environment 
 
-:::info**Roles:** system programmer, system administrator
+:::info Roles: system programmer, system administrator
 :::
 
 ## Output a routed instance header

--- a/docs/user-guide/api-mediation/configuration-at-tls.md
+++ b/docs/user-guide/api-mediation/configuration-at-tls.md
@@ -4,7 +4,7 @@ The communication server on z/OS provides a functionality to encrypt HTTP commun
 
 Review this article for descriptions of the configuration parameters required to make the Zowe API Mediation Layer work with AT-TLS, and security recommendations.
 
-:::info**Role:** security administrator
+:::info Role: security administrator
 :::
 
 - [AT-TLS configuration for Zowe](#at-tls-configuration-for-zowe)
@@ -59,13 +59,13 @@ While API ML does not handle TLS on its own with AT-TLS enabled, API ML requires
 
 2. If there is an outbound AT-TLS rule configured for the link between the API Gateway and z/OSMF, set the `zowe.zOSMF.scheme` property to `http`.
 
-:::note**Notes**
+:::note Notes
 * Currently, AT-TLS is not supported in the API Cloud Gateway Mediation Layer component.
 
 * As the Gateway is a core component of API ML, other components that need to interact with the Gateway, such as Zowe ZLUX App Server, also require AT-TLS configuration.
 :::
 
-:::caution**Important security consideration**
+:::caution Important security consideration
 
 Configuring AT-TLS for the Zowe API Mediation Layer requires careful consideration of security settings, specifically as these settings apply to the Client Certificate authentication feature in Zowe API Mediation Layer components, as well as for onboarded services that support the x.509 client certificates authentication scheme.
 

--- a/docs/user-guide/api-mediation/configuration-authorization.md
+++ b/docs/user-guide/api-mediation/configuration-authorization.md
@@ -1,6 +1,6 @@
 # Configuring authorization for API ML
 
-:::info**Role:** system administrator
+:::info Role: system administrator
 :::
 
 In Zowe's API Mediation Layer, system administrators can limit access to services and information in the API Catalog by hiding sensitive data like service instance URLs, configurable via the apiml.catalog.hide.serviceInfo property in zowe.yaml. Additionally, SAF resource checking for user authorization on specific endpoints is facilitated through various providers, such as Endpoint, Native, and Dummy. These configurations, modifiable in the zowe.yaml file, enhance security by controlling service exposure and ensuring proper authorization checks within the Zowe ecosystem.

--- a/docs/user-guide/api-mediation/configuration-client-certificates.md
+++ b/docs/user-guide/api-mediation/configuration-client-certificates.md
@@ -1,7 +1,7 @@
 # Enabling single sign on for clients via client certificate configuration
 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 Use the following procedure to enable the zowe.yaml file to use a client certificate as the method of authentication for the API Mediation Layer Gateway. 

--- a/docs/user-guide/api-mediation/configuration-connection-limits.md
+++ b/docs/user-guide/api-mediation/configuration-connection-limits.md
@@ -1,6 +1,6 @@
 # Customizing connection limits
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 By default, the API Gateway accepts up to 100 concurrent connections per route, and 1000 total concurrent connections. Any further concurrent requests are queued until the completion of an existing request. The API Gateway is built on top of Apache HTTP components that require these two connection limits for concurrent requests. 

--- a/docs/user-guide/api-mediation/configuration-cors.md
+++ b/docs/user-guide/api-mediation/configuration-cors.md
@@ -1,6 +1,6 @@
 # Customizing Cross-Origin Resource Sharing (CORS) 
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 As a system programmer, you can enable the Gateway to terminate CORS requests for itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled for Gateway routes `gateway/api/v1/**` and for individual services. After enabling the feature as stated in the following procedure, API Gateway endpoints start handling CORS requests. Individual services can control whether they want the Gateway to handle CORS for them through the [Custom Metadata](../../extend/extend-apiml/onboard-spring-boot-enabler/#custom-metadata) parameters.

--- a/docs/user-guide/api-mediation/configuration-customizing-management-of-apiml-load-limits.md
+++ b/docs/user-guide/api-mediation/configuration-customizing-management-of-apiml-load-limits.md
@@ -1,6 +1,6 @@
 # Customizing management of API ML load limits 
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 ::: 
 
 As a system programmer, you can customize your configuration for how API ML manages both northbound and southbound load limits in single instances:

--- a/docs/user-guide/api-mediation/configuration-customizing-the-api-catalog-ui.md
+++ b/docs/user-guide/api-mediation/configuration-customizing-the-api-catalog-ui.md
@@ -1,6 +1,6 @@
 # Customizing the API Catalog UI
 
-:::info**Role:** system administrator
+:::info Role: system administrator
 :::
 
 As a system administrator, you can customize the API Catalog UI to have a similar interface to your organization's service, or with your existing visualization portal.
@@ -71,7 +71,7 @@ An alternative to the API Catalog is displayed
 - **metrics-dashboard**  
  A possible dashboard that could appear in place of the API Catalog 
 
-:::note**Notes:**
+:::note Notes:
 - If the application contains the `homePageUrl` and `statusPageRelativeUrl`, then the full set of information is displayed.
 - If the application contains the `homePageUrl` the link is displayed without the `UP` information.
 - If the application contains the `statusPageRelativeUrl` then `UP` or `DOWN` is displayed based on the `statusPage` without the link.

--- a/docs/user-guide/api-mediation/configuration-distributed-load-balancer-cache.md
+++ b/docs/user-guide/api-mediation/configuration-distributed-load-balancer-cache.md
@@ -1,6 +1,6 @@
 # Distributing the load balancer cache
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 You can choose to distribute the load balancer cache between instances of the API Gateway. To distribute the load balancer cache, it is necessary that the caching service is running. Gateway service instances are reuqired to have the same DN (Distinguished name) on the server certificate. This may be relevant for the HA setups.

--- a/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
+++ b/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for extending services
 
-:::info**Roles:** system programmer, API service extender
+:::info Roles: system programmer, API service extender
 :::
 
 Enabling Single Sign On (SSO) in Zowe involves configuring JWT tokens or PassTickets for secure authentication. The JWT token configuration requires setting up a custom HTTP header to store the token, thereby enhancing secure communication with southbound services. 

--- a/docs/user-guide/api-mediation/configuration-extender-jwt.md
+++ b/docs/user-guide/api-mediation/configuration-extender-jwt.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for extending services via JWT token configuration 
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 ## Adding a custom HTTP Auth header to store Zowe JWT token

--- a/docs/user-guide/api-mediation/configuration-extender-passtickets.md
+++ b/docs/user-guide/api-mediation/configuration-extender-passtickets.md
@@ -2,7 +2,7 @@
 
 As a system programmer, follow the procedures described in this article to configure Zowe to use PassTickets, and to enable Zowe to use PassTickets to authenticate towards specific extending services.
 
-:::info**Roles:** system programmer, security administrator
+:::info Roles: system programmer, security administrator
 :::
 
 ## Configuring Zowe to use PassTickets

--- a/docs/user-guide/api-mediation/configuration-gateway-retry-policy.md
+++ b/docs/user-guide/api-mediation/configuration-gateway-retry-policy.md
@@ -2,7 +2,7 @@
 
 Use the following procedure to change the Gateway retry policy.
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 All requests are disabled as the default configuration for retry with one exception: the server retries `GET` requests that finish with status code `503`.

--- a/docs/user-guide/api-mediation/configuration-gateway-timeouts.md
+++ b/docs/user-guide/api-mediation/configuration-gateway-timeouts.md
@@ -1,6 +1,6 @@
 # Customizing Gateway timeouts
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 Use the following procedure to change the global timeout value for the API Mediation Layer instance.

--- a/docs/user-guide/api-mediation/configuration-jwt.md
+++ b/docs/user-guide/api-mediation/configuration-jwt.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for clients via JWT token configuration 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 As a system programmer, you can customize how JWT authentication is performed, the service that provides the JWT authentication token, whether it's possible to refresh JWT token and other characteristics of JWT for consumption. 

--- a/docs/user-guide/api-mediation/configuration-limiting-access-to-info-or-services-in-api-catalog.md
+++ b/docs/user-guide/api-mediation/configuration-limiting-access-to-info-or-services-in-api-catalog.md
@@ -1,6 +1,6 @@
 # Limiting access to information or services in the API Catalog
 
-:::info**Role:** system administrator
+:::info Role: system administrator
 :::
 
 As a system administrator, you can limit access to information and/or services available within the API Catalog and through the API Mediation Layer and check for the authorization of the user on certain endpoints.

--- a/docs/user-guide/api-mediation/configuration-personal-access-token.md
+++ b/docs/user-guide/api-mediation/configuration-personal-access-token.md
@@ -1,7 +1,7 @@
 # Enabling single sign on for clients via personal access token configuration 
 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 By default the API Mediation Layer does not provide the ability to use personal access tokens. For more information about about

--- a/docs/user-guide/api-mediation/configuration-routing.md
+++ b/docs/user-guide/api-mediation/configuration-routing.md
@@ -1,6 +1,6 @@
 # Customizing routing behavior 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 The Zowe API Mediation Layer offers a range of routing configurations for enhanced functionality and security. 

--- a/docs/user-guide/api-mediation/configuration-saf-resource-checking.md
+++ b/docs/user-guide/api-mediation/configuration-saf-resource-checking.md
@@ -1,6 +1,6 @@
 # Configuring SAF resource checking 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 You can use various SAF resource providers depending on your use case to handle the SAF authorization check. Follow the procedure in this article that applies to your specific configuration use case. 
 
@@ -95,7 +95,7 @@ The following YAML presents the structure of the file:
         - {UserID}
 ```
 
-:::note**Notes**
+:::note Notes
 - Classes and resources are mapped into a map, user IDs into a list.
 - The load method does not support formatting with dots, such as shown in the following example:
   **Example:** `{CLASS}.{RESOURCE}`

--- a/docs/user-guide/api-mediation/configuration-set-consistent-service-id.md
+++ b/docs/user-guide/api-mediation/configuration-set-consistent-service-id.md
@@ -1,6 +1,6 @@
 # Setting a consistent service ID
 
-:::info**Role:** API service extender
+:::info Role: API service extender
 :::
 
 As an API service extender you can modify the service ID to ensure compatibility of services that use a non-conformant organization prefix with Zowe v2.

--- a/docs/user-guide/api-mediation/configuration-single-sign-on-user.md
+++ b/docs/user-guide/api-mediation/configuration-single-sign-on-user.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for clients
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 As a system programmer or system administrator, you can customize the way API ML handles authentication towards clients such as CLI and/or users. Each of the following methods limits the frequency the user is reqired to enter credentials to access API Mediation Layer: 

--- a/docs/user-guide/api-mediation/configuration-unique-cookie-name-for-multiple-zowe-instances.md
+++ b/docs/user-guide/api-mediation/configuration-unique-cookie-name-for-multiple-zowe-instances.md
@@ -1,6 +1,6 @@
 # Configuring a unique cookie name for a specific API ML instance
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 By default, in the API Gateway, the cookie name is `apimlAuthenticationToken`.

--- a/docs/user-guide/api-mediation/configuration-url-handling.md
+++ b/docs/user-guide/api-mediation/configuration-url-handling.md
@@ -1,6 +1,6 @@
 # Using encoded slashes
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 By default, the API Mediation Layer accepts encoded slashes in the URL path of the request. If you are onboarding applications which expose endpoints that expect encoded slashes, it is necessary to keep the default configuration. We recommend that you change the property to `false` if you do not expect the applications to use the encoded slashes. 

--- a/docs/user-guide/api-mediation/using-multi-factor-authentication.md
+++ b/docs/user-guide/api-mediation/using-multi-factor-authentication.md
@@ -33,7 +33,7 @@ Neither Zowe CLI nor API Catalog issue a notification when a user is required to
 
 We recommend you first try to access self-service facilities and resolve the issue there. If you are unable to access your self-service facilities, contact your system administrator.
 
-:::tip**Tips:**
+:::tip Tips:
 * For more information about how to manage multi-factor authentication credentials in AAM, see [Manage Multi-Factor Authentication Credentials (IBM RACF)](https://techdocs.broadcom.com/us/en/ca-mainframe-software/security/ca-advanced-authentication-mainframe/2-0/using-with-ibm-racf/manage-multi-factor-authentication-credentials-ibm-racf.html) in the Advanced Authentication Mainframe 2.0 Broadcom documentation.
 * For more information about how to manage multi-factor authentication credentials in IBM Z MFA, see
 [IBM Z Multi-Factor Authentication](https://www.ibm.com/products/ibm-multifactor-authentication-for-zos).

--- a/docs/user-guide/assign-security-permissions-to-users.md
+++ b/docs/user-guide/assign-security-permissions-to-users.md
@@ -2,7 +2,7 @@
 
 Assign users (ZWESVUSR and ZWESIUSR) and the ZWEADMIN security group permissions required to perform specific tasks. Each TSO user ID that logs on to Zowe and uses Zowe services that use z/OSMF requires permission to access these z/OSMF services.
 
-:::info**Required roles:**  security administrator
+:::info Required roles:  security administrator
 :::
 
 ### Overview of user categories and roles

--- a/docs/user-guide/assign-security-permissions-to-users.md
+++ b/docs/user-guide/assign-security-permissions-to-users.md
@@ -64,7 +64,7 @@ see [zwe init security](../appendix/zwe_server_command_reference/zwe/init/zwe-in
 
 Each TSO user ID that logs on to Zowe and uses Zowe services that use z/OSMF requires permission to access these z/OSMF services. It is necessary that every user ID be added to the group with the appropriate z/OSMF privileges, `IZUUSER` or `IZUADMIN` (default). 
 
-:::info**Required role:**  security administrator
+:::info Required role:  security administrator
 :::
 
 This step is not included in the provided Zowe JCL because it must be done for every TSO user ID who wants to access Zowe's z/OS services.  The list of those user IDs will typically be the operators, administrators, developers, or anyone else in the z/OS environment who is logging in to Zowe.

--- a/docs/user-guide/authenticating-with-client-certificates.md
+++ b/docs/user-guide/authenticating-with-client-certificates.md
@@ -9,7 +9,7 @@ Authentication for integration with API ML can also be performed by the client w
 There is a limitation with respect to performing authentication using Z Secure Services (ZSS) with ACF2 systems. If you are using ACF2, and are using Zowe v2.14 or a later version, use the recommended internal API ML mapper.
 :::
 
-:::note**Notes:**
+:::note Notes:
 * When calling the login endpoint with basic authentication credentials as well as with client certificate, the basic authentication credentials take precedence and client certificate is ignored. 
 
 * If you are calling a specific endpoint on one of the onboarded services, API Mediation Layer ignores Basic authentication. In this case, the Basic authentication is not part of the authenticated request.
@@ -24,7 +24,7 @@ When sending a request to a service with a client certificate, the Gateway perfo
 * The public key of the provided client certificate is verified against SAF. SAF subsequently returns a user ID that owns this certificate. As of Zowe version 2.14, the API for API ML can be provided by the internal API ML mapper if the mapper is enabled. Alternatively, you can use Z Secure Services (ZSS) to provide this API for API ML, although we recommend using the internal API ML mapper.
 * The Gateway then performs the login of the mapped user and provides valid authentication to the downstream service. 
 
-:::note**Notes:**
+:::note Notes:
 * Currently, ZSS is the default API that provides this mapping between the public part of the client certificate and SAF user ID. However, the recommended method is to use the internal API ML mapper. For information about the internal API ML mapper, see [Enabling the internal API ML mapper](#enabling-the-internal-api-ml-mapper) described in this article.
 * For information about ZSS, see the section Zowe runtime in the [Zowe server-side installation overview](./install-zos).
 :::
@@ -88,13 +88,13 @@ This metadata can be used for TLS client authentication.
 2. Import the external CA to the truststore or keyring of the API Mediation Layer.
 3. Configure the Gateway for client certificate authentication. Follow the procedure described in [Enabling single sign on for clients via client certificate configuration](../user-guide/api-mediation/configuration-client-certificates.).
 
-:::caution**Important:**
+:::caution Important:
 * PassTicket generation must be enabled for the Zowe runtime user. The user must be able to generate a PassTicket for the user and for the APPLID of z/OSMF. For more information, see [Configuring Zowe to use PassTickets](./api-mediation/configuration-extender-passtickets/#configuring-zowe-to-use-passtickets).
 
 * The Zowe runtime user must be enabled to perform identity mapping in SAF. For more information about identity mapping in SAF, see [Configure main Zowe server to use client certificate identity mapping](./configure-zos-system/#configure-main-zowe-server-to-use-client-certificate-identity-mapping).
 :::
 
-:::note**Notes:**
+:::note Notes:
 * The internal API ML mapper can provide the API for API ML if enabled in the zowe.yaml file. Use of the internal API ML mapper is the recommended method. Note that the mapper feature is available for Zowe release 2.14 and later releases. Alternatively, ZSS can be configured to participate in Zowe SSO. 
 
 * Currently, ZSS is the default API that provides this mapping between the public part of the client certificate and the SAF user ID, however the use of the internal API ML mapper is the recommended method.  

--- a/docs/user-guide/authenticating-with-client-certificates.md
+++ b/docs/user-guide/authenticating-with-client-certificates.md
@@ -1,6 +1,6 @@
 # Authenticating with client certificates
 
-:::info**Required roles:** system administrator, security administrator
+:::info Required roles: system administrator, security administrator
 :::
 
 Authentication for integration with API ML can also be performed by the client when the service endpoint is called through the API ML Gateway with client certificates. 

--- a/docs/user-guide/authenticating-with-jwt-token.md
+++ b/docs/user-guide/authenticating-with-jwt-token.md
@@ -160,7 +160,7 @@ https://{gatewayUrl}:{gatewayPort}/gateway/api/v1/auth/refresh
 ```
 The new token overwrites the old cookie with a Set-Cookie header. As part of the process, the old token becomes invalidated and is no longer usable.
 
-:::note**Notes:**
+:::note Notes:
 - The endpoint is disabled by default. For more information, see [Enable JWT token endpoint](./api-mediation/configuration-jwt/#enabling-a-jwt-token-refresh-endpoint).
 - The endpoint is protected by a client certificate.
 - The refresh request requires the token in one of the following formats:

--- a/docs/user-guide/authenticating-with-jwt-token.md
+++ b/docs/user-guide/authenticating-with-jwt-token.md
@@ -1,6 +1,6 @@
 # Authenticating with a JWT token
 
-:::info**Required roles:** system administrator, security administrator
+:::info Required roles: system administrator, security administrator
 :::
 
 One user authentication method available in Zowe is via JWT tokens, whereby a token can be provided by a specialized service, which can then be used to provide authentication information.  

--- a/docs/user-guide/certificate-configuration-scenarios.md
+++ b/docs/user-guide/certificate-configuration-scenarios.md
@@ -3,7 +3,7 @@
 
  After you complete the Zowe certificates configuration questionnaire to determine your specific configuration use case, review the five scenarios presented in this article for configuring Zowe for automatic certificate setup. Examples of the zowe.yaml files are provided for each scenario.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 :::tip **Tip**

--- a/docs/user-guide/certificate-configuration-scenarios.md
+++ b/docs/user-guide/certificate-configuration-scenarios.md
@@ -19,7 +19,7 @@ This automation can be performed by defining and customizing the `zowe.setup.cer
 Zowe can then automate the certificate setup via the `zwe init certificate` command. 
 
 
-:::note**Note:**  
+:::note Note:  
 Automated generation of certificates is an option, but is not required. If you already have a keystore that contains a valid certificate*, and the  corresponding private key of the certificate, along with a truststore which validates the certificate and any other certificates you expect to encounter, then you also have the option to directly define the parameter `zowe.certificate` which specifies the location of each of these certificates and their storage objects. Note that this parameter should not be confused with the parameter `zowe.setup.certificate`.
 :::
 

--- a/docs/user-guide/certificates-configuration-questionnaire.md
+++ b/docs/user-guide/certificates-configuration-questionnaire.md
@@ -3,7 +3,7 @@
 To properly configure Zowe to use certificates for server-side component installation, review the  certificate setup options presented in this article. 
 Understanding these options makes it possible to select the best certificate configuration scenario that fits your Zowe deployment use case. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 
 If you know that you will be using certificates in a production deployment environment, and that you will be using an external certificate authority (CA), we recommend you consult with your organization's security administrator before you start certificate configuration.
 :::

--- a/docs/user-guide/certificates-setup.md
+++ b/docs/user-guide/certificates-setup.md
@@ -4,7 +4,7 @@ Zowe can use certificates that are held in z/OS Keyring.
 
 You can use four z/OSMF workflows that enable you to manage keyring setup, certificates, certificate sign requests, and signatures, and load certificates to a keyring.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Use the following workflows to set up certificates for Zowe in your environment:

--- a/docs/user-guide/configure-certificates.md
+++ b/docs/user-guide/configure-certificates.md
@@ -2,7 +2,7 @@
 
 Review this article to learn about the key concepts of Zowe certificates, and options for certificate configuration. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. Communication in Zowe can be between Zowe servers, from Zowe to another server, or even between Zowe's servers and Zowe's client components.

--- a/docs/user-guide/configure-uss.md
+++ b/docs/user-guide/configure-uss.md
@@ -2,7 +2,7 @@
 
 The Zowe z/OS component runtime requires UNIX System Services (USS) to be configured. As shown in the [Zowe architecture](../getting-started/zowe-architecture.md), a number of servers run under UNIX System Services (USS) on z/OS. Review this topic for knowledge and considerations about USS when you install and configure Zowe.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 ## What is USS?

--- a/docs/user-guide/configure-xmem-server.md
+++ b/docs/user-guide/configure-xmem-server.md
@@ -6,7 +6,7 @@ APF-authorized program. The same cross memory server can be used by multiple Zow
 :::info Required roles: system programmer, security administrator
 :::
 
-:::tip**Important**
+:::tip Important
 This article describes how to configure the cross server manually. However, most of this configuration should already be performed during [Zowe configuration](./configuring-overview). 
 If you have already successfully run the `zwe init` command, the load modules are already installed, and APF authorization and SAF configuration is complete.
 
@@ -159,7 +159,7 @@ Do not install the Zowe auxiliary address space unless a Zowe extension product'
 
 A default installation of Zowe does not require auxiliary address spaces to be configured.
 
-:::info**Important**
+:::info Important
 The cross memory `ZWESISTC` task starts and stops the `ZWESASTC` task as needed. **Do not start the `ZWESASTC` task manually.**
 :::
 

--- a/docs/user-guide/configure-xmem-server.md
+++ b/docs/user-guide/configure-xmem-server.md
@@ -3,7 +3,7 @@
 The Zowe cross memory server (ZIS) provides privileged cross-memory services to the Zowe Desktop and runs as an
 APF-authorized program. The same cross memory server can be used by multiple Zowe desktops. The cross memory server is required to log on to the Zowe desktop and operate the desktop apps such as the Code Editor. If you wish to start Zowe without the desktop (for example bring up just the API Mediation Layer), you do not need to install and configure a cross memory server and can skip this step. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 :::tip**Important**

--- a/docs/user-guide/configure-zos-system.md
+++ b/docs/user-guide/configure-zos-system.md
@@ -2,7 +2,7 @@
 
 As a security administrator it is necessary to  configure the z/OS system for Zowe. Review the following article to learn about z/OS prerequisites, and z/OS configuration requirements for specific settings.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 ## z/OS prerequisites
@@ -123,7 +123,7 @@ Define or check the following configurations depending on whether ICSF is alread
         (repeat for user-acids IKED, NSSD, and Policy Agent)
 
 
-:::note**Notes:**
+:::note Notes:
 - Determine whether you want SAF authorization checks against `CSFSERV` and set `CSF.CSFSERV.AUTH.CSFRNG.DISABLE` accordingly.
 - Refer to the [z/OS 2.3.0 z/OS Cryptographic Services ICSF System Programmer's Guide: Installation, initialization, and customization](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.csfb200/iandi.htm).
 - CCA and/or PKCS #11 coprocessor for random number generation.
@@ -481,7 +481,7 @@ To do this, issue the following commands that are also included in the `ZWESECUR
     TSS PERMIT(ZWESVUSR) IBMFAC(ZWES.IS) ACCESS(READ)
     ```
 
-:::note**Notes:**
+:::note Notes:
 - The cross memory server treats "no decision" style SAF return codes as failures. If there is no covering profile for the `ZWES.IS` resource in the FACILITY class, the request will be denied.
 - Cross memory server clients other than Zowe might have additional SAF security requirements. For more information, see the documentation for the specific client.
 :::

--- a/docs/user-guide/configure-zowe-runtime.md
+++ b/docs/user-guide/configure-zowe-runtime.md
@@ -2,7 +2,7 @@
 
 Begin configuration of your installation of Zowe z/OS components by initializing Zowe z/OS runtime.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 Use one of the following options to initialize Zowe z/OS runtime:

--- a/docs/user-guide/configure-zowe-zosmf-workflow.md
+++ b/docs/user-guide/configure-zowe-zosmf-workflow.md
@@ -2,7 +2,7 @@
 
 After you install Zowe, you can register and execute the z/OSMF workflows in the web interface to perform a range of Zowe configuration tasks. z/OSMF helps to simplify the Zowe configuration tasks and does not require the level of expertise that is needed to perform manual Zowe configuration. This configuration method also runs the `zwe init` command to initialize Zowe z/OS runtime.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 Ensure that you meet the following requirements before you start your Zowe configuration:

--- a/docs/user-guide/configuring-overview.md
+++ b/docs/user-guide/configuring-overview.md
@@ -2,7 +2,7 @@
 
 Review this article for an overview of the procedures that must be performed to configure Zowe z/OS components and the z/OS system. More details about the individual procedures are provided in the articles in this section. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Configuring Zowe z/OS components consists of the following four main steps:

--- a/docs/user-guide/configuring-security.md
+++ b/docs/user-guide/configuring-security.md
@@ -2,7 +2,7 @@
 
 During the initial installation of Zowe server-side components, it is necessary for your organization's security administrator to perform a range of tasks that require elevated security permissions. As a security administrator, follow the procedures outlined in this article to configure Zowe and your z/OS system to run Zowe with z/OS.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 ## Validate and re-run `zwe init` commands

--- a/docs/user-guide/generate-certificates.md
+++ b/docs/user-guide/generate-certificates.md
@@ -209,7 +209,7 @@ zowe:
         - 12.34.56.78
 ```
 
-:::note**Notes:**
+:::note Notes:
 - Alias names should be all lower cases.
 - The name and lables shown above are the default value in `zowe.yaml`.
 - `dname` for distinguished name is all optional.

--- a/docs/user-guide/generate-certificates.md
+++ b/docs/user-guide/generate-certificates.md
@@ -3,7 +3,7 @@
 
 If you do not have a certificate, follow the procedure in this article that corresponds to the certificate type you choose to generate.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Choose from the following certificate types:

--- a/docs/user-guide/import-certificates.md
+++ b/docs/user-guide/import-certificates.md
@@ -2,7 +2,7 @@
 
 One option to use certificates in Zowe is to import and configure existing certificates. Use the procedure that applies to the type of certificate you wish to import.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Choose from the following certificate importing options:

--- a/docs/user-guide/initialize-mvs-datasets.md
+++ b/docs/user-guide/initialize-mvs-datasets.md
@@ -3,7 +3,7 @@
 
 Review this article to learn about how to intialize Zowe custom MVS data sets by using the `zwe init mvs` command. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Introduction

--- a/docs/user-guide/initialize-security-configuration.md
+++ b/docs/user-guide/initialize-security-configuration.md
@@ -58,7 +58,7 @@ The JCL allows you to vary which security manager you use by setting the _PRODUC
 
 If `ZWESECUR` encounters an error or a step that has already been performed, it continues to the end, so it can be run repeatedly in a scenario such as a pipeline automating the configuration of a z/OS environment for Zowe installation.  
 
-:::info**Important**
+:::info Important
 It is expected that your security administrator will be required to review, edit where necessary, and either execute `ZWESECUR` as a single job, or execute individual TSO commands to complete the security configuration of a z/OS system in preparation for installing and running Zowe.
 :::
 

--- a/docs/user-guide/initialize-security-configuration.md
+++ b/docs/user-guide/initialize-security-configuration.md
@@ -2,7 +2,7 @@
 
 This security configuration step is required for first time setup of Zowe. If Zowe has already been launched on a z/OS system from a previous release of Zowe v2, and the `zwe init security` subcommand successfully ran when initializing the z/OS subsystem, you can skip this step unless told otherwise in the release documentation.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 
 Consult with your security administrator before you proceed with initializing Zowe security configurations.
 :::

--- a/docs/user-guide/initialize-zos-system.md
+++ b/docs/user-guide/initialize-zos-system.md
@@ -22,7 +22,7 @@ Configures the VSAM files needed to run the Zowe caching service used for high a
 - **stc**  
 Configures the system to launch the Zowe started task.
 
-:::info**Recommendation:**
+:::info Recommendation:
 We recommend you to run these sub commands one by one to clearly see the output of each step. To successfully run `zwe init security`, `zwe init apfauth`, and `zwe init certificate`, it is likely that your organization requires elevated permissions. We recommend you consult with your security administrator to run these commands. For more information about tasks for the security administrator, see the section [Configuring security](./configuring-security) in this configuration documentation.
 ::: 
 

--- a/docs/user-guide/initialize-zos-system.md
+++ b/docs/user-guide/initialize-zos-system.md
@@ -2,7 +2,7 @@
 
 Once you complete the installation of the Zowe runtime, begin configuration by initializing Zowe with proper security configurations. To simplify this configuration process, one option is to run the `zwe init` command. This step is common for installing and configuring Zowe from either a convenience build or from an SMP/E build.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 ## About the `zwe init` command

--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -2,7 +2,7 @@
 
 Before you install Zowe&trade; on z/OS, you must install IBM SDK for Node.js on the same z/OS server that hosts the Zowe Application Server and z/OS Explorer Services. Review the information in this topic to obtain and install Node.js.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 :::note

--- a/docs/user-guide/install-zowe-smpe.md
+++ b/docs/user-guide/install-zowe-smpe.md
@@ -5,7 +5,7 @@ Review this article and the procedures to install and activate the functions of 
 :::info Required roles: system programmer
 :::
 
-:::note**Notes:**
+:::note Notes:
 * To install Zowe into its own SMP/E environment, consult the SMP/E manuals for instructions on creating and initializing the SMPCSI and SMP/E control data sets.
 * You can use the sample jobs that are provided to perform part or all of the installation tasks. The SMP/E jobs assume that all DDDEF entries that are required for SMP/E execution have been defined in appropriate zones.
 * You can use the SMP/E dialogs instead of the sample jobs to accomplish the SMP/E installation steps.
@@ -135,7 +135,7 @@ You will receive a return code of `0` if this job runs correctly.
 
 Upload the `AZWE002.readme.txt` file in text format and the `AZWE002.pax.Z` file in binary format from your workstation to the z/OS UNIX file system. The instructions in this section are also in the `AZWE002.readme.txt` file that you downloaded.
 
-:::info**Important**
+:::info Important
 Ensure you download the pax file in a different file system than where you put Zowe runtime. 
 :::
 
@@ -153,7 +153,7 @@ tsopw | Your TSO password
 d: | Location of the downloaded files
 @zfs_path@ | z/OS UNIX path where to store the files. This matches the @zfs_path@ variable you specified in the previous step.
 
-:::danger**Important** 
+:::danger Important 
 The `AZWE002.pax.Z` file must be uploaded to the z/OS driving system in binary format. Not using binary format causes the subsequent UNPAX step to fail.
 :::
 
@@ -569,7 +569,7 @@ GROUPEXTEND
 BYPASS(HOLDCLASS(HIPER)) .
 ..any other parameters documented in the program directory
 ```
-:::note**Notes:**  
+:::note Notes:  
 * This method is quicker, but requires subsequent review of the Exception SYSMOD report produced by the REPORT ERRSYSMODS command to investigate any unresolved HIPERs. If you have received the latest HOLDDATA, you can also choose to use the REPORT MISSINGFIX command and specify Fix Category IBM.PRODUCTINSTALL-REQUIREDSERVICE to investigate missing recommended service.
 * If you bypass HOLDs during the installation of the FMIDs because fixing PTFs are not yet available, you can be notified when the fixing PTFs are available by using the APAR Status Tracking (AST) function of the ServiceLink or the APAR Tracking function of Resource Link.
 :::

--- a/docs/user-guide/install-zowe-smpe.md
+++ b/docs/user-guide/install-zowe-smpe.md
@@ -2,7 +2,7 @@
 
 Review this article and the procedures to install and activate the functions of Zowe server-side components using SMP/E.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 :::note**Notes:**

--- a/docs/user-guide/installandconfig.md
+++ b/docs/user-guide/installandconfig.md
@@ -2,7 +2,7 @@
 
 Review this overview article to familiarize yourself with key concepts used in the Zowe server-side installation process. After reviewing these key concepts, review the articles in this section to prepare your system for installation. 
 
-:::info**Required roles:** system programmer, security administrator, storage administrator
+:::info Required roles: system programmer, security administrator, storage administrator
 :::
 
 To prepare for Zowe server-side installation, we recommend that your installation team review the installation and configuration tasks and the indicated required roles to perform specific procedures. Doing so can help you complete the process without encountering delays waiting for tasks to be completed at the last minute.

--- a/docs/user-guide/installandconfig.md
+++ b/docs/user-guide/installandconfig.md
@@ -120,7 +120,7 @@ Configures the system to launch the Zowe started task.
 
 In combination, these commands initialize Zowe, manage Zowe instances, and perform common tasks.
 
-:::tip**Tips:**
+:::tip Tips:
 * The `zwe` command has built in help that can be retrieved with the `-h` suffix. Use `zwe -h` to see all supported `zwe` commands.
 
   For more information about `zwe` see [zwe](../appendix/zwe_server_command_reference/zwe/zwe) in the appendix.
@@ -147,7 +147,7 @@ Zowe has the following started tasks:
    - **`ZWESLSTC`**  
    This started task brings up other features of the Zowe runtime on z/OS upon request. Features may include Desktop, API Mediation Layer, ZSS, and more. When using containerization, it is likely that the only feature will be ZSS. This task can be used for a single Zowe instance deployment, and can also be used for Zowe high availability deployment in Sysplex. This task brings up and stops Zowe instances, or specific Zowe components without restarting the entire Zowe instances.
    
-:::info**Important!**
+:::info Important
 * In order for the above started tasks to run correctly, the security administrator permissions are required. For more information, see [Configuring the z/OS system for Zowe](configure-zos-system.md).
 * Note that the sample JCL member `ZWESECUR` is shipped with Zowe and contains commands for RACF, TopSecret, and ACF2 security managers.
 :::
@@ -195,7 +195,7 @@ To create this configuration, you can copy from `example-zowe.yaml` located in Z
 To learn more about this Zowe configuration file, see the [Zowe YAML configuration file reference](../appendix/zowe-yaml-configuration.md).
 
 
-:::tip**zowe.yaml configuration tips:**  
+:::tip zowe.yaml configuration tips:  
 
 When you execute the `zwe` command, the `--config` or `-c` argument is used to pass the location of a `zowe.yaml` file.
 

--- a/docs/user-guide/k8s-introduction.md
+++ b/docs/user-guide/k8s-introduction.md
@@ -2,7 +2,7 @@
 
 You can download Zowe (server) containers as an alternative to running Zowe servers on z/OS through the Zowe convenience and SMP/E builds. Choose the appropriate installation type for your use case.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 Using containers for installation has the following advantages:

--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -5,7 +5,7 @@ keywords: [security permissions, system permissions, monacat]
 
 Before installing Zowe&trade; z/OS components, ensure that your z/OS environment meets the prerequisites. The prerequisites you need to install depend on what Zowe z/OS components you want to use and how you want to install and configure Zowe on z/OS. Assess your installation scenario and install the prerequisites that meet your needs. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 All Zowe server components can be installed on a z/OS environment, while some can alternatively be installed on Linux or zLinux via Docker. The components provide a number of services that are accessed through a web browser such as an API catalog and a web desktop.  

--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -18,7 +18,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 - z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-  :::note**Notes:**
+  :::note Notes:
   * Zowe Version 2.11 or higher is required when using z/OS Version 3.1.
   * z/OS V2.3 reached end of support on 30 September, 2022. For more information, see the [z/OS v2.3 lifecycle details](https://www.ibm.com/support/pages/zos23x-withdrawal-notification).
   :::
@@ -57,7 +57,7 @@ Be sure your z/OS system meets the following prerequisites:
 
   - REST API services for Files (Data Sets and USS), JES, and z/OSMF workflows.  These are used by some Zowe applications such as the Zowe Explorers in the Zowe Desktop. If z/OSMF REST APIs are not present, other Zowe desktop application, such as the File Editor that provides access to USS directories and files as well as MVS data sets and members, will work through the Zowe Z Secure Services (ZSS) component to access z/OS resources.   
 
-  :::info**Recommendations**
+  :::info Recommendations
   - For production use of Zowe, we recommend configuring z/OSMF to leverage Zowe functionalities that require z/OSMF. For more information, see [Configuring z/OSMF](systemrequirements-zosmf.md).
   - For non-production use of Zowe (such as development, proof-of-concept, demo), you can customize the configuration of z/OSMF to create **_z/OS MF Lite_** to simplify your setup of z/OSMF. z/OS MF Lite only supports selected REST services (JES, DataSet/File, TSO and Workflow), resulting in considerable improvements in startup time as well as a reduction in steps to set up z/OSMF. For information about how to set up z/OSMF Lite, see [Configuring z/OSMF Lite (non-production environment)](systemrequirements-zosmf-lite.md).
   :::

--- a/docs/user-guide/systemrequirements-zosmf.md
+++ b/docs/user-guide/systemrequirements-zosmf.md
@@ -106,7 +106,7 @@ The Zowe CLI uses z/OSMF Representational State Transfer (REST) APIs to work wit
 
   To verify that z/OSMF REST services are configured correctly in your environment, enter the REST endpoint into your browser. For example: `https://mvs.ibm.com:443/zosmf/restjobs/jobs`
 
-  :::note**Notes**
+  :::note Notes
 
   - Browsing z/OSMF endpoints requests your user ID and password for defaultRealm; these are your TSO user credentials.
   - The browser returns the status code 200 and a list of all jobs on the z/OS system. The list is in raw JSON format.

--- a/docs/user-guide/systemrequirements-zosmf.md
+++ b/docs/user-guide/systemrequirements-zosmf.md
@@ -10,7 +10,7 @@ meta:
 
 Follow these steps described in this article to configure z/OSMF.
 
-:::info**Required roles:** system programmer, security administrator, domain administrator
+:::info Required roles: system programmer, security administrator, domain administrator
 :::
 
 1. From the console, issue the following command to verify the version of z/OS:

--- a/docs/user-guide/use-certificates.md
+++ b/docs/user-guide/use-certificates.md
@@ -2,7 +2,7 @@
 
 Once you have generated or imported your certificates, you can now use the certificates with Zowe. Use the procedure descibed in this article that corresponds to the type of certificates you generated or imported.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 Choose from the following procedures:
 

--- a/docs/user-guide/zowe-ha-overview.md
+++ b/docs/user-guide/zowe-ha-overview.md
@@ -3,7 +3,7 @@
 Zowe has a high availability feature built-in.
 For Zowe in a high availability configuration, one workspace directory is required. This workspace directory must be created on a shared file system (zFS directory) which all LPARs in a Sysplex can access. Review this article and the following articles in this section for the configuration steps to enable the high availability feature. Note that configuring high availability is optional.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Enable high availability when Zowe runs in Sysplex

--- a/docs/user-guide/zwe-init-subcommand-overview.md
+++ b/docs/user-guide/zwe-init-subcommand-overview.md
@@ -17,7 +17,7 @@ Some of the following `zwe init` subcommands require elevated permissions. See t
 
 Use the `zwe init mvs` command to intialize Zowe custom MVS data sets. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 During the installation of Zowe, the following three data sets are created and populated with members copied across from the Zowe installation files:
@@ -102,7 +102,7 @@ Successful execution of `zwe init mvs` has the following results:
 
 This subcommand creates the user IDs and security manager settings.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 If Zowe has already been launched on a z/OS system from a previous release of Zowe v2, you can skip this security configuration step unless told otherwise in the release documentation.
@@ -158,7 +158,7 @@ Installation of Zowe main started tasks requires that JCL members for each of Zo
 
 Once you have completed security configuration, you can install the Zowe main started tasks. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 The JCL members for each of Zowe's started tasks need to be present on the JES proclib concatenation path. The command `zwe init stc` copies these members from the install source location `.SZWESAMP` to the targted PDS specified in the `zowe.setup.dataset.proclib` value `USER.PROCLIB`. The three proclib member names are specified in `zowe.yaml` arguments.  

--- a/docs/user-guide/zwe-init-subcommand-overview.md
+++ b/docs/user-guide/zwe-init-subcommand-overview.md
@@ -116,7 +116,7 @@ For more information about `zwe init security`, see [Initializing Zowe security 
 
 Zowe contains load modules that require access to make privileged z/OS security manager calls. These load modules are held in two load libraries which must be APF authorized. 
 
-:::info**Required roles:** security administrator
+:::info Required roles: security administrator
 :::
 
 The command `zwe init apfauth` reads the PDS names for the following load libraries from zowe.yaml and performs the APF authority commands.
@@ -132,7 +132,7 @@ For more information about `zwe init apfauth` see [Performing APF authorization 
 
 Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Zowe supports using either file-based (PKCS12) or z/OS key ring-based (when on z/OS) keystores and truststores, and can reuse compatible stores. You can use the `zwe init certificate` command to create keystores and truststores by either generating certificates or by allowing users to import their own compatible certificates.
@@ -143,7 +143,7 @@ For more information, see [Configuring certificates](./configure-certificates).
 
 Zowe can work in a high availability (HA) configuration where multiple instances of the Zowe launcher are started, either on the same LPAR or different LPARs connected through sysplex distributor. If you are only running a single Zowe instance on a single LPAR you do not need to create a caching service so you may skip this step.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 The command `zwe init vsam` uses the template JCL in `SZWESAMP(ZWECSVSM)` to copy the source template member from `zowe.setup.mvs.hlq.SZWESAMP(ZWECVCSM)` and creates a target JCL member in `zowe.setup.mvs.jcllib(ZWECVSCM)` with values extracted from the `zowe.yaml` file.

--- a/versioned_docs/version-v2.12.x/extend/extend-apiml/api-mediation-message-service.md
+++ b/versioned_docs/version-v2.12.x/extend/extend-apiml/api-mediation-message-service.md
@@ -13,7 +13,7 @@ API ML uses a customizable infrastructure to format both REST API error messages
 
 - Message `key` - a unique ID in the form of a dot-delimited string that describes the reason for the message. The `key` enables the UI or the console to show a meaningful and localized message. 
 
-    :::tip**Tips:**
+    :::tip Tips:
     - We recommend using the format `org.zowe.sample.apiservice.{TYPE}.greeting.empty` to define the message key. `{TYPE}` can be the api or log keyword. 
     - Use the message `key` and not the message `number`. The message `number` makes the code less readable, and increases the possibility of errors when renumbering values inside the `number`.
     :::

--- a/versioned_docs/version-v2.12.x/extend/extend-apiml/custom-metadata.md
+++ b/versioned_docs/version-v2.12.x/extend/extend-apiml/custom-metadata.md
@@ -6,7 +6,7 @@ Additional metadata can be added to the instance information that is registered 
       
     When this parameter is set to `true`, the Gateway allows encoded characters to be part of URL requests redirected through the Gateway. The default setting of `false` is the recommended setting. Change this setting to `true` only if you expect certain encoded characters in your application's requests.
           
-    :::info**Important!**
+    :::info Important
     When the expected encoded character is an encoded slash or backslash (`%2F`, `%5C`), make sure the Gateway is also configured to allow encoded slashes. For  more information, see [Installing the Zowe runtime on z/OS](../../user-guide/install-zos.md).
     :::
 

--- a/versioned_docs/version-v2.12.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.12.x/extend/extend-apiml/onboard-static-definition.md
@@ -94,7 +94,7 @@ catalogUiTiles:
 
 In this example, a suitable name for the file is `petstore.yml`.
 
-:::note**Notes:**
+:::note Notes:
 
 * The filename does not need to follow specific naming conventions but it requires the `.yml` extension.
 * The file can contain one or more services defined under the `services:` node.
@@ -103,7 +103,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
 * The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
 
-:::tip**Tips:**
+:::tip Tips:
 
 * There are more examples of API definitions at this [link](https://github.com/zowe/api-layer/tree/master/config/local/api-defs).
 * For more details about how to use YAML format, see this [link](https://learnxinyminutes.com/docs/yaml/).
@@ -548,7 +548,7 @@ The `${zoweInstanceDir}` symbol is used in following instructions.
     
     - To place your YAML file within the instance directory, copy your YAML file to the `${zoweInstanceDir}/workspace/api-mediation/api-defs` directory. 
 
-    :::note**Notes:**
+    :::note Notes:
     - The `${zoweInstanceDir}/workspace/api-mediation/api-defs` directory is created the first time that Zowe starts. If you have not yet started Zowe, this directory might be missing.
     - The user ID `ZWESVUSR` that runs the Zowe started task must have permission to read the YAML file.
     :::  

--- a/versioned_docs/version-v2.12.x/user-guide/address-browser-requirements.md
+++ b/versioned_docs/version-v2.12.x/user-guide/address-browser-requirements.md
@@ -2,7 +2,7 @@
 
 Review the following browser requirements to avoid browser-specific issues when running particular server-side components.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Zowe Desktop requirements (client PC)

--- a/versioned_docs/version-v2.12.x/user-guide/address-network-requirements.md
+++ b/versioned_docs/version-v2.12.x/user-guide/address-network-requirements.md
@@ -3,7 +3,7 @@
 Review the following table during installation of Zowe server-side components to determine which TCP ports are required. 
 Values presented in the table are default values. You can change the values by updating variable values in the `zowe.yaml` file. 
 
-:::info**Required roles:** network administrator, system programmer
+:::info Required roles: network administrator, system programmer
 :::
 
 For more information about variable names in the following table, see the [Zowe YAML configuration file reference](../appendix/zowe-yaml-configuration.md) in the References section.

--- a/versioned_docs/version-v2.12.x/user-guide/apf-authorize-load-library.md
+++ b/versioned_docs/version-v2.12.x/user-guide/apf-authorize-load-library.md
@@ -2,7 +2,7 @@
 
 Review this article to learn how to perform APF authorization of Zowe load libraries to make privileged calls. Note that this procedure requires elevated permissions.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 Zowe contains load modules that require access to make privileged z/OS security manager calls. These load modules are held in two load libraries which must be APF authorized. The command `zwe init apfauth` reads the PDS names for the load libraries from `zowe.yaml` and performs the APF authority commands.  

--- a/versioned_docs/version-v2.12.x/user-guide/api-mediation-view-service-information-and-api-doc.md
+++ b/versioned_docs/version-v2.12.x/user-guide/api-mediation-view-service-information-and-api-doc.md
@@ -16,7 +16,7 @@ Services that belong to the same product family are displayed on the same tile.
 2. Click the tile to view header information, the registered services under that family ID,
  and API documentation for that service.
 
-   :::note**Notes:**
+   :::note Notes:
    * The state of the service is indicated in the service tile on the dashboard page.
     If no instances of the service are currently running, the tile displays a message that no services are running.
    * At least one instance of a service must be started and registered with the Discovery Service for it to be visible
@@ -45,7 +45,7 @@ Services that belong to the same product family are displayed on the same tile.
 
    <img src={require("../images/api-mediation/expanded.png").default} alt="endpoint detail" width="500px"/>
 
-   :::note**Notes:**
+   :::note Notes:
    * If a lock icon is visible on the right side of the endpoint panel, the endpoint requires authentication.
    * The structure of the endpoint is displayed relative to the base URL.
    * The URL path of the abbreviated endpoint relative to the base URL is displayed in the following format:

--- a/versioned_docs/version-v2.12.x/user-guide/api-mediation/api-mediation-jwt-token-refresh.md
+++ b/versioned_docs/version-v2.12.x/user-guide/api-mediation/api-mediation-jwt-token-refresh.md
@@ -7,7 +7,7 @@ The refresh request requires the token in one of the following formats:
 - A cookie named `apimlAuthenticationToken`.
 - Bearer authentication
 
-:::note**Notes:**
+:::note Notes:
 - The endpoint is disabled by default. For more information, see [Enable JWT token endpoint](api-gateway-configuration.md#enable-jwt-token-refresh-endpoint).
 - The endpoint is protected by a client certificate.
   For more information, see the OpenAPI documentation of the API Mediation Layer in the API Catalog.

--- a/versioned_docs/version-v2.12.x/user-guide/assign-security-permissions-to-users.md
+++ b/versioned_docs/version-v2.12.x/user-guide/assign-security-permissions-to-users.md
@@ -2,7 +2,7 @@
 
 Assign users (ZWESVUSR and ZWESIUSR) and the ZWEADMIN security group permissions required to perform specific tasks. Each TSO user ID that logs on to Zowe and uses Zowe services that use z/OSMF requires permission to access these z/OSMF services.
 
-:::info**Required roles:**  security administrator
+:::info Required roles:  security administrator
 :::
 
 ### Overview of user categories and roles

--- a/versioned_docs/version-v2.12.x/user-guide/assign-security-permissions-to-users.md
+++ b/versioned_docs/version-v2.12.x/user-guide/assign-security-permissions-to-users.md
@@ -64,7 +64,7 @@ see [zwe init security](../appendix/zwe_server_command_reference/zwe/init/zwe-in
 
 Each TSO user ID that logs on to Zowe and uses Zowe services that use z/OSMF requires permission to access these z/OSMF services. It is necessary that every user ID be added to the group with the appropriate z/OSMF privileges, `IZUUSER` or `IZUADMIN` (default). 
 
-:::info**Required role:**  security administrator
+:::info Required role:  security administrator
 :::
 
 This step is not included in the provided Zowe JCL because it must be done for every TSO user ID who wants to access Zowe's z/OS services.  The list of those user IDs will typically be the operators, administrators, developers, or anyone else in the z/OS environment who is logging in to Zowe.

--- a/versioned_docs/version-v2.12.x/user-guide/certificate-configuration-scenarios.md
+++ b/versioned_docs/version-v2.12.x/user-guide/certificate-configuration-scenarios.md
@@ -3,7 +3,7 @@
 
  After you complete the Zowe certificates configuration questionnaire to determine your specific configuration use case, review the five scenarios presented in this article for configuring Zowe for automatic certificate setup. Examples of the zowe.yaml files are provided for each scenario.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 :::tip **Tip**

--- a/versioned_docs/version-v2.12.x/user-guide/certificate-configuration-scenarios.md
+++ b/versioned_docs/version-v2.12.x/user-guide/certificate-configuration-scenarios.md
@@ -19,7 +19,7 @@ This automation can be performed by defining and customizing the `zowe.setup.cer
 Zowe can then automate the certificate setup via the `zwe init certificate` command. 
 
 
-:::note**Note:**  
+:::note Note:  
 Automated generation of certificates is an option, but is not required. If you already have a keystore that contains a valid certificate*, and the  corresponding private key of the certificate, along with a truststore which validates the certificate and any other certificates you expect to encounter, then you also have the option to directly define the parameter `zowe.certificate` which specifies the location of each of these certificates and their storage objects. Note that this parameter should not be confused with the parameter `zowe.setup.certificate`.
 :::
 

--- a/versioned_docs/version-v2.12.x/user-guide/certificates-configuration-questionnaire.md
+++ b/versioned_docs/version-v2.12.x/user-guide/certificates-configuration-questionnaire.md
@@ -3,7 +3,7 @@
 To properly configure Zowe to use certificates for server-side component installation, review the  certificate setup options presented in this article. 
 Understanding these options makes it possible to select the best certificate configuration scenario that fits your Zowe deployment use case. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 
 If you know that you will be using certificates in a production deployment environment, and that you will be using an external certificate authority (CA), we recommend you consult with your organization's security administrator before you start certificate configuration.
 :::

--- a/versioned_docs/version-v2.12.x/user-guide/certificates-setup.md
+++ b/versioned_docs/version-v2.12.x/user-guide/certificates-setup.md
@@ -4,7 +4,7 @@ Zowe can use certificates that are held in z/OS Keyring.
 
 You can use four z/OSMF workflows that enable you to manage keyring setup, certificates, certificate sign requests, and signatures, and load certificates to a keyring.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Use the following workflows to set up certificates for Zowe in your environment:

--- a/versioned_docs/version-v2.12.x/user-guide/configure-certificates.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configure-certificates.md
@@ -2,7 +2,7 @@
 
 Review this article to learn about the key concepts of Zowe certificates, and options for certificate configuration. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. Communication in Zowe can be between Zowe servers, from Zowe to another server, or even between Zowe's servers and Zowe's client components.

--- a/versioned_docs/version-v2.12.x/user-guide/configure-uss.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configure-uss.md
@@ -2,7 +2,7 @@
 
 The Zowe z/OS component runtime requires UNIX System Services (USS) to be configured. As shown in the [Zowe architecture](../getting-started/zowe-architecture.md), a number of servers run under UNIX System Services (USS) on z/OS. Review this topic for knowledge and considerations about USS when you install and configure Zowe.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 ## What is USS?

--- a/versioned_docs/version-v2.12.x/user-guide/configure-xmem-server.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configure-xmem-server.md
@@ -6,7 +6,7 @@ APF-authorized program. The same cross memory server can be used by multiple Zow
 :::info Required roles: system programmer, security administrator
 :::
 
-:::tip**Important**
+:::tip Important
 This article describes how to configure the cross server manually. However, most of this configuration should already be performed during [Zowe configuration](./configuring-overview). 
 If you have already successfully run the `zwe init` command, the load modules are already installed, and APF authorization and SAF configuration is complete.
 
@@ -159,7 +159,7 @@ Do not install the Zowe auxiliary address space unless a Zowe extension product'
 
 A default installation of Zowe does not require auxiliary address spaces to be configured.
 
-:::info**Important**
+:::info Important
 The cross memory `ZWESISTC` task starts and stops the `ZWESASTC` task as needed. **Do not start the `ZWESASTC` task manually.**
 :::
 

--- a/versioned_docs/version-v2.12.x/user-guide/configure-xmem-server.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configure-xmem-server.md
@@ -3,7 +3,7 @@
 The Zowe cross memory server (ZIS) provides privileged cross-memory services to the Zowe Desktop and runs as an
 APF-authorized program. The same cross memory server can be used by multiple Zowe desktops. The cross memory server is required to log on to the Zowe desktop and operate the desktop apps such as the Code Editor. If you wish to start Zowe without the desktop (for example bring up just the API Mediation Layer), you do not need to install and configure a cross memory server and can skip this step. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 :::tip**Important**

--- a/versioned_docs/version-v2.12.x/user-guide/configure-zos-system.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configure-zos-system.md
@@ -2,7 +2,7 @@
 
 As a security administrator it is necessary to  configure the z/OS system for Zowe. Review the following article to learn about z/OS prerequisites, and z/OS configuration requirements for specific settings.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 ## z/OS prerequisites
@@ -123,7 +123,7 @@ Define or check the following configurations depending on whether ICSF is alread
         (repeat for user-acids IKED, NSSD, and Policy Agent)
 
 
-:::note**Notes:**
+:::note Notes:
 - Determine whether you want SAF authorization checks against `CSFSERV` and set `CSF.CSFSERV.AUTH.CSFRNG.DISABLE` accordingly.
 - Refer to the [z/OS 2.3.0 z/OS Cryptographic Services ICSF System Programmer's Guide: Installation, initialization, and customization](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.csfb200/iandi.htm).
 - CCA and/or PKCS #11 coprocessor for random number generation.
@@ -481,7 +481,7 @@ To do this, issue the following commands that are also included in the `ZWESECUR
     TSS PERMIT(ZWESVUSR) IBMFAC(ZWES.IS) ACCESS(READ)
     ```
 
-:::note**Notes:**
+:::note Notes:
 - The cross memory server treats "no decision" style SAF return codes as failures. If there is no covering profile for the `ZWES.IS` resource in the FACILITY class, the request will be denied.
 - Cross memory server clients other than Zowe might have additional SAF security requirements. For more information, see the documentation for the specific client.
 :::

--- a/versioned_docs/version-v2.12.x/user-guide/configure-zowe-runtime.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configure-zowe-runtime.md
@@ -2,7 +2,7 @@
 
 Begin configuration of your installation of Zowe z/OS components by initializing Zowe z/OS runtime.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 Use one of the following options to initialize Zowe z/OS runtime:

--- a/versioned_docs/version-v2.12.x/user-guide/configure-zowe-zosmf-workflow.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configure-zowe-zosmf-workflow.md
@@ -2,7 +2,7 @@
 
 After you install Zowe, you can register and execute the z/OSMF workflows in the web interface to perform a range of Zowe configuration tasks. z/OSMF helps to simplify the Zowe configuration tasks and does not require the level of expertise that is needed to perform manual Zowe configuration. This configuration method also runs the `zwe init` command to initialize Zowe z/OS runtime.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 Ensure that you meet the following requirements before you start your Zowe configuration:

--- a/versioned_docs/version-v2.12.x/user-guide/configuring-overview.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configuring-overview.md
@@ -2,7 +2,7 @@
 
 Review this article for an overview of the procedures that must be performed to configure Zowe z/OS components and the z/OS system. More details about the individual procedures are provided in the articles in this section. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Configuring Zowe z/OS components consists of the following four main steps:

--- a/versioned_docs/version-v2.12.x/user-guide/configuring-security.md
+++ b/versioned_docs/version-v2.12.x/user-guide/configuring-security.md
@@ -2,7 +2,7 @@
 
 During the initial installation of Zowe server-side components, it is necessary for your organization's security administrator to perform a range of tasks that require elevated security permissions. As a security administrator, follow the procedures outlined in this article to configure Zowe and your z/OS system to run Zowe with z/OS.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 ## Validate and re-run `zwe init` commands

--- a/versioned_docs/version-v2.12.x/user-guide/generate-certificates.md
+++ b/versioned_docs/version-v2.12.x/user-guide/generate-certificates.md
@@ -209,7 +209,7 @@ zowe:
         - 12.34.56.78
 ```
 
-:::note**Notes:**
+:::note Notes:
 - Alias names should be all lower cases.
 - The name and lables shown above are the default value in `zowe.yaml`.
 - `dname` for distinguished name is all optional.

--- a/versioned_docs/version-v2.12.x/user-guide/generate-certificates.md
+++ b/versioned_docs/version-v2.12.x/user-guide/generate-certificates.md
@@ -3,7 +3,7 @@
 
 If you do not have a certificate, follow the procedure in this article that corresponds to the certificate type you choose to generate.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Choose from the following certificate types:

--- a/versioned_docs/version-v2.12.x/user-guide/import-certificates.md
+++ b/versioned_docs/version-v2.12.x/user-guide/import-certificates.md
@@ -2,7 +2,7 @@
 
 One option to use certificates in Zowe is to import and configure existing certificates. Use the procedure that applies to the type of certificate you wish to import.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Choose from the following certificate importing options:

--- a/versioned_docs/version-v2.12.x/user-guide/initialize-mvs-datasets.md
+++ b/versioned_docs/version-v2.12.x/user-guide/initialize-mvs-datasets.md
@@ -3,7 +3,7 @@
 
 Review this article to learn about how to intialize Zowe custom MVS data sets by using the `zwe init mvs` command. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Introduction

--- a/versioned_docs/version-v2.12.x/user-guide/initialize-security-configuration.md
+++ b/versioned_docs/version-v2.12.x/user-guide/initialize-security-configuration.md
@@ -58,7 +58,7 @@ The JCL allows you to vary which security manager you use by setting the _PRODUC
 
 If `ZWESECUR` encounters an error or a step that has already been performed, it continues to the end, so it can be run repeatedly in a scenario such as a pipeline automating the configuration of a z/OS environment for Zowe installation.  
 
-:::info**Important**
+:::info Important
 It is expected that your security administrator will be required to review, edit where necessary, and either execute `ZWESECUR` as a single job, or execute individual TSO commands to complete the security configuration of a z/OS system in preparation for installing and running Zowe.
 :::
 

--- a/versioned_docs/version-v2.12.x/user-guide/initialize-security-configuration.md
+++ b/versioned_docs/version-v2.12.x/user-guide/initialize-security-configuration.md
@@ -2,7 +2,7 @@
 
 This security configuration step is required for first time setup of Zowe. If Zowe has already been launched on a z/OS system from a previous release of Zowe v2, and the `zwe init security` subcommand successfully ran when initializing the z/OS subsystem, you can skip this step unless told otherwise in the release documentation.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 
 Consult with your security administrator before you proceed with initializing Zowe security configurations.
 :::

--- a/versioned_docs/version-v2.12.x/user-guide/initialize-zos-system.md
+++ b/versioned_docs/version-v2.12.x/user-guide/initialize-zos-system.md
@@ -2,7 +2,7 @@
 
 Once you complete the installation of the Zowe runtime, begin configuration by initializing Zowe with proper security configurations. To simplify this configuration process, one option is to run the `zwe init` command. This step is common for installing and configuring Zowe from either a convenience build or from an SMP/E build.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 ## About the `zwe init` command

--- a/versioned_docs/version-v2.12.x/user-guide/install-nodejs-zos.md
+++ b/versioned_docs/version-v2.12.x/user-guide/install-nodejs-zos.md
@@ -2,7 +2,7 @@
 
 Before you install Zowe&trade; on z/OS, you must install IBM SDK for Node.js on the same z/OS server that hosts the Zowe Application Server and z/OS Explorer Services. Review the information in this topic to obtain and install Node.js.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 :::note

--- a/versioned_docs/version-v2.12.x/user-guide/install-zowe-smpe.md
+++ b/versioned_docs/version-v2.12.x/user-guide/install-zowe-smpe.md
@@ -5,7 +5,7 @@ Review this article and the procedures to install and activate the functions of 
 :::info Required roles: system programmer
 :::
 
-:::note**Notes:**
+:::note Notes:
 * To install Zowe into its own SMP/E environment, consult the SMP/E manuals for instructions on creating and initializing the SMPCSI and SMP/E control data sets.
 * You can use the sample jobs that are provided to perform part or all of the installation tasks. The SMP/E jobs assume that all DDDEF entries that are required for SMP/E execution have been defined in appropriate zones.
 * You can use the SMP/E dialogs instead of the sample jobs to accomplish the SMP/E installation steps.
@@ -135,7 +135,7 @@ You will receive a return code of `0` if this job runs correctly.
 
 Upload the `AZWE002.readme.txt` file in text format and the `AZWE002.pax.Z` file in binary format from your workstation to the z/OS UNIX file system. The instructions in this section are also in the `AZWE002.readme.txt` file that you downloaded.
 
-:::info**Important**
+:::info Important
 Ensure you download the pax file in a different file system than where you put Zowe runtime. 
 :::
 
@@ -153,7 +153,7 @@ tsopw | Your TSO password
 d: | Location of the downloaded files
 @zfs_path@ | z/OS UNIX path where to store the files. This matches the @zfs_path@ variable you specified in the previous step.
 
-:::danger**Important** 
+:::danger Important 
 The `AZWE002.pax.Z` file must be uploaded to the z/OS driving system in binary format. Not using binary format causes the subsequent UNPAX step to fail.
 :::
 
@@ -569,7 +569,7 @@ GROUPEXTEND
 BYPASS(HOLDCLASS(HIPER)) .
 ..any other parameters documented in the program directory
 ```
-:::note**Notes:**  
+:::note Notes:  
 * This method is quicker, but requires subsequent review of the Exception SYSMOD report produced by the REPORT ERRSYSMODS command to investigate any unresolved HIPERs. If you have received the latest HOLDDATA, you can also choose to use the REPORT MISSINGFIX command and specify Fix Category IBM.PRODUCTINSTALL-REQUIREDSERVICE to investigate missing recommended service.
 * If you bypass HOLDs during the installation of the FMIDs because fixing PTFs are not yet available, you can be notified when the fixing PTFs are available by using the APAR Status Tracking (AST) function of the ServiceLink or the APAR Tracking function of Resource Link.
 :::

--- a/versioned_docs/version-v2.12.x/user-guide/install-zowe-smpe.md
+++ b/versioned_docs/version-v2.12.x/user-guide/install-zowe-smpe.md
@@ -2,7 +2,7 @@
 
 Review this article and the procedures to install and activate the functions of Zowe server-side components using SMP/E.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 :::note**Notes:**

--- a/versioned_docs/version-v2.12.x/user-guide/installandconfig.md
+++ b/versioned_docs/version-v2.12.x/user-guide/installandconfig.md
@@ -2,7 +2,7 @@
 
 Review this overview article to familiarize yourself with key concepts used in the Zowe server-side installation process. After reviewing these key concepts, review the articles in this section to prepare your system for installation. 
 
-:::info**Required roles:** system programmer, security administrator, storage administrator
+:::info Required roles: system programmer, security administrator, storage administrator
 :::
 
 To prepare for Zowe server-side installation, we recommend that your installation team review the installation and configuration tasks and the indicated required roles to perform specific procedures. Doing so can help you complete the process without encountering delays waiting for tasks to be completed at the last minute.

--- a/versioned_docs/version-v2.12.x/user-guide/installandconfig.md
+++ b/versioned_docs/version-v2.12.x/user-guide/installandconfig.md
@@ -87,7 +87,7 @@ Configures the system to launch the Zowe started task.
 
 In combination, these commands initialize Zowe, manage Zowe instances, and perform common tasks.
 
-:::tip**Tips:**
+:::tip Tips:
 * The `zwe` command has built in help that can be retrieved with the `-h` suffix. Use `zwe -h` to see all supported `zwe` commands.
 
   For more information about `zwe` see [zwe](../appendix/zwe_server_command_reference/zwe/zwe) in the appendix.
@@ -114,7 +114,7 @@ Zowe has the following started tasks:
    - **`ZWESLSTC`**  
    This started task brings up other features of the Zowe runtime on z/OS upon request. Features may include Desktop, API Mediation Layer, ZSS, and more. When using containerization, it is likely that the only feature will be ZSS. This task can be used for a single Zowe instance deployment, and can also be used for Zowe high availability deployment in Sysplex. This task brings up and stops Zowe instances, or specific Zowe components without restarting the entire Zowe instances.
    
-:::info**Important!**
+:::info Important
 * In order for the above started tasks to run correctly, the security administrator permissions are required. For more information, see [Configuring the z/OS system for Zowe](configure-zos-system.md).
 * Note that the sample JCL member `ZWESECUR` is shipped with Zowe and contains commands for RACF, TopSecret, and ACF2 security managers.
 :::
@@ -162,7 +162,7 @@ To create this configuration, you can copy from `example-zowe.yaml` located in Z
 To learn more about this Zowe configuration file, see the [Zowe YAML configuration file reference](../appendix/zowe-yaml-configuration.md).
 
 
-:::tip**zowe.yaml configuration tips:**  
+:::tip zowe.yaml configuration tips:  
 
 When you execute the `zwe` command, the `--config` or `-c` argument is used to pass the location of a `zowe.yaml` file.
 

--- a/versioned_docs/version-v2.12.x/user-guide/k8s-introduction.md
+++ b/versioned_docs/version-v2.12.x/user-guide/k8s-introduction.md
@@ -2,7 +2,7 @@
 
 You can download Zowe (server) containers as an alternative to running Zowe servers on z/OS through the Zowe convenience and SMP/E builds. Choose the appropriate installation type for your use case.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 Using containers for installation has the following advantages:

--- a/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zos.md
@@ -5,7 +5,7 @@ keywords: [security permissions, system permissions, monacat]
 
 Before installing Zowe&trade; z/OS components, ensure that your z/OS environment meets the prerequisites. The prerequisites you need to install depend on what Zowe z/OS components you want to use and how you want to install and configure Zowe on z/OS. Assess your installation scenario and install the prerequisites that meet your needs. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 All Zowe server components can be installed on a z/OS environment, while some can alternatively be installed on Linux or zLinux via Docker. The components provide a number of services that are accessed through a web browser such as an API catalog and a web desktop.  

--- a/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zos.md
@@ -18,7 +18,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 - z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-  :::note**Notes:**
+  :::note Notes:
   * Zowe Version 2.11 or higher is required when using z/OS Version 3.1.
   * z/OS V2.3 reached end of support on 30 September, 2022. For more information, see the [z/OS v2.3 lifecycle details](https://www.ibm.com/support/pages/zos23x-withdrawal-notification).
   :::
@@ -57,7 +57,7 @@ Be sure your z/OS system meets the following prerequisites:
 
   - REST API services for Files (Data Sets and USS), JES, and z/OSMF workflows.  These are used by some Zowe applications such as the Zowe Explorers in the Zowe Desktop. If z/OSMF REST APIs are not present, other Zowe desktop application, such as the File Editor that provides access to USS directories and files as well as MVS data sets and members, will work through the Zowe Z Secure Services (ZSS) component to access z/OS resources.   
 
-  :::info**Recommendations**
+  :::info Recommendations
   - For production use of Zowe, we recommend configuring z/OSMF to leverage Zowe functionalities that require z/OSMF. For more information, see [Configuring z/OSMF](systemrequirements-zosmf.md).
   - For non-production use of Zowe (such as development, proof-of-concept, demo), you can customize the configuration of z/OSMF to create **_z/OS MF Lite_** to simplify your setup of z/OSMF. z/OS MF Lite only supports selected REST services (JES, DataSet/File, TSO and Workflow), resulting in considerable improvements in startup time as well as a reduction in steps to set up z/OSMF. For information about how to set up z/OSMF Lite, see [Configuring z/OSMF Lite (non-production environment)](systemrequirements-zosmf-lite.md).
   :::

--- a/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zosmf.md
+++ b/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zosmf.md
@@ -106,7 +106,7 @@ The Zowe CLI uses z/OSMF Representational State Transfer (REST) APIs to work wit
 
   To verify that z/OSMF REST services are configured correctly in your environment, enter the REST endpoint into your browser. For example: `https://mvs.ibm.com:443/zosmf/restjobs/jobs`
 
-  :::note**Notes**
+  :::note Notes
 
   - Browsing z/OSMF endpoints requests your user ID and password for defaultRealm; these are your TSO user credentials.
   - The browser returns the status code 200 and a list of all jobs on the z/OS system. The list is in raw JSON format.

--- a/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zosmf.md
+++ b/versioned_docs/version-v2.12.x/user-guide/systemrequirements-zosmf.md
@@ -10,7 +10,7 @@ meta:
 
 Follow these steps described in this article to configure z/OSMF.
 
-:::info**Required roles:** system programmer, security administrator, domain administrator
+:::info Required roles: system programmer, security administrator, domain administrator
 :::
 
 1. From the console, issue the following command to verify the version of z/OS:

--- a/versioned_docs/version-v2.12.x/user-guide/use-certificates.md
+++ b/versioned_docs/version-v2.12.x/user-guide/use-certificates.md
@@ -2,7 +2,7 @@
 
 Once you have generated or imported your certificates, you can now use the certificates with Zowe. Use the procedure descibed in this article that corresponds to the type of certificates you generated or imported.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 Choose from the following procedures:
 

--- a/versioned_docs/version-v2.12.x/user-guide/zowe-ha-overview.md
+++ b/versioned_docs/version-v2.12.x/user-guide/zowe-ha-overview.md
@@ -3,7 +3,7 @@
 Zowe has a high availability feature built-in.
 For Zowe in a high availability configuration, one workspace directory is required. This workspace directory must be created on a shared file system (zFS directory) which all LPARs in a Sysplex can access. Review this article and the following articles in this section for the configuration steps to enable the high availability feature. Note that configuring high availability is optional.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Enable high availability when Zowe runs in Sysplex

--- a/versioned_docs/version-v2.12.x/user-guide/zwe-init-subcommand-overview.md
+++ b/versioned_docs/version-v2.12.x/user-guide/zwe-init-subcommand-overview.md
@@ -17,7 +17,7 @@ Some of the following `zwe init` subcommands require elevated permissions. See t
 
 Use the `zwe init mvs` command to intialize Zowe custom MVS data sets. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 During the installation of Zowe, the following three data sets are created and populated with members copied across from the Zowe installation files:
@@ -102,7 +102,7 @@ Successful execution of `zwe init mvs` has the following results:
 
 This subcommand creates the user IDs and security manager settings.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 If Zowe has already been launched on a z/OS system from a previous release of Zowe v2, you can skip this security configuration step unless told otherwise in the release documentation.
@@ -158,7 +158,7 @@ Installation of Zowe main started tasks requires that JCL members for each of Zo
 
 Once you have completed security configuration, you can install the Zowe main started tasks. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 The JCL members for each of Zowe's started tasks need to be present on the JES proclib concatenation path. The command `zwe init stc` copies these members from the install source location `.SZWESAMP` to the targted PDS specified in the `zowe.setup.dataset.proclib` value `USER.PROCLIB`. The three proclib member names are specified in `zowe.yaml` arguments.  

--- a/versioned_docs/version-v2.12.x/user-guide/zwe-init-subcommand-overview.md
+++ b/versioned_docs/version-v2.12.x/user-guide/zwe-init-subcommand-overview.md
@@ -116,7 +116,7 @@ For more information about `zwe init security`, see [Initializing Zowe security 
 
 Zowe contains load modules that require access to make privileged z/OS security manager calls. These load modules are held in two load libraries which must be APF authorized. 
 
-:::info**Required roles:** security administrator
+:::info Required roles: security administrator
 :::
 
 The command `zwe init apfauth` reads the PDS names for the following load libraries from zowe.yaml and performs the APF authority commands.
@@ -132,7 +132,7 @@ For more information about `zwe init apfauth` see [Performing APF authorization 
 
 Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Zowe supports using either file-based (PKCS12) or z/OS key ring-based (when on z/OS) keystores and truststores, and can reuse compatible stores. You can use the `zwe init certificate` command to create keystores and truststores by either generating certificates or by allowing users to import their own compatible certificates.
@@ -143,7 +143,7 @@ For more information, see [Configuring certificates](./configure-certificates).
 
 Zowe can work in a high availability (HA) configuration where multiple instances of the Zowe launcher are started, either on the same LPAR or different LPARs connected through sysplex distributor. If you are only running a single Zowe instance on a single LPAR you do not need to create a caching service so you may skip this step.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 The command `zwe init vsam` uses the template JCL in `SZWESAMP(ZWECSVSM)` to copy the source template member from `zowe.setup.mvs.hlq.SZWESAMP(ZWECVCSM)` and creates a target JCL member in `zowe.setup.mvs.jcllib(ZWECVSCM)` with values extracted from the `zowe.yaml` file.

--- a/versioned_docs/version-v2.13.x/extend/extend-apiml/api-mediation-message-service.md
+++ b/versioned_docs/version-v2.13.x/extend/extend-apiml/api-mediation-message-service.md
@@ -13,7 +13,7 @@ API ML uses a customizable infrastructure to format both REST API error messages
 
 - Message `key` - a unique ID in the form of a dot-delimited string that describes the reason for the message. The `key` enables the UI or the console to show a meaningful and localized message. 
 
-    :::tip**Tips:**
+    :::tip Tips:
     - We recommend using the format `org.zowe.sample.apiservice.{TYPE}.greeting.empty` to define the message key. `{TYPE}` can be the api or log keyword. 
     - Use the message `key` and not the message `number`. The message `number` makes the code less readable, and increases the possibility of errors when renumbering values inside the `number`.
     :::

--- a/versioned_docs/version-v2.13.x/extend/extend-apiml/api-mediation-oidc-authentication.md
+++ b/versioned_docs/version-v2.13.x/extend/extend-apiml/api-mediation-oidc-authentication.md
@@ -164,7 +164,7 @@ curl --location 'https://"$HOSTNAME:$PORT"/gateway/api/v1/auth/oidc-token/valida
 An HTTP `200` code is returned if the validation passes. Failure to validate returns an HTTP `40x` error.
 :::
 
-:::note**Azure Entra ID OIDC notes:**
+:::note Azure Entra ID OIDC notes:
 API ML uses the `sub` claim of the ID Token to identify the user, and to map to the mainframe account. Note that the structure of the `sub` claim varies between the Azure token and the OKTA ID token:
 * The Azure token `sub` is an alphanumeric value.  
 For more information, see the topic _Use claims to reliably identify a user_ in the Microsoft Learn documentation.

--- a/versioned_docs/version-v2.13.x/extend/extend-apiml/authentication-for-apiml-services.md
+++ b/versioned_docs/version-v2.13.x/extend/extend-apiml/authentication-for-apiml-services.md
@@ -163,7 +163,7 @@ For more information, see your security system documentation.
 2. Import the external CA to the truststore or keyring of the API Mediation Layer.
 3. Configure the Gateway for client certificate authentication. Follow the procedure described in [Enabling single sign on for clients via client certificate configuration](../../user-guide/api-mediation/configuration-client-certificates).
 
-:::note**Notes:**
+:::note Notes:
 * PassTicket generation must be enabled for the Zowe runtime user. The user has to be able to generate a PassTicket for itself and for the APPLID of z/OSMF. For more information, see [Configure Passticket](#authentication-with-passtickets).
 * The Zowe runtime user must be enabled to perform identity mapping in SAF. For more information, see [Additional security rights that need to be granted](../../user-guide/configure-zos-system/#configure-main-Zowe-server-use-identity-mapping).
 * ZSS has to be configured to participate in Zowe SSO. For more information, see [Configure components zss](../../appendix/zowe-yaml-configuration/#configure-component-zss).

--- a/versioned_docs/version-v2.13.x/extend/extend-apiml/custom-metadata.md
+++ b/versioned_docs/version-v2.13.x/extend/extend-apiml/custom-metadata.md
@@ -6,7 +6,7 @@ Additional metadata can be added to the instance information that is registered 
       
     When this parameter is set to `true`, the Gateway allows encoded characters to be part of URL requests redirected through the Gateway. The default setting of `false` is the recommended setting. Change this setting to `true` only if you expect certain encoded characters in your application's requests.
           
-    :::info**Important!**
+    :::info Important
     When the expected encoded character is an encoded slash or backslash (`%2F`, `%5C`), make sure the Gateway is also configured to allow encoded slashes. For  more information, see [Installing the Zowe runtime on z/OS](../../user-guide/install-zos.md).
     :::
 

--- a/versioned_docs/version-v2.13.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.13.x/extend/extend-apiml/onboard-static-definition.md
@@ -94,7 +94,7 @@ catalogUiTiles:
 
 In this example, a suitable name for the file is `petstore.yml`.
 
-:::note**Notes:**
+:::note Notes:
 
 * The filename does not need to follow specific naming conventions but it requires the `.yml` extension.
 * The file can contain one or more services defined under the `services:` node.
@@ -103,7 +103,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
 * The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
 
-:::tip**Tips:**
+:::tip Tips:
 
 * There are more examples of API definitions at this [link](https://github.com/zowe/api-layer/tree/master/config/local/api-defs).
 * For more details about how to use YAML format, see this [link](https://learnxinyminutes.com/docs/yaml/).
@@ -548,7 +548,7 @@ The `${zoweInstanceDir}` symbol is used in following instructions.
     
     - To place your YAML file within the instance directory, copy your YAML file to the `${zoweInstanceDir}/workspace/api-mediation/api-defs` directory. 
 
-    :::note**Notes:**
+    :::note Notes:
     - The `${zoweInstanceDir}/workspace/api-mediation/api-defs` directory is created the first time that Zowe starts. If you have not yet started Zowe, this directory might be missing.
     - The user ID `ZWESVUSR` that runs the Zowe started task must have permission to read the YAML file.
     :::  

--- a/versioned_docs/version-v2.13.x/user-guide/address-browser-requirements.md
+++ b/versioned_docs/version-v2.13.x/user-guide/address-browser-requirements.md
@@ -2,7 +2,7 @@
 
 Review the following browser requirements to avoid browser-specific issues when running particular server-side components.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Zowe Desktop requirements (client PC)

--- a/versioned_docs/version-v2.13.x/user-guide/address-network-requirements.md
+++ b/versioned_docs/version-v2.13.x/user-guide/address-network-requirements.md
@@ -3,7 +3,7 @@
 Review the following table during installation of Zowe server-side components to determine which TCP ports are required. 
 Values presented in the table are default values. You can change the values by updating variable values in the `zowe.yaml` file. 
 
-:::info**Required roles:** network administrator, system programmer
+:::info Required roles: network administrator, system programmer
 :::
 
 For more information about variable names in the following table, see the [Zowe YAML configuration file reference](../appendix/zowe-yaml-configuration.md) in the References section.

--- a/versioned_docs/version-v2.13.x/user-guide/apf-authorize-load-library.md
+++ b/versioned_docs/version-v2.13.x/user-guide/apf-authorize-load-library.md
@@ -2,7 +2,7 @@
 
 Review this article to learn how to perform APF authorization of Zowe load libraries to make privileged calls. Note that this procedure requires elevated permissions.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 Zowe contains load modules that require access to make privileged z/OS security manager calls. These load modules are held in two load libraries which must be APF authorized. The command `zwe init apfauth` reads the PDS names for the load libraries from `zowe.yaml` and performs the APF authority commands.  

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation-view-service-information-and-api-doc.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation-view-service-information-and-api-doc.md
@@ -16,7 +16,7 @@ Services that belong to the same product family are displayed on the same tile.
 2. Click the tile to view header information, the registered services under that family ID,
  and API documentation for that service.
 
-   :::note**Notes:**
+   :::note Notes:
    * The state of the service is indicated in the service tile on the dashboard page.
     If no instances of the service are currently running, the tile displays a message that no services are running.
    * At least one instance of a service must be started and registered with the Discovery Service for it to be visible
@@ -45,7 +45,7 @@ Services that belong to the same product family are displayed on the same tile.
 
    <img src={require("../images/api-mediation/expanded.png").default} alt="endpoint detail" width="500px"/>
 
-   :::note**Notes:**
+   :::note Notes:
    * If a lock icon is visible on the right side of the endpoint panel, the endpoint requires authentication.
    * The structure of the endpoint is displayed relative to the base URL.
    * The URL path of the abbreviated endpoint relative to the base URL is displayed in the following format:

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/api-mediation-jwt-token-refresh.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/api-mediation-jwt-token-refresh.md
@@ -7,7 +7,7 @@ The refresh request requires the token in one of the following formats:
 - A cookie named `apimlAuthenticationToken`.
 - Bearer authentication
 
-:::note**Notes:**
+:::note Notes:
 - The endpoint is disabled by default. For more information, see [Enable JWT token endpoint](configuration-jwt.md#enable-jwt-token-refresh-endpoint).
 - The endpoint is protected by a client certificate.
   For more information, see the OpenAPI documentation of the API Mediation Layer in the API Catalog.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/api-mediation-personal-access-token.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/api-mediation-personal-access-token.md
@@ -1,6 +1,6 @@
 # Generating, validating, and invalidating a Personal Access Token
 
-:::info**Roles:** system programmer, security administrator
+:::info Roles: system programmer, security administrator
 :::
 
 You can use API Mediation Layer to generate, validate, and invalidate a **Personal Access Token (PAT)** that can enable access to tools such as VCS without having to use credentials of a specific person. The use of PAT does not require storing mainframe credentials as part of the automation configuration on a server during application development on z/OS.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-access-specific-instance-of-service.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-access-specific-instance-of-service.md
@@ -1,6 +1,6 @@
 # Retrieving a specific service within your environment 
 
-:::info**Roles:** system programmer, system administrator
+:::info Roles: system programmer, system administrator
 :::
 
 ## Output a routed instance header

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-at-tls.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-at-tls.md
@@ -4,7 +4,7 @@ The communication server on z/OS provides a functionality to encrypt HTTP commun
 
 Review this article for descriptions of the configuration parameters required to make the Zowe API Mediation Layer work with AT-TLS, and security recommendations.
 
-:::info**Role:** security administrator
+:::info Role: security administrator
 :::
 
 - [AT-TLS configuration for Zowe](#at-tls-configuration-for-zowe)
@@ -59,13 +59,13 @@ While API ML does not handle TLS on its own with AT-TLS enabled, API ML requires
 
 2. If there is an outbound AT-TLS rule configured for the link between the API Gateway and z/OSMF, set the `zowe.zOSMF.scheme` property to `http`.
 
-:::note**Notes**
+:::note Notes
 * Currently, AT-TLS is not supported in the API Cloud Gateway Mediation Layer component.
 
 * As the Gateway is a core component of API ML, other components that need to interact with the Gateway, such as Zowe ZLUX App Server, also require AT-TLS configuration.
 :::
 
-:::caution**Important security consideration**
+:::caution Important security consideration
 
 Configuring AT-TLS for the Zowe API Mediation Layer requires careful consideration of security settings, specifically as these settings apply to the Client Certificate authentication feature in Zowe API Mediation Layer components, as well as for onboarded services that support the x.509 client certificates authentication scheme.
 

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-authorization.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-authorization.md
@@ -1,6 +1,6 @@
 # Configuring authorization for API ML
 
-:::info**Role:** system administrator
+:::info Role: system administrator
 :::
 
 In Zowe's API Mediation Layer, system administrators can limit access to services and information in the API Catalog by hiding sensitive data like service instance URLs, configurable via the apiml.catalog.hide.serviceInfo property in zowe.yaml. Additionally, SAF resource checking for user authorization on specific endpoints is facilitated through various providers, such as Endpoint, Native, and Dummy. These configurations, modifiable in the zowe.yaml file, enhance security by controlling service exposure and ensuring proper authorization checks within the Zowe ecosystem.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-client-certificates.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-client-certificates.md
@@ -1,7 +1,7 @@
 # Enabling single sign on for clients via client certificate configuration
 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 Use the following procedure to enable the zowe.yaml file to use a client certificate as the method of authentication for the API Mediation Layer Gateway. 

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-connection-limits.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-connection-limits.md
@@ -1,6 +1,6 @@
 # Customizing connection limits
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 By default, the API Gateway accepts up to 100 concurrent connections per route, and 1000 total concurrent connections. Any further concurrent requests are queued until the completion of an existing request. The API Gateway is built on top of Apache HTTP components that require these two connection limits for concurrent requests. 

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-cors.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-cors.md
@@ -1,6 +1,6 @@
 # Customizing Cross-Origin Resource Sharing (CORS) 
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 As a system programmer, you can enable the Gateway to terminate CORS requests for itself and also for routed services. By default, Cross-Origin Resource Sharing (CORS) handling is disabled for Gateway routes `gateway/api/v1/**` and for individual services. After enabling the feature as stated in the following procedure, API Gateway endpoints start handling CORS requests. Individual services can control whether they want the Gateway to handle CORS for them through the [Custom Metadata](../../extend/extend-apiml/onboard-spring-boot-enabler/#custom-metadata) parameters.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-customizing-management-of-apiml-load-limits.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-customizing-management-of-apiml-load-limits.md
@@ -1,6 +1,6 @@
 # Customizing management of API ML load limits 
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 ::: 
 
 As a system programmer, you can customize your configuration for how API ML manages both northbound and southbound load limits in single instances:

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-customizing-the-api-catalog-ui.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-customizing-the-api-catalog-ui.md
@@ -1,6 +1,6 @@
 # Customizing the API Catalog UI
 
-:::info**Role:** system administrator
+:::info Role: system administrator
 :::
 
 As a system administrator, you can customize the API Catalog UI to have a similar interface to your organization's service, or with your existing visualization portal.
@@ -71,7 +71,7 @@ An alternative to the API Catalog is displayed
 - **metrics-dashboard**  
  A possible dashboard that could appear in place of the API Catalog 
 
-:::note**Notes:**
+:::note Notes:
 - If the application contains the `homePageUrl` and `statusPageRelativeUrl`, then the full set of information is displayed.
 - If the application contains the `homePageUrl` the link is displayed without the `UP` information.
 - If the application contains the `statusPageRelativeUrl` then `UP` or `DOWN` is displayed based on the `statusPage` without the link.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-distributed-load-balancer-cache.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-distributed-load-balancer-cache.md
@@ -1,6 +1,6 @@
 # Distributing the load balancer cache
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 You can choose to distribute the load balancer cache between instances of the API Gateway. To distribute the load balancer cache, it is necessary that the caching service is running. Gateway service instances are reuqired to have the same DN (Distinguished name) on the server certificate. This may be relevant for the HA setups.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for extending services
 
-:::info**Roles:** system programmer, API service extender
+:::info Roles: system programmer, API service extender
 :::
 
 Enabling Single Sign On (SSO) in Zowe involves configuring JWT tokens or PassTickets for secure authentication. The JWT token configuration requires setting up a custom HTTP header to store the token, thereby enhancing secure communication with southbound services. 

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-extender-jwt.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-extender-jwt.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for extending services via JWT token configuration 
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 ## Adding a custom HTTP Auth header to store Zowe JWT token

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-extender-passtickets.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-extender-passtickets.md
@@ -2,7 +2,7 @@
 
 As a system programmer, follow the procedures described in this article to configure Zowe to use PassTickets, and to enable Zowe to use PassTickets to authenticate towards specific extending services.
 
-:::info**Roles:** system programmer, security administrator
+:::info Roles: system programmer, security administrator
 :::
 
 ## Configuring Zowe to use PassTickets

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-gateway-retry-policy.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-gateway-retry-policy.md
@@ -2,7 +2,7 @@
 
 Use the following procedure to change the Gateway retry policy.
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 All requests are disabled as the default configuration for retry with one exception: the server retries `GET` requests that finish with status code `503`.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-gateway-timeouts.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-gateway-timeouts.md
@@ -1,6 +1,6 @@
 # Customizing Gateway timeouts
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 Use the following procedure to change the global timeout value for the API Mediation Layer instance.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-jwt.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-jwt.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for clients via JWT token configuration 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 As a system programmer, you can customize how JWT authentication is performed, the service that provides the JWT authentication token, whether it's possible to refresh JWT token and other characteristics of JWT for consumption. 

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-limiting-access-to-info-or-services-in-api-catalog.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-limiting-access-to-info-or-services-in-api-catalog.md
@@ -1,6 +1,6 @@
 # Limiting access to information or services in the API Catalog
 
-:::info**Role:** system administrator
+:::info Role: system administrator
 :::
 
 As a system administrator, you can limit access to information and/or services available within the API Catalog and through the API Mediation Layer and check for the authorization of the user on certain endpoints.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-personal-access-token.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-personal-access-token.md
@@ -1,7 +1,7 @@
 # Enabling single sign on for clients via personal access token configuration 
 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 By default the API Mediation Layer does not provide the ability to use personal access tokens. For more information about about

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-routing.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-routing.md
@@ -1,6 +1,6 @@
 # Customizing routing behavior 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 The Zowe API Mediation Layer offers a range of routing configurations for enhanced functionality and security. 

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-saf-resource-checking.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-saf-resource-checking.md
@@ -1,6 +1,6 @@
 # Configuring SAF resource checking 
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 You can use various SAF resource providers depending on your use case to handle the SAF authorization check. Follow the procedure in this article that applies to your specific configuration use case. 
 
@@ -95,7 +95,7 @@ The following YAML presents the structure of the file:
         - {UserID}
 ```
 
-:::note**Notes**
+:::note Notes
 - Classes and resources are mapped into a map, user IDs into a list.
 - The load method does not support formatting with dots, such as shown in the following example:
   **Example:** `{CLASS}.{RESOURCE}`

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-set-consistent-service-id.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-set-consistent-service-id.md
@@ -1,6 +1,6 @@
 # Setting a consistent service ID
 
-:::info**Role:** API service extender
+:::info Role: API service extender
 :::
 
 As an API service extender you can modify the service ID to ensure compatibility of services that use a non-conformant organization prefix with Zowe v2.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-single-sign-on-user.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-single-sign-on-user.md
@@ -1,6 +1,6 @@
 # Enabling single sign on for clients
 
-:::info**Roles:** system programmer, system administrator, security administrator
+:::info Roles: system programmer, system administrator, security administrator
 :::
 
 As a system programmer or system administrator, you can customize the way API ML handles authentication towards clients such as CLI and/or users. Each of the following methods limits the frequency the user is reqired to enter credentials to access API Mediation Layer: 

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-unique-cookie-name-for-multiple-zowe-instances.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-unique-cookie-name-for-multiple-zowe-instances.md
@@ -1,6 +1,6 @@
 # Configuring a unique cookie name for a specific API ML instance
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 By default, in the API Gateway, the cookie name is `apimlAuthenticationToken`.

--- a/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-url-handling.md
+++ b/versioned_docs/version-v2.13.x/user-guide/api-mediation/configuration-url-handling.md
@@ -1,6 +1,6 @@
 # Using encoded slashes
 
-:::info**Role:** system programmer
+:::info Role: system programmer
 :::
 
 By default, the API Mediation Layer accepts encoded slashes in the URL path of the request. If you are onboarding applications which expose endpoints that expect encoded slashes, it is necessary to keep the default configuration. We recommend that you change the property to `false` if you do not expect the applications to use the encoded slashes. 

--- a/versioned_docs/version-v2.13.x/user-guide/assign-security-permissions-to-users.md
+++ b/versioned_docs/version-v2.13.x/user-guide/assign-security-permissions-to-users.md
@@ -2,7 +2,7 @@
 
 Assign users (ZWESVUSR and ZWESIUSR) and the ZWEADMIN security group permissions required to perform specific tasks. Each TSO user ID that logs on to Zowe and uses Zowe services that use z/OSMF requires permission to access these z/OSMF services.
 
-:::info**Required roles:**  security administrator
+:::info Required roles:  security administrator
 :::
 
 ### Overview of user categories and roles

--- a/versioned_docs/version-v2.13.x/user-guide/assign-security-permissions-to-users.md
+++ b/versioned_docs/version-v2.13.x/user-guide/assign-security-permissions-to-users.md
@@ -64,7 +64,7 @@ see [zwe init security](../appendix/zwe_server_command_reference/zwe/init/zwe-in
 
 Each TSO user ID that logs on to Zowe and uses Zowe services that use z/OSMF requires permission to access these z/OSMF services. It is necessary that every user ID be added to the group with the appropriate z/OSMF privileges, `IZUUSER` or `IZUADMIN` (default). 
 
-:::info**Required role:**  security administrator
+:::info Required role:  security administrator
 :::
 
 This step is not included in the provided Zowe JCL because it must be done for every TSO user ID who wants to access Zowe's z/OS services.  The list of those user IDs will typically be the operators, administrators, developers, or anyone else in the z/OS environment who is logging in to Zowe.

--- a/versioned_docs/version-v2.13.x/user-guide/certificate-configuration-scenarios.md
+++ b/versioned_docs/version-v2.13.x/user-guide/certificate-configuration-scenarios.md
@@ -3,7 +3,7 @@
 
  After you complete the Zowe certificates configuration questionnaire to determine your specific configuration use case, review the five scenarios presented in this article for configuring Zowe for automatic certificate setup. Examples of the zowe.yaml files are provided for each scenario.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 :::tip **Tip**

--- a/versioned_docs/version-v2.13.x/user-guide/certificate-configuration-scenarios.md
+++ b/versioned_docs/version-v2.13.x/user-guide/certificate-configuration-scenarios.md
@@ -19,7 +19,7 @@ This automation can be performed by defining and customizing the `zowe.setup.cer
 Zowe can then automate the certificate setup via the `zwe init certificate` command. 
 
 
-:::note**Note:**  
+:::note Note:  
 Automated generation of certificates is an option, but is not required. If you already have a keystore that contains a valid certificate*, and the  corresponding private key of the certificate, along with a truststore which validates the certificate and any other certificates you expect to encounter, then you also have the option to directly define the parameter `zowe.certificate` which specifies the location of each of these certificates and their storage objects. Note that this parameter should not be confused with the parameter `zowe.setup.certificate`.
 :::
 

--- a/versioned_docs/version-v2.13.x/user-guide/certificates-configuration-questionnaire.md
+++ b/versioned_docs/version-v2.13.x/user-guide/certificates-configuration-questionnaire.md
@@ -3,7 +3,7 @@
 To properly configure Zowe to use certificates for server-side component installation, review the  certificate setup options presented in this article. 
 Understanding these options makes it possible to select the best certificate configuration scenario that fits your Zowe deployment use case. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 
 If you know that you will be using certificates in a production deployment environment, and that you will be using an external certificate authority (CA), we recommend you consult with your organization's security administrator before you start certificate configuration.
 :::

--- a/versioned_docs/version-v2.13.x/user-guide/certificates-setup.md
+++ b/versioned_docs/version-v2.13.x/user-guide/certificates-setup.md
@@ -4,7 +4,7 @@ Zowe can use certificates that are held in z/OS Keyring.
 
 You can use four z/OSMF workflows that enable you to manage keyring setup, certificates, certificate sign requests, and signatures, and load certificates to a keyring.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Use the following workflows to set up certificates for Zowe in your environment:

--- a/versioned_docs/version-v2.13.x/user-guide/configure-certificates.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configure-certificates.md
@@ -2,7 +2,7 @@
 
 Review this article to learn about the key concepts of Zowe certificates, and options for certificate configuration. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. Communication in Zowe can be between Zowe servers, from Zowe to another server, or even between Zowe's servers and Zowe's client components.

--- a/versioned_docs/version-v2.13.x/user-guide/configure-uss.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configure-uss.md
@@ -2,7 +2,7 @@
 
 The Zowe z/OS component runtime requires UNIX System Services (USS) to be configured. As shown in the [Zowe architecture](../getting-started/zowe-architecture.md), a number of servers run under UNIX System Services (USS) on z/OS. Review this topic for knowledge and considerations about USS when you install and configure Zowe.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 ## What is USS?

--- a/versioned_docs/version-v2.13.x/user-guide/configure-xmem-server.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configure-xmem-server.md
@@ -6,7 +6,7 @@ APF-authorized program. The same cross memory server can be used by multiple Zow
 :::info Required roles: system programmer, security administrator
 :::
 
-:::tip**Important**
+:::tip Important
 This article describes how to configure the cross server manually. However, most of this configuration should already be performed during [Zowe configuration](./configuring-overview). 
 If you have already successfully run the `zwe init` command, the load modules are already installed, and APF authorization and SAF configuration is complete.
 
@@ -159,7 +159,7 @@ Do not install the Zowe auxiliary address space unless a Zowe extension product'
 
 A default installation of Zowe does not require auxiliary address spaces to be configured.
 
-:::info**Important**
+:::info Important
 The cross memory `ZWESISTC` task starts and stops the `ZWESASTC` task as needed. **Do not start the `ZWESASTC` task manually.**
 :::
 

--- a/versioned_docs/version-v2.13.x/user-guide/configure-xmem-server.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configure-xmem-server.md
@@ -3,7 +3,7 @@
 The Zowe cross memory server (ZIS) provides privileged cross-memory services to the Zowe Desktop and runs as an
 APF-authorized program. The same cross memory server can be used by multiple Zowe desktops. The cross memory server is required to log on to the Zowe desktop and operate the desktop apps such as the Code Editor. If you wish to start Zowe without the desktop (for example bring up just the API Mediation Layer), you do not need to install and configure a cross memory server and can skip this step. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 :::tip**Important**

--- a/versioned_docs/version-v2.13.x/user-guide/configure-zos-system.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configure-zos-system.md
@@ -2,7 +2,7 @@
 
 As a security administrator it is necessary to  configure the z/OS system for Zowe. Review the following article to learn about z/OS prerequisites, and z/OS configuration requirements for specific settings.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 ## z/OS prerequisites
@@ -123,7 +123,7 @@ Define or check the following configurations depending on whether ICSF is alread
         (repeat for user-acids IKED, NSSD, and Policy Agent)
 
 
-:::note**Notes:**
+:::note Notes:
 - Determine whether you want SAF authorization checks against `CSFSERV` and set `CSF.CSFSERV.AUTH.CSFRNG.DISABLE` accordingly.
 - Refer to the [z/OS 2.3.0 z/OS Cryptographic Services ICSF System Programmer's Guide: Installation, initialization, and customization](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.csfb200/iandi.htm).
 - CCA and/or PKCS #11 coprocessor for random number generation.
@@ -481,7 +481,7 @@ To do this, issue the following commands that are also included in the `ZWESECUR
     TSS PERMIT(ZWESVUSR) IBMFAC(ZWES.IS) ACCESS(READ)
     ```
 
-:::note**Notes:**
+:::note Notes:
 - The cross memory server treats "no decision" style SAF return codes as failures. If there is no covering profile for the `ZWES.IS` resource in the FACILITY class, the request will be denied.
 - Cross memory server clients other than Zowe might have additional SAF security requirements. For more information, see the documentation for the specific client.
 :::

--- a/versioned_docs/version-v2.13.x/user-guide/configure-zowe-runtime.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configure-zowe-runtime.md
@@ -2,7 +2,7 @@
 
 Begin configuration of your installation of Zowe z/OS components by initializing Zowe z/OS runtime.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 Use one of the following options to initialize Zowe z/OS runtime:

--- a/versioned_docs/version-v2.13.x/user-guide/configure-zowe-zosmf-workflow.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configure-zowe-zosmf-workflow.md
@@ -2,7 +2,7 @@
 
 After you install Zowe, you can register and execute the z/OSMF workflows in the web interface to perform a range of Zowe configuration tasks. z/OSMF helps to simplify the Zowe configuration tasks and does not require the level of expertise that is needed to perform manual Zowe configuration. This configuration method also runs the `zwe init` command to initialize Zowe z/OS runtime.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 Ensure that you meet the following requirements before you start your Zowe configuration:

--- a/versioned_docs/version-v2.13.x/user-guide/configuring-overview.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configuring-overview.md
@@ -2,7 +2,7 @@
 
 Review this article for an overview of the procedures that must be performed to configure Zowe z/OS components and the z/OS system. More details about the individual procedures are provided in the articles in this section. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Configuring Zowe z/OS components consists of the following four main steps:

--- a/versioned_docs/version-v2.13.x/user-guide/configuring-security.md
+++ b/versioned_docs/version-v2.13.x/user-guide/configuring-security.md
@@ -2,7 +2,7 @@
 
 During the initial installation of Zowe server-side components, it is necessary for your organization's security administrator to perform a range of tasks that require elevated security permissions. As a security administrator, follow the procedures outlined in this article to configure Zowe and your z/OS system to run Zowe with z/OS.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 ## Validate and re-run `zwe init` commands

--- a/versioned_docs/version-v2.13.x/user-guide/generate-certificates.md
+++ b/versioned_docs/version-v2.13.x/user-guide/generate-certificates.md
@@ -209,7 +209,7 @@ zowe:
         - 12.34.56.78
 ```
 
-:::note**Notes:**
+:::note Notes:
 - Alias names should be all lower cases.
 - The name and lables shown above are the default value in `zowe.yaml`.
 - `dname` for distinguished name is all optional.

--- a/versioned_docs/version-v2.13.x/user-guide/generate-certificates.md
+++ b/versioned_docs/version-v2.13.x/user-guide/generate-certificates.md
@@ -3,7 +3,7 @@
 
 If you do not have a certificate, follow the procedure in this article that corresponds to the certificate type you choose to generate.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Choose from the following certificate types:

--- a/versioned_docs/version-v2.13.x/user-guide/import-certificates.md
+++ b/versioned_docs/version-v2.13.x/user-guide/import-certificates.md
@@ -2,7 +2,7 @@
 
 One option to use certificates in Zowe is to import and configure existing certificates. Use the procedure that applies to the type of certificate you wish to import.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Choose from the following certificate importing options:

--- a/versioned_docs/version-v2.13.x/user-guide/initialize-mvs-datasets.md
+++ b/versioned_docs/version-v2.13.x/user-guide/initialize-mvs-datasets.md
@@ -3,7 +3,7 @@
 
 Review this article to learn about how to intialize Zowe custom MVS data sets by using the `zwe init mvs` command. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Introduction

--- a/versioned_docs/version-v2.13.x/user-guide/initialize-security-configuration.md
+++ b/versioned_docs/version-v2.13.x/user-guide/initialize-security-configuration.md
@@ -58,7 +58,7 @@ The JCL allows you to vary which security manager you use by setting the _PRODUC
 
 If `ZWESECUR` encounters an error or a step that has already been performed, it continues to the end, so it can be run repeatedly in a scenario such as a pipeline automating the configuration of a z/OS environment for Zowe installation.  
 
-:::info**Important**
+:::info Important
 It is expected that your security administrator will be required to review, edit where necessary, and either execute `ZWESECUR` as a single job, or execute individual TSO commands to complete the security configuration of a z/OS system in preparation for installing and running Zowe.
 :::
 

--- a/versioned_docs/version-v2.13.x/user-guide/initialize-security-configuration.md
+++ b/versioned_docs/version-v2.13.x/user-guide/initialize-security-configuration.md
@@ -2,7 +2,7 @@
 
 This security configuration step is required for first time setup of Zowe. If Zowe has already been launched on a z/OS system from a previous release of Zowe v2, and the `zwe init security` subcommand successfully ran when initializing the z/OS subsystem, you can skip this step unless told otherwise in the release documentation.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 
 Consult with your security administrator before you proceed with initializing Zowe security configurations.
 :::

--- a/versioned_docs/version-v2.13.x/user-guide/initialize-zos-system.md
+++ b/versioned_docs/version-v2.13.x/user-guide/initialize-zos-system.md
@@ -2,7 +2,7 @@
 
 Once you complete the installation of the Zowe runtime, begin configuration by initializing Zowe with proper security configurations. To simplify this configuration process, one option is to run the `zwe init` command. This step is common for installing and configuring Zowe from either a convenience build or from an SMP/E build.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 ## About the `zwe init` command

--- a/versioned_docs/version-v2.13.x/user-guide/install-nodejs-zos.md
+++ b/versioned_docs/version-v2.13.x/user-guide/install-nodejs-zos.md
@@ -2,7 +2,7 @@
 
 Before you install Zowe&trade; on z/OS, you must install IBM SDK for Node.js on the same z/OS server that hosts the Zowe Application Server and z/OS Explorer Services. Review the information in this topic to obtain and install Node.js.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 :::note

--- a/versioned_docs/version-v2.13.x/user-guide/install-zowe-smpe.md
+++ b/versioned_docs/version-v2.13.x/user-guide/install-zowe-smpe.md
@@ -5,7 +5,7 @@ Review this article and the procedures to install and activate the functions of 
 :::info Required roles: system programmer
 :::
 
-:::note**Notes:**
+:::note Notes:
 * To install Zowe into its own SMP/E environment, consult the SMP/E manuals for instructions on creating and initializing the SMPCSI and SMP/E control data sets.
 * You can use the sample jobs that are provided to perform part or all of the installation tasks. The SMP/E jobs assume that all DDDEF entries that are required for SMP/E execution have been defined in appropriate zones.
 * You can use the SMP/E dialogs instead of the sample jobs to accomplish the SMP/E installation steps.
@@ -135,7 +135,7 @@ You will receive a return code of `0` if this job runs correctly.
 
 Upload the `AZWE002.readme.txt` file in text format and the `AZWE002.pax.Z` file in binary format from your workstation to the z/OS UNIX file system. The instructions in this section are also in the `AZWE002.readme.txt` file that you downloaded.
 
-:::info**Important**
+:::info Important
 Ensure you download the pax file in a different file system than where you put Zowe runtime. 
 :::
 
@@ -153,7 +153,7 @@ tsopw | Your TSO password
 d: | Location of the downloaded files
 @zfs_path@ | z/OS UNIX path where to store the files. This matches the @zfs_path@ variable you specified in the previous step.
 
-:::danger**Important** 
+:::danger Important 
 The `AZWE002.pax.Z` file must be uploaded to the z/OS driving system in binary format. Not using binary format causes the subsequent UNPAX step to fail.
 :::
 
@@ -569,7 +569,7 @@ GROUPEXTEND
 BYPASS(HOLDCLASS(HIPER)) .
 ..any other parameters documented in the program directory
 ```
-:::note**Notes:**  
+:::note Notes:  
 * This method is quicker, but requires subsequent review of the Exception SYSMOD report produced by the REPORT ERRSYSMODS command to investigate any unresolved HIPERs. If you have received the latest HOLDDATA, you can also choose to use the REPORT MISSINGFIX command and specify Fix Category IBM.PRODUCTINSTALL-REQUIREDSERVICE to investigate missing recommended service.
 * If you bypass HOLDs during the installation of the FMIDs because fixing PTFs are not yet available, you can be notified when the fixing PTFs are available by using the APAR Status Tracking (AST) function of the ServiceLink or the APAR Tracking function of Resource Link.
 :::

--- a/versioned_docs/version-v2.13.x/user-guide/install-zowe-smpe.md
+++ b/versioned_docs/version-v2.13.x/user-guide/install-zowe-smpe.md
@@ -2,7 +2,7 @@
 
 Review this article and the procedures to install and activate the functions of Zowe server-side components using SMP/E.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 :::note**Notes:**

--- a/versioned_docs/version-v2.13.x/user-guide/installandconfig.md
+++ b/versioned_docs/version-v2.13.x/user-guide/installandconfig.md
@@ -2,7 +2,7 @@
 
 Review this overview article to familiarize yourself with key concepts used in the Zowe server-side installation process. After reviewing these key concepts, review the articles in this section to prepare your system for installation. 
 
-:::info**Required roles:** system programmer, security administrator, storage administrator
+:::info Required roles: system programmer, security administrator, storage administrator
 :::
 
 To prepare for Zowe server-side installation, we recommend that your installation team review the installation and configuration tasks and the indicated required roles to perform specific procedures. Doing so can help you complete the process without encountering delays waiting for tasks to be completed at the last minute.

--- a/versioned_docs/version-v2.13.x/user-guide/installandconfig.md
+++ b/versioned_docs/version-v2.13.x/user-guide/installandconfig.md
@@ -120,7 +120,7 @@ Configures the system to launch the Zowe started task.
 
 In combination, these commands initialize Zowe, manage Zowe instances, and perform common tasks.
 
-:::tip**Tips:**
+:::tip Tips:
 * The `zwe` command has built in help that can be retrieved with the `-h` suffix. Use `zwe -h` to see all supported `zwe` commands.
 
   For more information about `zwe` see [zwe](../appendix/zwe_server_command_reference/zwe/zwe) in the appendix.
@@ -147,7 +147,7 @@ Zowe has the following started tasks:
    - **`ZWESLSTC`**  
    This started task brings up other features of the Zowe runtime on z/OS upon request. Features may include Desktop, API Mediation Layer, ZSS, and more. When using containerization, it is likely that the only feature will be ZSS. This task can be used for a single Zowe instance deployment, and can also be used for Zowe high availability deployment in Sysplex. This task brings up and stops Zowe instances, or specific Zowe components without restarting the entire Zowe instances.
    
-:::info**Important!**
+:::info Important
 * In order for the above started tasks to run correctly, the security administrator permissions are required. For more information, see [Configuring the z/OS system for Zowe](configure-zos-system.md).
 * Note that the sample JCL member `ZWESECUR` is shipped with Zowe and contains commands for RACF, TopSecret, and ACF2 security managers.
 :::
@@ -195,7 +195,7 @@ To create this configuration, you can copy from `example-zowe.yaml` located in Z
 To learn more about this Zowe configuration file, see the [Zowe YAML configuration file reference](../appendix/zowe-yaml-configuration.md).
 
 
-:::tip**zowe.yaml configuration tips:**  
+:::tip zowe.yaml configuration tips:  
 
 When you execute the `zwe` command, the `--config` or `-c` argument is used to pass the location of a `zowe.yaml` file.
 

--- a/versioned_docs/version-v2.13.x/user-guide/k8s-introduction.md
+++ b/versioned_docs/version-v2.13.x/user-guide/k8s-introduction.md
@@ -2,7 +2,7 @@
 
 You can download Zowe (server) containers as an alternative to running Zowe servers on z/OS through the Zowe convenience and SMP/E builds. Choose the appropriate installation type for your use case.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 Using containers for installation has the following advantages:

--- a/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zos.md
@@ -5,7 +5,7 @@ keywords: [security permissions, system permissions, monacat]
 
 Before installing Zowe&trade; z/OS components, ensure that your z/OS environment meets the prerequisites. The prerequisites you need to install depend on what Zowe z/OS components you want to use and how you want to install and configure Zowe on z/OS. Assess your installation scenario and install the prerequisites that meet your needs. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 All Zowe server components can be installed on a z/OS environment, while some can alternatively be installed on Linux or zLinux via Docker. The components provide a number of services that are accessed through a web browser such as an API catalog and a web desktop.  

--- a/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zos.md
@@ -18,7 +18,7 @@ Be sure your z/OS system meets the following prerequisites:
 
 - z/OS version is in active support, such as Version 2.4, 2.5, and 3.1
 
-  :::note**Notes:**
+  :::note Notes:
   * Zowe Version 2.11 or higher is required when using z/OS Version 3.1.
   * z/OS V2.3 reached end of support on 30 September, 2022. For more information, see the [z/OS v2.3 lifecycle details](https://www.ibm.com/support/pages/zos23x-withdrawal-notification).
   :::
@@ -57,7 +57,7 @@ Be sure your z/OS system meets the following prerequisites:
 
   - REST API services for Files (Data Sets and USS), JES, and z/OSMF workflows.  These are used by some Zowe applications such as the Zowe Explorers in the Zowe Desktop. If z/OSMF REST APIs are not present, other Zowe desktop application, such as the File Editor that provides access to USS directories and files as well as MVS data sets and members, will work through the Zowe Z Secure Services (ZSS) component to access z/OS resources.   
 
-  :::info**Recommendations**
+  :::info Recommendations
   - For production use of Zowe, we recommend configuring z/OSMF to leverage Zowe functionalities that require z/OSMF. For more information, see [Configuring z/OSMF](systemrequirements-zosmf.md).
   - For non-production use of Zowe (such as development, proof-of-concept, demo), you can customize the configuration of z/OSMF to create **_z/OS MF Lite_** to simplify your setup of z/OSMF. z/OS MF Lite only supports selected REST services (JES, DataSet/File, TSO and Workflow), resulting in considerable improvements in startup time as well as a reduction in steps to set up z/OSMF. For information about how to set up z/OSMF Lite, see [Configuring z/OSMF Lite (non-production environment)](systemrequirements-zosmf-lite.md).
   :::

--- a/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zosmf.md
+++ b/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zosmf.md
@@ -106,7 +106,7 @@ The Zowe CLI uses z/OSMF Representational State Transfer (REST) APIs to work wit
 
   To verify that z/OSMF REST services are configured correctly in your environment, enter the REST endpoint into your browser. For example: `https://mvs.ibm.com:443/zosmf/restjobs/jobs`
 
-  :::note**Notes**
+  :::note Notes
 
   - Browsing z/OSMF endpoints requests your user ID and password for defaultRealm; these are your TSO user credentials.
   - The browser returns the status code 200 and a list of all jobs on the z/OS system. The list is in raw JSON format.

--- a/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zosmf.md
+++ b/versioned_docs/version-v2.13.x/user-guide/systemrequirements-zosmf.md
@@ -10,7 +10,7 @@ meta:
 
 Follow these steps described in this article to configure z/OSMF.
 
-:::info**Required roles:** system programmer, security administrator, domain administrator
+:::info Required roles: system programmer, security administrator, domain administrator
 :::
 
 1. From the console, issue the following command to verify the version of z/OS:

--- a/versioned_docs/version-v2.13.x/user-guide/use-certificates.md
+++ b/versioned_docs/version-v2.13.x/user-guide/use-certificates.md
@@ -2,7 +2,7 @@
 
 Once you have generated or imported your certificates, you can now use the certificates with Zowe. Use the procedure descibed in this article that corresponds to the type of certificates you generated or imported.
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 Choose from the following procedures:
 

--- a/versioned_docs/version-v2.13.x/user-guide/zowe-ha-overview.md
+++ b/versioned_docs/version-v2.13.x/user-guide/zowe-ha-overview.md
@@ -3,7 +3,7 @@
 Zowe has a high availability feature built-in.
 For Zowe in a high availability configuration, one workspace directory is required. This workspace directory must be created on a shared file system (zFS directory) which all LPARs in a Sysplex can access. Review this article and the following articles in this section for the configuration steps to enable the high availability feature. Note that configuring high availability is optional.
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 ## Enable high availability when Zowe runs in Sysplex

--- a/versioned_docs/version-v2.13.x/user-guide/zwe-init-subcommand-overview.md
+++ b/versioned_docs/version-v2.13.x/user-guide/zwe-init-subcommand-overview.md
@@ -17,7 +17,7 @@ Some of the following `zwe init` subcommands require elevated permissions. See t
 
 Use the `zwe init mvs` command to intialize Zowe custom MVS data sets. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 During the installation of Zowe, the following three data sets are created and populated with members copied across from the Zowe installation files:
@@ -102,7 +102,7 @@ Successful execution of `zwe init mvs` has the following results:
 
 This subcommand creates the user IDs and security manager settings.
 
-:::info**Required role:** security administrator
+:::info Required role: security administrator
 :::
 
 If Zowe has already been launched on a z/OS system from a previous release of Zowe v2, you can skip this security configuration step unless told otherwise in the release documentation.
@@ -158,7 +158,7 @@ Installation of Zowe main started tasks requires that JCL members for each of Zo
 
 Once you have completed security configuration, you can install the Zowe main started tasks. 
 
-:::info**Required role:** system programmer
+:::info Required role: system programmer
 :::
 
 The JCL members for each of Zowe's started tasks need to be present on the JES proclib concatenation path. The command `zwe init stc` copies these members from the install source location `.SZWESAMP` to the targted PDS specified in the `zowe.setup.dataset.proclib` value `USER.PROCLIB`. The three proclib member names are specified in `zowe.yaml` arguments.  

--- a/versioned_docs/version-v2.13.x/user-guide/zwe-init-subcommand-overview.md
+++ b/versioned_docs/version-v2.13.x/user-guide/zwe-init-subcommand-overview.md
@@ -116,7 +116,7 @@ For more information about `zwe init security`, see [Initializing Zowe security 
 
 Zowe contains load modules that require access to make privileged z/OS security manager calls. These load modules are held in two load libraries which must be APF authorized. 
 
-:::info**Required roles:** security administrator
+:::info Required roles: security administrator
 :::
 
 The command `zwe init apfauth` reads the PDS names for the following load libraries from zowe.yaml and performs the APF authority commands.
@@ -132,7 +132,7 @@ For more information about `zwe init apfauth` see [Performing APF authorization 
 
 Zowe uses digital certificates for secure, encrypted network communication over Secure Sockets Layer/Transport Layer Security (SSL/TLS) and HTTPS protocols. 
 
-:::info**Required roles:** system programmer, security administrator
+:::info Required roles: system programmer, security administrator
 :::
 
 Zowe supports using either file-based (PKCS12) or z/OS key ring-based (when on z/OS) keystores and truststores, and can reuse compatible stores. You can use the `zwe init certificate` command to create keystores and truststores by either generating certificates or by allowing users to import their own compatible certificates.
@@ -143,7 +143,7 @@ For more information, see [Configuring certificates](./configure-certificates).
 
 Zowe can work in a high availability (HA) configuration where multiple instances of the Zowe launcher are started, either on the same LPAR or different LPARs connected through sysplex distributor. If you are only running a single Zowe instance on a single LPAR you do not need to create a caching service so you may skip this step.
 
-:::info**Required roles:** system programmer
+:::info Required roles: system programmer
 :::
 
 The command `zwe init vsam` uses the template JCL in `SZWESAMP(ZWECSVSM)` to copy the source template member from `zowe.setup.mvs.hlq.SZWESAMP(ZWECVCSM)` and creates a target JCL member in `zowe.setup.mvs.jcllib(ZWECVSCM)` with values extracted from the `zowe.yaml` file.


### PR DESCRIPTION
Describe your pull request here: Fixed bad syntax used on **Required Roles** admonitions

List the file(s) included in this PR: zowe-ha-overview.md + many more

After creating the PR, follow the instructions in the comments.
