### PR TITLE
Visualize "install" options as options under parent category

### DIFF
--- a/docs/user-guide/install-zowe-zos-convenience-build.md
+++ b/docs/user-guide/install-zowe-zos-convenience-build.md
@@ -1,4 +1,4 @@
-# Installing Zowe via a convenience build (PAX file)
+# Installing the z/OS Build via Convenience Build (PAX file)
 
 You install the Zowe&trade; convenience build by obtaining a PAX file and using this to create the Zowe runtime environment.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -132,51 +132,57 @@ module.exports = {
         },
         {
           type: "category",
-          label: "Installing Zowe Server Install Wizard",
-          link: { type: "doc", id: "user-guide/install-zowe-server-install-wizard" },
+          label: "Installing",
           items: [
-            "user-guide/troubleshooting-zowe-server-install-wizard",
-          ]
-        },
-        {
-          type: "category",
-          label: "Installing Zowe via SMP/E",
-          link: { type: "doc", id: "user-guide/install-zowe-smpe-overview" },
-          items: [
-            "user-guide/install-zowe-smpe",
-          ]
-        },
-        {
-          type: "category",
-          label: "Installing Zowe via z/OSMF from PSWI and SMP/E workflow",
-          link: { type: "doc", id: "user-guide/zosmf-install" },
-          items: [
-            "user-guide/install-zowe-pswi-address-requirements",
-            "user-guide/systemrequirements-zosmf",
-            "user-guide/systemrequirements-zosmf-lite",
+           {
+              type: "category",
+              label: "Installing the z/OS Build via Zowe Server Install Wizard",
+              link: { type: "doc", id: "user-guide/install-zowe-server-install-wizard" },
+              items: [
+                "user-guide/troubleshooting-zowe-server-install-wizard",
+              ]
+            },
             {
               type: "category",
-              label: "Installing Zowe via z/OSMF from PSWI",
-              link: { type: "doc", id: "user-guide/install-zowe-pswi" },
+              label: "Installing the z/OS Build via SMP/E",
+              link: { type: "doc", id: "user-guide/install-zowe-smpe-overview" },
               items: [
-                "user-guide/install-zowe-pswi-acquire",
-                "user-guide/install-zowe-pswi-deployment",
+                "user-guide/install-zowe-smpe",
+              ]
+            },
+            {
+              type: "category",
+              label: "Installing the z/OS Build via z/OSMF from PSWI and SMP/E workflow",
+              link: { type: "doc", id: "user-guide/zosmf-install" },
+              items: [
+                "user-guide/install-zowe-pswi-address-requirements",
+                "user-guide/systemrequirements-zosmf",
+                "user-guide/systemrequirements-zosmf-lite",
+                {
+                  type: "category",
+                  label: "Installing Zowe via z/OSMF from PSWI",
+                  link: { type: "doc", id: "user-guide/install-zowe-pswi" },
+                  items: [
+                    "user-guide/install-zowe-pswi-acquire",
+                    "user-guide/install-zowe-pswi-deployment",
+                  ],
+                },
+                "user-guide/install-zowe-smpe-zosmf-workflow",
               ],
             },
-            "user-guide/install-zowe-smpe-zosmf-workflow",
-          ],
-        },
-        "user-guide/install-zowe-zos-convenience-build",
-        {
-          type: "category",
-          label: "Installing Zowe via a containerization build (PAX file)",
-          link: { type: "doc", id: "user-guide/k8s-introduction" },
-          items: [
-            "user-guide/k8s-prereqs",
-            "user-guide/k8s-downloading",
-            "user-guide/k8s-config",
-            "user-guide/k8s-using",
-          ],
+            "user-guide/install-zowe-zos-convenience-build",
+            {
+              type: "category",
+              label: "Installing the Container Build with Kubernetes",
+              link: { type: "doc", id: "user-guide/k8s-introduction" },
+              items: [
+                "user-guide/k8s-prereqs",
+                "user-guide/k8s-downloading",
+                "user-guide/k8s-config",
+                "user-guide/k8s-using",
+              ],
+            }
+          ]
         },
         {
           type: "category",


### PR DESCRIPTION
Today you can install zowe servers via many techniques and either on or off of z/OS.
All these options are currently visualized on the sidebar like this 
<img width="253" alt="image" src="https://github.com/user-attachments/assets/5cd9c2e8-e8d7-4541-bf30-02d29b1cbd90">


Since each one of these items is an option, you don't want to do more than one really. You want to choose one and only one.
To help make that obvious, I put them all under a parent item in the sidebar that just says "installing"
Then, I revised the titles to make clear what you're installing and how, so hopefully people will understand these are choices where you only choose one option.

Now it looks like this
<img width="265" alt="image" src="https://github.com/user-attachments/assets/692906b6-5caf-4b49-ae0c-eaefd3f07f55">
