### PR TITLE
Update systemrequirements-zosmf-lite.md

### DIFF
--- a/docs/user-guide/systemrequirements-zosmf-lite.md
+++ b/docs/user-guide/systemrequirements-zosmf-lite.md
@@ -86,13 +86,7 @@ Otherwise, you might encounter errors later in the process. If you encounter err
 
 ### Web browser
 
-For the best results with z/OSMF, use one of the following web browsers on your workstation:
-
--   Microsoft Internet Explorer Version 11 or later
-
--   Microsoft Edge (Windows 10)
-
--   Mozilla Firefox ESR Version 52 or later.
+For the best results with z/OSMF, use one of the [web browsers supported by z/OSMF](https://www.ibm.com/docs/en/zos/3.1.0?topic=zosmf-software-prerequisites#SoftwarePrerequisites__title__4)
 
 To check your web browser's level, click **About** in the web browser.
 

--- a/docs/user-guide/systemrequirements-zosmf-lite.md
+++ b/docs/user-guide/systemrequirements-zosmf-lite.md
@@ -86,7 +86,7 @@ Otherwise, you might encounter errors later in the process. If you encounter err
 
 ### Web browser
 
-For the best results with z/OSMF, use one of the [web browsers supported by z/OSMF](https://www.ibm.com/docs/en/zos/3.1.0?topic=zosmf-software-prerequisites#SoftwarePrerequisites__title__4)
+For best results with z/OSMF, use one of the [web browsers supported by z/OSMF](https://www.ibm.com/docs/en/zos/3.1.0?topic=zosmf-software-prerequisites#SoftwarePrerequisites__title__4).
 
 To check your web browser's level, click **About** in the web browser.
 


### PR DESCRIPTION
I removed the 3 bullets, namely:
- Microsoft Internet Explorer Version 11 or later.
- Microsoft Edge (Windows 10).
- Mozilla Firefox ESR Version 52 or later.

I added a link to a page in the IBM documentation. This page lists the browsers supported by zosmf.

Describe your pull request here:

List the file(s) included in this PR:

After creating the PR, follow the instructions in the comments.
