### PR TITLE
Typo in example: configuration-connection-limits.md

### DIFF
--- a/docs/user-guide/api-mediation/configuration-connection-limits.md
+++ b/docs/user-guide/api-mediation/configuration-connection-limits.md
@@ -22,7 +22,7 @@ zowe:
   components:
     gateway:
       server:
-        websocket:
+        webSocket:
           connectTimeout: 15000
           stopTimeout: 30000
           asyncWriteTimeout: 60000


### PR DESCRIPTION
websocket is [webSocket](https://github.com/zowe/api-layer/blob/f5ef28460cac6a9d5a1fc478cef9932789f7064d/schemas/gateway-schema.json#L250).

Yaml is case sensitive.