### PR TITLE
Change the example for login in zaas

### DIFF
--- a/docs/extend/extend-apiml/zaas-client.md
+++ b/docs/extend/extend-apiml/zaas-client.md
@@ -225,7 +225,7 @@ You can now use any method from `ZaasClient` in your class.
 For login, use the following code snippet:
 
 ```java
-   String zaasClientToken = zaasClient.login("user", "user");
+   String zaasClientToken = zaasClient.login("user", "password");
  ```
 
 The following codeblock is an example of a `SampleZaasClientImplementation`.


### PR DESCRIPTION
Describe your pull request here:
Login example was using confusing "user" instead of "password". Linked to #3697 

List the file(s) included in this PR:
zaas-client.md

After creating the PR, follow the instructions in the comments.
