### PR TITLE
Fix file type check in PR checker workflow

### DIFF
--- a/.github/workflows/pull-request-checker.yml
+++ b/.github/workflows/pull-request-checker.yml
@@ -132,7 +132,7 @@ jobs:
         uses: docker://agilepathway/pull-request-label-checker:latest
         with:
           prefix_mode: true
-          one_of: "release:"
+          any_of: "release:"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Missing Release Label Comment PR
         if: failure()

--- a/.github/workflows/pull-request-checker.yml
+++ b/.github/workflows/pull-request-checker.yml
@@ -69,10 +69,12 @@ jobs:
             If you have addressed this issue already, refresh this page in your browser to remove this comment.
       - name: File type checker
         id: file_type_checker
+        uses: actions/github-script@v6
         env:
           PR_BODY_PATTERN: '\.md|\.jpg|\.gif|\.png|\.pdf'
-        run: |
-          [[ "${{ github.event.pull_request.body }}" =~ "$PR_BODY_PATTERN" ]] || exit 1
+        with:
+          script: |
+            new RegExp(process.env.PR_BODY_PATTERN).test(context.payload.pull_request.body) || process.exit(1)
       - name: Missing File Name Comment PR
         if: failure() && steps.file_type_checker.outcome == 'failure'
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
Describe your pull request here: Fixes check that enforces list of changed files is present in PR description.

Check failed on this PR: https://github.com/zowe/docs-site/pull/3573

The same PR description is now passing in my fork: https://github.com/t1m0thyj/zowe-docs-site/pull/1

List the file(s) included in this PR: pull-request-checker.yml

After creating the PR, follow the instructions in the comments.
