### PR TITLE
Remove link to deprecated content in change password via catalog

### DIFF
--- a/docs/user-guide/api-mediation-change-password-via-catalog.md
+++ b/docs/user-guide/api-mediation-change-password-via-catalog.md
@@ -15,4 +15,4 @@ After you repeat the new password, you are able to request the change again. The
 
 Once you successfully change the password, you are informed with a green pop-up message indicating `Your mainframe password was successfully changed`. You can now use the new password for authentication.
 
-For more information about the password change REST API available on the API Gateway service, see [API Gateway REST APIs](../user-guide/api-mediation/api-gateway-rest-apis-documentation.md).
+


### PR DESCRIPTION
Describe your pull request here: Remove link to API Gateway features which have been deprecated after reorg

List the file(s) included in this PR:  api-mediation-change-password-via-catalog.md

After creating the PR, follow the instructions in the comments. 
