### PR TITLE
Remove misleading port configuration variable

### DIFF
--- a/docs/user-guide/address-network-requirements.md
+++ b/docs/user-guide/address-network-requirements.md
@@ -10,7 +10,7 @@ For more information about variable names in the following table, see the [Zowe 
 
 | Port number | zowe.yaml variable name | Purpose |
 |------|------|------|
-| 2157 | zowe.environments.JGROUPS_KEYEXCHANGE_PORT | The port at which the key server in Infinispan is listening. If the port is not available, the next port is probed, up to port+5. Used by the key server (server) to create an SSLServerSocket and by clients to connect to the key server.
+| 2157 | - | The port at which the key server in Infinispan is listening. If the port is not available, the next port is probed, up to port+5. Used by the key server (server) to create an SSLServerSocket and by clients to connect to the key server.
 | 7098 | zowe.components.caching-service.storage.infinispan.jgroups.port | Bind port for the socket that is used to form an Infinispan cluster.
 | 7552 | zowe.components.api-catalog.port | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
 | 7553 | zowe.components.discovery.port | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.

--- a/docs/user-guide/address-network-requirements.md
+++ b/docs/user-guide/address-network-requirements.md
@@ -10,7 +10,7 @@ For more information about variable names in the following table, see the [Zowe 
 
 | Port number | zowe.yaml variable name | Purpose |
 |------|------|------|
-| 2157 | - | The port at which the key server in Infinispan is listening. If the port is not available, the next port is probed, up to port+5. Used by the key server (server) to create an SSLServerSocket and by clients to connect to the key server.
+| 2157 | NA | The port at which the key server in Infinispan is listening. If the port is not available, the next port is probed, up to port+5. Used by the key server (server) to create an SSLServerSocket and by clients to connect to the key server.
 | 7098 | zowe.components.caching-service.storage.infinispan.jgroups.port | Bind port for the socket that is used to form an Infinispan cluster.
 | 7552 | zowe.components.api-catalog.port | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
 | 7553 | zowe.components.discovery.port | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.


### PR DESCRIPTION
Describe your pull request here:
The variable `zowe.environments.JGROUPS_KEYEXCHANGE_PORT` won't setup the port for JGroups KeyExchange server. Such variable (different from this one) was added in 2.16 (already in staging). This port is not possible to change in the current version (2.15), so there is no variable.

List the file(s) included in this PR:
docs/user-guide/address-network-requirements.md
