### PR TITLE
Correctly require Unicode instead of ASCII for the static definitions.

### DIFF
--- a/docs/extend/extend-apiml/onboard-static-definition.md
+++ b/docs/extend/extend-apiml/onboard-static-definition.md
@@ -101,7 +101,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * Each service has a service ID. In this example, the service ID is `petstore`. The service id is used as a part of the request URL towards the Gateway. It is removed by the Gateway when forwarding the request to the service.
 * The service can have one or more instances. In this case, only one instance `http://localhost:8080` is used.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 :::tip Tips:
 

--- a/versioned_docs/version-v2.10.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.10.x/extend/extend-apiml/onboard-static-definition.md
@@ -100,7 +100,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
 
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 **Tips:**
 

--- a/versioned_docs/version-v2.11.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.11.x/extend/extend-apiml/onboard-static-definition.md
@@ -100,7 +100,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
 
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 **Tips:**
 

--- a/versioned_docs/version-v2.12.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.12.x/extend/extend-apiml/onboard-static-definition.md
@@ -101,7 +101,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * Each service has a service ID. In this example, the service ID is `petstore`. The service id is used as a part of the request URL towards the Gateway. It is removed by the Gateway when forwarding the request to the service.
 * The service can have one or more instances. In this case, only one instance `http://localhost:8080` is used.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 :::tip Tips:
 

--- a/versioned_docs/version-v2.13.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.13.x/extend/extend-apiml/onboard-static-definition.md
@@ -101,7 +101,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * Each service has a service ID. In this example, the service ID is `petstore`. The service id is used as a part of the request URL towards the Gateway. It is removed by the Gateway when forwarding the request to the service.
 * The service can have one or more instances. In this case, only one instance `http://localhost:8080` is used.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 :::tip Tips:
 

--- a/versioned_docs/version-v2.14.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.14.x/extend/extend-apiml/onboard-static-definition.md
@@ -101,7 +101,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * Each service has a service ID. In this example, the service ID is `petstore`. The service id is used as a part of the request URL towards the Gateway. It is removed by the Gateway when forwarding the request to the service.
 * The service can have one or more instances. In this case, only one instance `http://localhost:8080` is used.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 :::tip Tips:
 

--- a/versioned_docs/version-v2.15.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.15.x/extend/extend-apiml/onboard-static-definition.md
@@ -101,7 +101,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 * Each service has a service ID. In this example, the service ID is `petstore`. The service id is used as a part of the request URL towards the Gateway. It is removed by the Gateway when forwarding the request to the service.
 * The service can have one or more instances. In this case, only one instance `http://localhost:8080` is used.
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 :::tip Tips:
 

--- a/versioned_docs/version-v2.8.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.8.x/extend/extend-apiml/onboard-static-definition.md
@@ -89,7 +89,6 @@ catalogUiTiles:
 In this example, a suitable name for the file is `petstore.yml`.
 
 **Notes:**
-
 * The filename does not need to follow specific naming conventions but it requires the `.yml` extension.
 
 * The file can contain one or more services defined under the `services:` node.
@@ -100,7 +99,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
 
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 **Tips:**
 

--- a/versioned_docs/version-v2.9.x/extend/extend-apiml/onboard-static-definition.md
+++ b/versioned_docs/version-v2.9.x/extend/extend-apiml/onboard-static-definition.md
@@ -100,7 +100,7 @@ In this example, a suitable name for the file is `petstore.yml`.
 
 * One API is provided and the requests with the relative base path `api/v2` at the API Gateway (full gateway URL: `https://gateway:port/serviceId/api/v2/...`) are routed to the relative base path `/v2` at the full URL of the service (`http://localhost:8080/v2/...`).
 
-* The file on USS should be encoded in ASCII to be read correctly by the API Mediation Layer.
+* The file on USS should be encoded in Unicode (UTF-8 / UTF-16) to be read correctly by the API Mediation Layer.
 
 **Tips:**
 


### PR DESCRIPTION
Describe your pull request here:
The requirements for the static definition was incorrectly requiring ASCII as the encoding, while the actual requirement is Unicode. This PR fixes the requirement for all the published v2.x versions. 

List the file(s) included in this PR: onboard-static-definition.md

After creating the PR, follow the instructions in the comments.
