### PR TITLE
Add explanation for Websocket timeouts.

### DIFF
--- a/docs/user-guide/api-mediation/configuration-connection-limits.md
+++ b/docs/user-guide/api-mediation/configuration-connection-limits.md
@@ -21,13 +21,12 @@ The API Mediation Layer supports Websocket connections. It's possible to configu
 zowe:
   components:
     gateway:
-      apiml:
-        server:
-          websocket:
-            connectTimeout: 15000
-            stopTimeout: 30000
-            asyncWriteTimeout: 60000
-            maxIdleTimeout:3600000
+      server:
+        websocket:
+          connectTimeout: 15000
+          stopTimeout: 30000
+          asyncWriteTimeout: 60000
+          maxIdleTimeout:3600000
 ```
 
 Use the following procedure to change the limits:
@@ -35,5 +34,5 @@ Use the following procedure to change the limits:
 1. Open the file `zowe.yaml`.
 2. Find or add the property `zowe.components.gateway.server.websocket.connectTimeout` and set the value to an appropriate positive integer. This timeout limits how long the API Gateway waits until it drops connection if it can't reach the target server. Default is 15 seconds.
 3. Find or add the property `zowe.components.gateway.server.websocket.stopTimeout` and set the value to an appropriate positive integer. This timeout handles how long the API Gateway waits before it fails on stop message for the Websocket connection. Default is 30 seconds.
-4. Find or add the property `zowe.components.gateway.apiml.websocket.asyncWriteTimeout` and set the value to an appropriate positive integer. This timeout handles how long it takes before the server fails with unsuccessful response when trying to write message to the Websocket connection. Default is 60 seconds.
-5. Find or add the property `zowe.components.gateway.apiml.websocket.maxIdleTimeout` and set the value to an appropriate positive integer. This timeout handles how long the Websocket connection remains open if there is no communication happening over the open connection. Default is one hour.
+4. Find or add the property `zowe.components.gateway.server.websocket.asyncWriteTimeout` and set the value to an appropriate positive integer. This timeout handles how long it takes before the server fails with unsuccessful response when trying to write message to the Websocket connection. Default is 60 seconds.
+5. Find or add the property `zowe.components.gateway.server.websocket.maxIdleTimeout` and set the value to an appropriate positive integer. This timeout handles how long the Websocket connection remains open if there is no communication happening over the open connection. Default is one hour.

--- a/docs/user-guide/api-mediation/configuration-connection-limits.md
+++ b/docs/user-guide/api-mediation/configuration-connection-limits.md
@@ -3,10 +3,37 @@
 :::info Role: system programmer
 :::
 
+## TCP/IP Connection Limits
+
 By default, the API Gateway accepts up to 100 concurrent connections per route, and 1000 total concurrent connections. Any further concurrent requests are queued until the completion of an existing request. The API Gateway is built on top of Apache HTTP components that require these two connection limits for concurrent requests. 
 
 Use the following procedure to change the number of concurrent connections.
 
 1. Open the file `zowe.yaml`.
-2. Find or add the property `components.gateway.server.maxConnectionsPerRoute` and set the value to an appropriate positive integer.
-3. Find or add the property `components.gateway.server.maxTotalConnections` and set the value to an appropriate positive integer.
+2. Find or add the property `zowe.components.gateway.server.maxConnectionsPerRoute` and set the value to an appropriate positive integer.
+3. Find or add the property `zowe.components.gateway.server.maxTotalConnections` and set the value to an appropriate positive integer.
+
+## Websocket Limits
+
+The API Mediation Layer supports Websocket connections. It's possible to configure the limits around timeouts, all the values are in miliseconds. This may be relevant if you see problems for example around the usage of TN32790 terminal in Virtual Desktop. 
+
+```
+zowe:
+  components:
+    gateway:
+      apiml:
+        server:
+          websocket:
+            connectTimeout: 15000
+            stopTimeout: 30000
+            asyncWriteTimeout: 60000
+            maxIdleTimeout:3600000
+```
+
+Use the following procedure to change the limits:
+
+1. Open the file `zowe.yaml`.
+2. Find or add the property `zowe.components.gateway.apiml.server.websocket.connectTimeout` and set the value to an appropriate positive integer. This timeout limits how long the API Gateway waits untill it drops connection if it can't reach the target server.
+3. Find or add the property `zowe.components.gateway.apiml.server.websocket.` and set the value to an appropriate positive integer. This timeout handles how long the API Gateway waits before it fails on stop message for teh Websocket connection
+4. Find or add the property `zowe.components.gateway.apiml.server.websocket.` and set the value to an appropriate positive integer. This timeout handles how long it takes before the server fails with unsuccessful response when trying to write message to the Websocket connection. 
+5. Find or add the property `zowe.components.gateway.apiml.server.websocket.` and set the value to an appropriate positive integer. This timeout handles how long the Websocket connection remains open if there is no communication happening over the open connection. 

--- a/docs/user-guide/api-mediation/configuration-connection-limits.md
+++ b/docs/user-guide/api-mediation/configuration-connection-limits.md
@@ -7,7 +7,7 @@
 
 By default, the API Gateway accepts up to 100 concurrent connections per route, and 1000 total concurrent connections. Any further concurrent requests are queued until the completion of an existing request. The API Gateway is built on top of Apache HTTP components that require these two connection limits for concurrent requests. 
 
-Use the following procedure to change the number of concurrent connections.
+Use the following procedure to change the number of concurrent connections:
 
 1. Open the file `zowe.yaml`.
 2. Find or add the property `zowe.components.gateway.server.maxConnectionsPerRoute` and set the value to an appropriate positive integer.
@@ -15,7 +15,7 @@ Use the following procedure to change the number of concurrent connections.
 
 ## Websocket Limits
 
-The API Mediation Layer supports Websocket connections. It's possible to configure the limits around timeouts, all the values are in miliseconds. This may be relevant if you see problems for example around the usage of TN32790 terminal in Virtual Desktop. 
+The API Mediation Layer supports Websocket connections. It is possible to configure the limits around timeouts. All the values are in milliseconds. Customizing this limit may be practical if you see problems such as with the usage of the TN32790 terminal in Virtual Desktop. 
 
 ```
 zowe:
