### PR TITLE
Update CLI plug-in docs around creating user profiles

### DIFF
--- a/docs/user-guide/cli-ftpplugin.md
+++ b/docs/user-guide/cli-ftpplugin.md
@@ -39,45 +39,26 @@ Use one of the following methods to install or update the plug-in:
 
 ## Creating a user profile
 
-You create a zftp profile to avoid entering your connection details each time that you issue a command. You can create multiple profiles and switch between them as needed. Use one of the following methods to create a profile:
+After you install the plug-in, create an FTP profile. An FTP profile is recommended to issue commands to via FTP. FTP profiles contain your host, port, user name, and password for connect to z/OS using FTP. You can create multiple profiles and switch between them as needed.
 
-- **Create plug-in profiles using a configuration file:** Specify your profile and connection details in the `zowe.config.json` configuration file.
+**Follow these steps:**
+1.  Install the z/OS FTP Plug-in for Zowe CLI
+2.  Create an FTP profile:
 
-- **Create plug-in profiles using a command:** Issue the `zowe profiles create` command to create the profile.
-
-We recommend that you create profiles using the configuration file. We do not recommend using profile commands because we are removing them in a future major release.
-
-### Creating plug-in profiles using a configuration file
-
-When you issue various `zowe config` commands, such as `init`, `auto-init`, and `convert-profiles`, they create a `zowe.config.json` configuration file. When you install the z/OS FTP plug-in, the commands create an entry for a `zftp profile` in your `zowe.config.json` file.
-
-Alternatively, you can create a zftp profile manually by adding a section that contains the configuration details to your `zowe.config.json` configuration file.
-
-1. Browse to the following directory: `C:\Users\<username>\.zowe`
-
-2. Open the `zowe.config.json` configuration file using a text editor or IDE, such as Visual Studio Code or IntelliJ.
-
-  NOTE: If the file does not exist, issue the following command to create the configuration file: `zowe config init --gc`
-
-3. Add code to the "profiles" section as shown in the following example: 
-  
     ```
-    "Your_zftp_profile": {
-       "type": "zftp",
-        "properties": {
-            "host": "Your_host_name",
-            "port": Your_port_number,
-            "secureFtp": true
-        },
-        "secure": [
-            "user",
-            "password"
-        ]
-    }
+    zowe config init
     ```
-    **Note:** The value of the “`secureftp`" option is defined as true by default. We recommend that you specify this value when FTPS (FTP over SSL) is enabled in the z/OS FTP service. FTPS is not equivalent to SFTP (FTP over SSH). SFTP is not currently supported.
+3.  If using a non-standard port, set the port number to your FTP connection:
 
-4. Save the file
+    ```
+    zowe config set profiles.zftp.properties.port <port number>
+    ```
+4. If using a insecure connection, set the secureFtp value to false:
+
+    ```
+    zowe config set profiles.zftp.properties.secureFtp false
+    ```
+
 
 You can now use your profile when you issue commands in the zftp command group.
 
@@ -90,27 +71,27 @@ The following steps describe how to create a profile using the `zowe profiles cr
     zowe profiles create zftp  <profile_name> --host <host> --port <port> --user <user> --password <password>
     ```
 
-    **`profile_name`:** 
-  
+    **`profile_name`:**
+
     Specifies a name for your profile.
-  
-    **`host`:** 
-  
+
+    **`host`:**
+
     Specifies the host name for the instance.
-  
-    **`user`:** 
-  
+
+    **`user`:**
+
     Specifies your user name to log in to the instance.
-  
-    **`password`:** 
-  
+
+    **`password`:**
+
     Specifies your password to log in to the instance.
-  
-    **`port`:** 
-  
+
+    **`port`:**
+
     Specifies the port number to connect to the instance.
 
-    **Example:** 
+    **Example:**
     ```
     zowe profiles create zftp-profile LPAR1 --host ftp.zowe.org --port 21 --user zowe --password zowepass --secure-ftp
     ```
@@ -133,5 +114,5 @@ For example, you can use one of the following methods to download a data set:
   ```
 - Download a data set without using a default profile:
   ```
