### PR TITLE
removing V1 EOS site banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -29,12 +29,6 @@ module.exports = {
     }),
   },
   themeConfig: {
-    announcementBar: {
-      id: 'announcementBar-1', // increment on change
-      content:
-          '📌 <b>Support for Zowe Version 1 ends on Sept. 30, 2024</b>. Follow <a href="https://docs.zowe.org/stable/extend/migrate-extensions/" target="_blank">this guide</a> to migrate to Zowe Version 2.',
-      textColor: '#000',
-    },
     docs: {
       sidebar: {
         hideable: true

--- a/release-handbook/creating_site_banner.md
+++ b/release-handbook/creating_site_banner.md
@@ -27,7 +27,7 @@ Depending on the changes you make, you also might need to edit the `custom.css` 
 
 1. In the `docs-site` repository, find the `docusaurus.config.js` file and open it.
 
-2. After `themeConfig: {:` (in Line 26), add the following code:
+2. After `themeConfig: {:` (in Line 31), add the following code:
 
     ```
     announcementBar: {


### PR DESCRIPTION
Describe your pull request here: Removing the Zowe Docs site banner re: V1 EOS. Updating banner instructions in Release handbook.

List the file(s) included in this PR: creating_site_banner.md

After creating the PR, follow the instructions in the comments.
