### PR TITLE
Add System Changes section to migrate guide

### DIFF
--- a/docs/whats-new/zowe-v3-migration.md
+++ b/docs/whats-new/zowe-v3-migration.md
@@ -18,6 +18,22 @@ The Zowe YAML parameter `node.home` value should be a **Node.js 18 or 20** home 
 If you are using keyrings, verify that Zowe YAML references to `safkeyring` uses 2 slashes, not 4, such as `safkeyring://` instead of `safkeyring:////`.
 
 
+## System and Security Changes
+
+- Existing SAF settings for Zowe do not need to be changed for v3, so install steps such as `zwe init security`, the job or workflow ZWESECUR, and the jobs ZWEIRAC, ZWEITSS, and ZWEIACF are not required to be re-run.
+
+- Existing keyrings and keystores do not need to be changed for v3, so install steps such as `zwe init certificate`, the job or workflow ZWEKRING or jobs starting with ZWEIKR* are not required to be re-run.
+
+- The following network changes are needed for added or removed servers:
+
+| Component name | Change | Default Port | Default Jobname | Details |
+|----------------|--------|--------------|-----------------|---------|
+| zaas | Added | 7558 | ZWE1AZ | This component is required when using the API Mediation Layer |
+| metrics-service | Removed | 7551 | ZWE1MS | |
+| jobs-api | Removed | 7558 | ZWE1EJ | |
+| files-api | Removed | 7559 | ZwE1EF | |
+| cloud-gateway | Removed | 7563 | ZWE1CG | |
+
 
 ## Configuration changes
 


### PR DESCRIPTION
I think its important to tell people that for the most part, migrating from zowe v2 to v3 does not require significant system changes.
So, this PR not only lists the networking changes needed, but reassures that certificate & security changes are otherwise not required.