### PR TITLE
Remove node v16 reference for installing node

### DIFF
--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -27,10 +27,6 @@ IBM SDK for Node.js withdrew v16 from marketing on September 4, 2023. The v14 se
 :::
 
 
-- v16.x
-   - z/OS V2R4: PTFs [UI64830](https://www.ibm.com/support/pages/apar/PH14560), [UI64837](https://www.ibm.com/support/pages/apar/PH14560), [UI64839](https://www.ibm.com/support/pages/apar/PH14559), [UI64940](https://www.ibm.com/support/pages/apar/PH16038), [UI65567](https://www.ibm.com/support/pages/apar/PH17481).
-   - z/OS V2R5: PTFs [UI64830](https://www.ibm.com/support/pages/apar/PH14560), [UI64837](https://www.ibm.com/support/pages/apar/PH15674),[UI64940](https://www.ibm.com/support/pages/apar/PH16038).
-
 - v18.x
    - z/OS V2R4: PTFs UI78913, UI81096, UI78103, UI80155, UI83490
    - z/OS V2R5: PTFs UI78912, UI81095, UI80156, UI83424


### PR DESCRIPTION
The page "Addressing Node.js requirements" mentions node 16, but this is no longer supported.