-  zowe zftp download data-set USERHLQ.DATASET.NAME --host <hostname> --port 21 --user <User_ID> --password <password> --secure-ftp false 
+  zowe zftp download data-set USERHLQ.DATASET.NAME --host <hostname> --port 21 --user <User_ID> --password <password> --secure-ftp false
   ```

--- a/docs/user-guide/cli-ftpplugin.md
+++ b/docs/user-guide/cli-ftpplugin.md
@@ -1,19 +1,19 @@
 # IBM® z/OS FTP Plug-in for Zowe CLI
 
-The IBM® z/OS FTP Plug-in for Zowe&trade; CLI lets you extend Zowe CLI to access z/OS datasets, USS files, and submit JCL. The plug-in uses the z/OS FTP service to achieve the interaction with z/OS.
+The IBM® z/OS FTP Plug-in for Zowe&trade; CLI lets you extend Zowe CLI to access z/OS data sets, USS files, and submit JCL. The plug-in uses the z/OS FTP service to achieve the interaction with z/OS.
 
 ## Use cases
 
 As a z/OS user, you can use the plug-in to perform the following tasks:
 
-  - List, view, rename, and download z/OS datasets or USS files.
-  - Upload local files or `stdin` to z/OS datasets or USS files.
+  - List, view, rename, and download z/OS data sets or USS files.
+  - Upload local files or `stdin` to z/OS data sets or USS files.
   - List, view, and download job status or job spool files.
-  - Delete a z/OS dataset, USS file, or job.
+  - Delete a z/OS data set, USS file, or job.
 
 ## Commands
 
-:::
+:::note
 
 When transferring files, data sets, or data set members, use only ASCII characters. If a file contains non-ASCII characters (such as glyphs or mathematical symbols), a translation error can happen when the file is downloaded from, or uploaded to, the mainframe. This error can result in data loss.
 
@@ -39,7 +39,7 @@ Use one of the following methods to install or update the plug-in:
 
 ## Creating a user profile
 
-After you install the plug-in, create an FTP profile. An FTP profile is recommended to issue commands to via FTP. FTP profiles contain your host, port, user name, and password for connect to z/OS using FTP. You can create multiple profiles and switch between them as needed.
+After you install the plug-in, create an FTP profile. An FTP profile is recommended to issue commands via FTP. FTP profiles contain your host, port, user name, and password to connect to z/OS using FTP. You can create multiple profiles and switch between them as needed.
 
 **Follow these steps:**
 1.  Install the z/OS FTP Plug-in for Zowe CLI
@@ -104,7 +104,7 @@ You can now use your profile when you issue commands in the zftp command group.
 
 ### Issuing test commands
 
-After installing the plugin successfully, you can issue commands to test basic Zowe CLI functionality.
+After installing the plug-in successfully, you can issue commands to test basic Zowe CLI functionality.
 
 For example, you can use one of the following methods to download a data set:
 

--- a/docs/user-guide/cli-mqplugin.md
+++ b/docs/user-guide/cli-mqplugin.md
@@ -30,83 +30,19 @@ Use one of the following methods to install or update the plug-in:
 
 ## Creating a user profile
 
-You create an mq profile to avoid entering your connection details each time that you issue a command. You can create multiple profiles and switch between them as needed. Use one of the following methods to create a profile:
+After you install the plug-in, create an MQ profile. An MQ profile is recommended to issue commands to the MQ resource. MQ profiles contain your host, port, user name, and password for the IBM MQ REST API server of your choice. You can create multiple profiles and switch between them as needed.
 
-- **Create plug-in profiles using a configuration file:** Specify your profile and connection details in the `zowe.config.json` configuration file.
-
-- **Create plug-in profiles using a command:** Issue the `zowe profiles create` command to create the profile.
-
-We recommend that you create profiles using the configuration file. We do not recommend using profile commands because we are removing them in a future major release.
-
-
-### Creating plug-in profiles using a configuration file
-
-When you issue various zowe config commands, such as `init`, `auto-init`, and `convert-profiles`, they create a `zowe.config.json` configuration file. When you install the MQ plug-in, the commands create an entry for an `mq profile` in your `zowe.config.json` file.
-
-Alternatively, you can create a mq profile manually by adding a section that contains the configuration details to your `zowe.config.json`ok configuration file.
-
-1. Browse to the following directory `C:\Users\<username>\.zowe`
-
-2. Open the `zowe.config.json` configuration file using a text editor or IDE, such as Visual Studio Code or IntelliJ. 
-
-    **NOTE:** If the file does not exist, issue the following command to create the configuration file: `zowe config init --gc`
-
-3. Add code to the "profiles" section as shown in the following example: 
-
-    **Example:**
-    ```
-    "Your_mq_profile": {
-        "type": "mq",
-        "properties": {
-            "host": "Your_host_name",
-            "port": Your_port_number
-        },
-        "secure": [
-            "user",
-            "password"
-        ]
-    }
-    ```
-4. Save the file
-
-You can now use your profile when you issue commands in the mq command group.
-
-### Creating plug-in profiles using a command
-
-The following steps describe how to create a profile using the `zowe profiles create` command.
-
-1. Open a terminal window and issue the following command:
+**Follow these steps:**
+1.  Install the IBM MQ Plug-in for Zowe CLI.
+2.  Create an MQ profile:
 
     ```
-    zowe profiles create mq  <profile_name> --host <host> --port <port> --user <user> --password <password>
+    zowe config init
     ```
-
-    **`profile_name`:**
-
-    Specifies a name for your profile.
-
-    **`host`:**
-
-    Specifies the host name for the instance.
-
-    **`user`:**
-
-    Specifies your user name to log in to the instance.
-
-    **`password`:**
-
-    Specifies your password to log in to the instance.
-
-    **`port`:**
-
-    Specifies the port number to connect to the instance.
-
-    **Example:**
+3.  Set the port number to your MQ port:
 
     ```
-    zowe profiles create mq-profile queue1 --host mq.zowe.org --port 1443 --user zowe --password zowepass
+    zowe config set profiles.mq.properties.port <port number>
     ```
-
-2. Press Enter. The result of the command displays as a success or failure message.
 
 You can now use your profile when you issue commands in the mq command group.


### PR DESCRIPTION
Describe your pull request here: Removed the V1 `zowe profiles` commands when creating profiles for the MQ and FTP plug-ins

List the file(s) included in this PR:  `docs/user-guide/cli-ftpplugin.md` and `docs/user-guide/cli-mqplugin.md`

After creating the PR, follow the instructions in the comments.
