### PR TITLE
fixing admonition and typo

### DIFF
--- a/docs/user-guide/configure-xmem-server.md
+++ b/docs/user-guide/configure-xmem-server.md
@@ -125,7 +125,7 @@ For example, the sample JCL below shows `ZWESISTC` where the APF-authorized PDSE
 
 Because the ZIS server makes z/OS security calls it restrits which clients are able to use it services, by requiring them to have `READ` access to a security profile `ZWES.IS` in the `FACILITY` class.  
 
-The Zowe launcher started task `ZWESLSTC` needs to be able to access the ZIS server, which requires that the user ID `ZWESVUSR` has access to `ZWES.IS`.  The steps to do this are desribed in [Configure the cross memory server for SAF](configure-zos-system.md#configure-the-cross-memory-server-for-saf).  
+The Zowe launcher started task `ZWESLSTC` needs to be able to access the ZIS server, which requires that the user ID `ZWESVUSR` has access to `ZWES.IS`.  The steps to do this are described in [Configure the cross memory server for SAF](configure-zos-system.md#configure-the-cross-memory-server-for-saf).  
 
 ## Zowe auxiliary service
 

--- a/docs/user-guide/configure-zos-system.md
+++ b/docs/user-guide/configure-zos-system.md
@@ -123,7 +123,7 @@ Define or check the following configurations depending on whether ICSF is alread
         (repeat for user-acids IKED, NSSD, and Policy Agent)
 
 
-:::note Notes:
+:::note Notes
 - Determine whether you want SAF authorization checks against `CSFSERV` and set `CSF.CSFSERV.AUTH.CSFRNG.DISABLE` accordingly.
 - Refer to the [z/OS 2.3.0 z/OS Cryptographic Services ICSF System Programmer's Guide: Installation, initialization, and customization](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.csfb200/iandi.htm).
 - CCA and/or PKCS #11 coprocessor for random number generation.
@@ -481,7 +481,7 @@ To do this, issue the following commands that are also included in the `ZWESECUR
     TSS PERMIT(ZWESVUSR) IBMFAC(ZWES.IS) ACCESS(READ)
     ```
 
-:::note Notes:
+:::note Notes
 - The cross memory server treats "no decision" style SAF return codes as failures. If there is no covering profile for the `ZWES.IS` resource in the FACILITY class, the request will be denied.
 - Cross memory server clients other than Zowe might have additional SAF security requirements. For more information, see the documentation for the specific client.
 :::
@@ -693,7 +693,7 @@ Multi-factor authentication is provided by third-party products which Zowe is co
 - [CA Advanced Authentication Mainframe](https://techdocs.broadcom.com/us/en/ca-mainframe-software/security/ca-advanced-authentication-mainframe/2-0.html)
 - [IBM Z Multi-Factor Authentication](https://www.ibm.com/products/ibm-multifactor-authentication-for-zos).
 
-:::notes**Notes**
+:::note Notes
 * To support the multi-factor authentication, it is necessary to apply z/OSMF APAR  [PH39582](https://www.ibm.com/support/pages/apar/PH39582). 
 
 * For information on using MFA in Zowe, see [Multi-Factor Authentication](mvd-configuration.md#multi-factor-authentication-configuration).


### PR DESCRIPTION
Describe your pull request here: Fixing bad syntax on an admonition. Resolves [Issue 3521](https://github.com/zowe/docs-site/issues/3521).

List the file(s) included in this PR: configure-zos-system.md

After creating the PR, follow the instructions in the comments.