@@ -32,7 +32,7 @@ zowe:
 Use the following procedure to change the limits:
 
 1. Open the file `zowe.yaml`.
-2. Find or add the property `zowe.components.gateway.server.websocket.connectTimeout` and set the value to an appropriate positive integer. This timeout limits how long the API Gateway waits until it drops connection if it can't reach the target server. Default is 15 seconds.
-3. Find or add the property `zowe.components.gateway.server.websocket.stopTimeout` and set the value to an appropriate positive integer. This timeout handles how long the API Gateway waits before it fails on stop message for the Websocket connection. Default is 30 seconds.
-4. Find or add the property `zowe.components.gateway.server.websocket.asyncWriteTimeout` and set the value to an appropriate positive integer. This timeout handles how long it takes before the server fails with unsuccessful response when trying to write message to the Websocket connection. Default is 60 seconds.
-5. Find or add the property `zowe.components.gateway.server.websocket.maxIdleTimeout` and set the value to an appropriate positive integer. This timeout handles how long the Websocket connection remains open if there is no communication happening over the open connection. Default is one hour.
+2. Find or add the property `zowe.components.gateway.server.websocket.connectTimeout`, and set the value to an appropriate positive integer. This timeout limits how long the API Gateway waits until it drops connection if it cannot reach the target server. The default is 15 seconds.
+3. Find or add the property `zowe.components.gateway.server.websocket.stopTimeout`, and set the value to an appropriate positive integer. This timeout handles how long the API Gateway waits before it fails on stop message for the Websocket connection. The default is 30 seconds.
+4. Find or add the property `zowe.components.gateway.server.websocket.asyncWriteTimeout`, and set the value to an appropriate positive integer. This timeout handles how long it takes before the server fails with unsuccessful response when trying to write message to the Websocket connection. The default is 60 seconds.
+5. Find or add the property `zowe.components.gateway.server.websocket.maxIdleTimeout`, and set the value to an appropriate positive integer. This timeout handles how long the Websocket connection remains open if there is no communication happening over the open connection. The default is one hour.

--- a/docs/user-guide/api-mediation/configuration-connection-limits.md
+++ b/docs/user-guide/api-mediation/configuration-connection-limits.md
@@ -33,7 +33,7 @@ zowe:
 Use the following procedure to change the limits:
 
 1. Open the file `zowe.yaml`.
-2. Find or add the property `zowe.components.gateway.apiml.server.websocket.connectTimeout` and set the value to an appropriate positive integer. This timeout limits how long the API Gateway waits untill it drops connection if it can't reach the target server.
-3. Find or add the property `zowe.components.gateway.apiml.server.websocket.` and set the value to an appropriate positive integer. This timeout handles how long the API Gateway waits before it fails on stop message for teh Websocket connection
-4. Find or add the property `zowe.components.gateway.apiml.server.websocket.` and set the value to an appropriate positive integer. This timeout handles how long it takes before the server fails with unsuccessful response when trying to write message to the Websocket connection. 
-5. Find or add the property `zowe.components.gateway.apiml.server.websocket.` and set the value to an appropriate positive integer. This timeout handles how long the Websocket connection remains open if there is no communication happening over the open connection. 
+2. Find or add the property `zowe.components.gateway.server.websocket.connectTimeout` and set the value to an appropriate positive integer. This timeout limits how long the API Gateway waits until it drops connection if it can't reach the target server. Default is 15 seconds.
+3. Find or add the property `zowe.components.gateway.server.websocket.stopTimeout` and set the value to an appropriate positive integer. This timeout handles how long the API Gateway waits before it fails on stop message for the Websocket connection. Default is 30 seconds.
+4. Find or add the property `zowe.components.gateway.apiml.websocket.asyncWriteTimeout` and set the value to an appropriate positive integer. This timeout handles how long it takes before the server fails with unsuccessful response when trying to write message to the Websocket connection. Default is 60 seconds.
+5. Find or add the property `zowe.components.gateway.apiml.websocket.maxIdleTimeout` and set the value to an appropriate positive integer. This timeout handles how long the Websocket connection remains open if there is no communication happening over the open connection. Default is one hour.


### PR DESCRIPTION
Describe your pull request here:
API Mediation Layer from 2.15 supports changing timeouts for Websocket connections. This is documenting how. 
The documentation is linked to the issue: https://github.com/zowe/api-layer/issues/2603 

List the file(s) included in this PR:
user-guide/api-mediation/configuration-connection-limits

After creating the PR, follow the instructions in the comments.
