### PR TITLE
Fixed a minor typo in the 'Trace' zwe option

### DIFF
--- a/docs/user-guide/initialize-zos-system.md
+++ b/docs/user-guide/initialize-zos-system.md
@@ -40,7 +40,7 @@ The following `zwe init` arguments can assist you with the initization process:
  This argument allows you to rerun the `zwe init` command repeatedly regardless of whether some data sets are already created.
 - **-v** or **--verbose**  
    This argument provides execution details of the `zwe` command. You can use it for troubleshooting purposes if the error message is not clear enough.
-- **T-vv** or **--trace**  
+- **-vv** or **--trace**  
  This argument provides you more execution details than the `--verbose` mode for troubleshooting purposes.
 
 ## Zowe initilization command

--- a/versioned_docs/version-v2.12.x/user-guide/initialize-zos-system.md
+++ b/versioned_docs/version-v2.12.x/user-guide/initialize-zos-system.md
@@ -40,7 +40,7 @@ The following `zwe init` arguments can assist you with the initization process:
  This argument allows you to rerun the `zwe init` command repeatedly regardless of whether some data sets are already created.
 - **-v** or **--verbose**  
    This argument provides execution details of the `zwe` command. You can use it for troubleshooting purposes if the error message is not clear enough.
-- **T-vv** or **--trace**  
+- **-vv** or **--trace**  
  This argument provides you more execution details than the `--verbose` mode for troubleshooting purposes.
 
 ## Zowe initilization command

--- a/versioned_docs/version-v2.13.x/user-guide/initialize-zos-system.md
+++ b/versioned_docs/version-v2.13.x/user-guide/initialize-zos-system.md
@@ -40,7 +40,7 @@ The following `zwe init` arguments can assist you with the initization process:
  This argument allows you to rerun the `zwe init` command repeatedly regardless of whether some data sets are already created.
 - **-v** or **--verbose**  
    This argument provides execution details of the `zwe` command. You can use it for troubleshooting purposes if the error message is not clear enough.
-- **T-vv** or **--trace**  
+- **-vv** or **--trace**  
  This argument provides you more execution details than the `--verbose` mode for troubleshooting purposes.
 
 ## Zowe initilization command

--- a/versioned_docs/version-v2.14.x/user-guide/initialize-zos-system.md
+++ b/versioned_docs/version-v2.14.x/user-guide/initialize-zos-system.md
@@ -40,7 +40,7 @@ The following `zwe init` arguments can assist you with the initization process:
  This argument allows you to rerun the `zwe init` command repeatedly regardless of whether some data sets are already created.
 - **-v** or **--verbose**  
    This argument provides execution details of the `zwe` command. You can use it for troubleshooting purposes if the error message is not clear enough.
-- **T-vv** or **--trace**  
+- **-vv** or **--trace**  
  This argument provides you more execution details than the `--verbose` mode for troubleshooting purposes.
 
 ## Zowe initilization command

--- a/versioned_docs/version-v2.15.x/user-guide/initialize-zos-system.md
+++ b/versioned_docs/version-v2.15.x/user-guide/initialize-zos-system.md
@@ -40,7 +40,7 @@ The following `zwe init` arguments can assist you with the initization process:
  This argument allows you to rerun the `zwe init` command repeatedly regardless of whether some data sets are already created.
 - **-v** or **--verbose**  
    This argument provides execution details of the `zwe` command. You can use it for troubleshooting purposes if the error message is not clear enough.
-- **T-vv** or **--trace**  
+- **-vv** or **--trace**  
  This argument provides you more execution details than the `--verbose` mode for troubleshooting purposes.
 
 ## Zowe initilization command

--- a/versioned_docs/version-v2.16.x/user-guide/initialize-zos-system.md
+++ b/versioned_docs/version-v2.16.x/user-guide/initialize-zos-system.md
@@ -40,7 +40,7 @@ The following `zwe init` arguments can assist you with the initization process:
  This argument allows you to rerun the `zwe init` command repeatedly regardless of whether some data sets are already created.
 - **-v** or **--verbose**  
    This argument provides execution details of the `zwe` command. You can use it for troubleshooting purposes if the error message is not clear enough.
-- **T-vv** or **--trace**  
+- **-vv** or **--trace**  
  This argument provides you more execution details than the `--verbose` mode for troubleshooting purposes.
 
 ## Zowe initilization command


### PR DESCRIPTION
### The instructions for the zwe client contained a minor typo in the "trace" option

The url:
[Initialize zos system](https://docs.zowe.org/stable/user-guide/initialize-zos-system/ )

Contains the following line under the "zwe init arguments" section:
<img width="855" alt="image" src="https://github.com/user-attachments/assets/59019291-d4c8-4ed8-a78a-153c65a791f2">

The letter "**T**" just before the "**-vv**" is likely a typo, it exists in a few of the older versions as well, all of which have been updated in this PR.

I didn't see this typo anywhere else the Trace option was mentioned.
