### PR TITLE
Support multiple certificate validation URLs

### DIFF
--- a/docs/troubleshoot/troubleshoot-apiml-error-codes.md
+++ b/docs/troubleshoot/troubleshoot-apiml-error-codes.md
@@ -551,7 +551,7 @@ The following error message codes may appear on logs or API responses. Use the f
   
   **Action:**
   
-  Ensure that the parameter apiml.security.x509.certificatesUrl is correctly configured with the complete URL to the central Gateway certificates endpoint. Test the URL manually.
+  Ensure that the parameter apiml.security.x509.certificatesUrls is correctly configured with the complete URL to the central Gateway certificates endpoint. Test the URL manually.
 
 ### ZWEAT502E
 
@@ -559,11 +559,11 @@ The following error message codes may appear on logs or API responses. Use the f
   
   **Reason:**
   
-  The parameter apiml.security.x509.certificatesUrl is not correctly configured with the complete URL to the central Gateway certificates endpoint.
+  The parameter apiml.security.x509.certificatesUrls is not correctly configured with the complete URL to the central Gateway certificates endpoint.
   
   **Action:**
   
-  Ensure that the parameter apiml.security.x509.certificatesUrl is correctly configured.
+  Ensure that the parameter apiml.security.x509.certificatesUrls is correctly configured.
 
 ### ZWEAT503E
 
@@ -587,7 +587,7 @@ The following error message codes may appear on logs or API responses. Use the f
   
   **Action:**
   
-  Check that the URL configured in apiml.security.x509.certificatesUrl responds with valid DER-encoded certificates in the Base64 printable form.
+  Check that the URL configured in apiml.security.x509.certificatesUrls responds with valid DER-encoded certificates in the Base64 printable form.
 
 ### ZWEAT505E
 
@@ -599,7 +599,7 @@ The following error message codes may appear on logs or API responses. Use the f
   
   **Action:**
   
-  Check that the URL configured in apiml.security.x509.certificatesUrl points to the central Gateway and it responds with valid DER-encoded certificates in the Base64 printable form.
+  Check that the URL configured in apiml.security.x509.certificatesUrls points to the central Gateway and it responds with valid DER-encoded certificates in the Base64 printable form.
 
 ### ZWEAT601E
 


### PR DESCRIPTION
Describe your pull request here:
Update troubleshooting codes with the support for multiple certificate URLs. 

List the file(s) included in this PR:
troubleshoot-apiml-error-codes.md

After creating the PR, follow the instructions in the comments.
