### PR TITLE
Remove swap space in "Build docs site" workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,10 +16,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 6
+      # - name: Set Swap Space
+      #   uses: pierotofy/set-swap-space@master
+      #   with:
+      #     swap-size-gb: 6
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Describe your pull request here: Previously our Docusaurus builds were running out of memory, but now they are running out of disk space. Since GitHub Actions increased the amount of memory available for `ubuntu-latest` runners, we shouldn't need to allocate swap space anymore 😋 

List the file(s) included in this PR: builds-docs.yml workflow

After creating the PR, follow the instructions in the comments.
