### PR TITLE
Clarify jobname for app-server port

### DIFF
--- a/docs/user-guide/address-network-requirements.md
+++ b/docs/user-guide/address-network-requirements.md
@@ -21,7 +21,7 @@ Each Jobname has a default prefix of ZWE1, but that can be customized via the `z
 | 7554 | API Mediation Layer | gateway | ZWE1**AG** | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
 | 7555 | API Mediation Layer | caching-service | ZWE1**CS** | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
 | 7556 | App Framework | app-server | ZWE1**DS** & ZWE1SV | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
-| 7557 | App Framework | zss | ZWE1SZ | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
+| 7557 | App Framework | zss | ZWE1**SZ** | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
 | 7558 | API Mediation Layer | zaas | ZWE1**AZ** | AZ | 
 
 ## Application Server Jobname for Port
@@ -56,7 +56,8 @@ When `zowe.job.prefix` is "ZWE1", An example of port reservations with a fixed I
    7553 TCP ZWE1AD BIND 10.11.12.13 ; Zowe Discovery
    7554 TCP ZWE1AG BIND 10.11.12.13 ; Zowe Gateway
    7555 TCP ZWE1CS BIND 10.11.12.13 ; Zowe Caching Service
-   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server
+   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server without Cluster
+   7556 TCP ZWE1SV BIND 10.11.12.13 ; Zowe App Server with Cluster (Default)
    7557 TCP ZWE1SZ BIND 10.11.12.13 ; Zowe ZSS
    7558 TCP ZWE1AZ BIND 10.11.12.13 ; Zowe ZAAS
 ```

--- a/docs/user-guide/address-network-requirements.md
+++ b/docs/user-guide/address-network-requirements.md
@@ -16,13 +16,23 @@ Each Jobname has a default prefix of ZWE1, but that can be customized via the `z
 
 | Port number | Category | Component | Default Jobname | Log Suffix | Purpose |
 |------|------|------|------|------|------|
-| 7552 | API Mediation Layer | api-catalog | ZWE1AC | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
-| 7553 | API Mediation Layer | discovery | ZWE1AD | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
-| 7554 | API Mediation Layer | gateway | ZWE1AG | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
-| 7555 | API Mediation Layer | caching-service | ZWE1CS | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
-| 7556 | App Framework | app-server | ZWE1DS | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
+| 7552 | API Mediation Layer | api-catalog | ZWE1**AC** | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
+| 7553 | API Mediation Layer | discovery | ZWE1**AD** | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
+| 7554 | API Mediation Layer | gateway | ZWE1**AG** | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
+| 7555 | API Mediation Layer | caching-service | ZWE1**CS** | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
+| 7556 | App Framework | app-server | ZWE1**DS** & ZWE1SV | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
 | 7557 | App Framework | zss | ZWE1SZ | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
-| 7558 | API Mediation Layer | zaas | ZWE1AZ | AZ | 
+| 7558 | API Mediation Layer | zaas | ZWE1**AZ** | AZ | 
+
+## Application Server Jobname for Port
+The jobnames associated with the component "app-server" varies depending on whether cluster mode is enabled or not (default: enabled). 
+
+| Cluster mode | Jobname for listener port | Jobname for worker processes |
+|---|---|---
+| Enabled (Default) | Name of STC (default: ZWE1SV) | `zowe.job.prefix` + DS (default: ZWE1**DS**) |
+| Disabled | `zowe.job.prefix` + DS (default: ZWE1**DS**) | Not Applicable |
+
+To enable or disable cluster mode, see the [Advanced Application Framework Configuration Guide](./mvd-configuration.md).
 
 ## Caching Service Infinispan ports
 

--- a/versioned_docs/version-v2.15.x/user-guide/address-network-requirements.md
+++ b/versioned_docs/version-v2.15.x/user-guide/address-network-requirements.md
@@ -16,14 +16,24 @@ Each Jobname has a default prefix of ZWE1, but that can be customized via the `z
 
 | Port number | Category | Component | Default Jobname | Log Suffix | Purpose |
 |------|------|------|------|------|------|
-| 7552 | API Mediation Layer | api-catalog | ZWE1AC | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
-| 7553 | API Mediation Layer | discovery | ZWE1AD | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
-| 7554 | API Mediation Layer | gateway | ZWE1AG | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
-| 7555 | API Mediation Layer | caching-service | ZWE1CS | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
-| 7556 | App Framework | app-server | ZWE1DS | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
-| 7557 | App Framework | zss | ZWE1SZ | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
-| 7558 | | jobs-api | ZWE1EJ | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
-| 7559 | | files-api | ZWE1EF | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7552 | API Mediation Layer | api-catalog | ZWE1**AC** | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
+| 7553 | API Mediation Layer | discovery | ZWE1**AD** | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
+| 7554 | API Mediation Layer | gateway | ZWE1**AG** | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
+| 7555 | API Mediation Layer | caching-service | ZWE1**CS** | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
+| 7556 | App Framework | app-server | ZZWE1**DS** & ZWE1SV | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
+| 7557 | App Framework | zss | ZWE1**SZ** | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
+| 7558 | | jobs-api | ZWE1**EJ** | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7559 | | files-api | ZWE1**EF** | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+
+## Application Server Jobname for Port
+The jobnames associated with the component "app-server" varies depending on whether cluster mode is enabled or not (default: enabled). 
+
+| Cluster mode | Jobname for listener port | Jobname for worker processes |
+|---|---|---
+| Enabled (Default) | Name of STC (default: ZWE1SV) | `zowe.job.prefix` + DS (default: ZWE1**DS**) |
+| Disabled | `zowe.job.prefix` + DS (default: ZWE1**DS**) | Not Applicable |
+
+To enable or disable cluster mode, see the [Advanced Application Framework Configuration Guide](./mvd-configuration.md).
 
 ## Caching Service Infinispan ports
 
@@ -47,7 +57,8 @@ When `zowe.job.prefix` is "ZWE1", An example of port reservations with a fixed I
    7553 TCP ZWE1AD BIND 10.11.12.13 ; Zowe Discovery
    7554 TCP ZWE1AG BIND 10.11.12.13 ; Zowe Gateway
    7555 TCP ZWE1CS BIND 10.11.12.13 ; Zowe Caching Service
-   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server
+   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server without Cluster
+   7556 TCP ZWE1SV BIND 10.11.12.13 ; Zowe App Server with Cluster (Default)
    7557 TCP ZWE1SZ BIND 10.11.12.13 ; Zowe ZSS
 ```
 

--- a/versioned_docs/version-v2.16.x/user-guide/address-network-requirements.md
+++ b/versioned_docs/version-v2.16.x/user-guide/address-network-requirements.md
@@ -16,14 +16,24 @@ Each Jobname has a default prefix of ZWE1, but that can be customized via the `z
 
 | Port number | Category | Component | Default Jobname | Log Suffix | Purpose |
 |------|------|------|------|------|------|
-| 7552 | API Mediation Layer | api-catalog | ZWE1AC | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
-| 7553 | API Mediation Layer | discovery | ZWE1AD | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
-| 7554 | API Mediation Layer | gateway | ZWE1AG | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
-| 7555 | API Mediation Layer | caching-service | ZWE1CS | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
-| 7556 | App Framework | app-server | ZWE1DS | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
-| 7557 | App Framework | zss | ZWE1SZ | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
-| 7558 | | jobs-api | ZWE1EJ | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
-| 7559 | | files-api | ZWE1EF | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7552 | API Mediation Layer | api-catalog | ZWE1**AC** | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
+| 7553 | API Mediation Layer | discovery | ZWE1**AD** | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
+| 7554 | API Mediation Layer | gateway | ZWE1**AG** | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
+| 7555 | API Mediation Layer | caching-service | ZWE1**CS** | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
+| 7556 | App Framework | app-server | ZZWE1**DS** & ZWE1SV | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
+| 7557 | App Framework | zss | ZWE1**SZ** | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
+| 7558 | | jobs-api | ZWE1**EJ** | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7559 | | files-api | ZWE1**EF** | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+
+## Application Server Jobname for Port
+The jobnames associated with the component "app-server" varies depending on whether cluster mode is enabled or not (default: enabled). 
+
+| Cluster mode | Jobname for listener port | Jobname for worker processes |
+|---|---|---
+| Enabled (Default) | Name of STC (default: ZWE1SV) | `zowe.job.prefix` + DS (default: ZWE1**DS**) |
+| Disabled | `zowe.job.prefix` + DS (default: ZWE1**DS**) | Not Applicable |
+
+To enable or disable cluster mode, see the [Advanced Application Framework Configuration Guide](./mvd-configuration.md).
 
 ## Caching Service Infinispan ports
 
@@ -47,7 +57,8 @@ When `zowe.job.prefix` is "ZWE1", An example of port reservations with a fixed I
    7553 TCP ZWE1AD BIND 10.11.12.13 ; Zowe Discovery
    7554 TCP ZWE1AG BIND 10.11.12.13 ; Zowe Gateway
    7555 TCP ZWE1CS BIND 10.11.12.13 ; Zowe Caching Service
-   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server
+   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server without Cluster
+   7556 TCP ZWE1SV BIND 10.11.12.13 ; Zowe App Server with Cluster (Default)
    7557 TCP ZWE1SZ BIND 10.11.12.13 ; Zowe ZSS
 ```
 

--- a/versioned_docs/version-v2.17.x/user-guide/address-network-requirements.md
+++ b/versioned_docs/version-v2.17.x/user-guide/address-network-requirements.md
@@ -16,14 +16,24 @@ Each Jobname has a default prefix of ZWE1, but that can be customized via the `z
 
 | Port number | Category | Component | Default Jobname | Log Suffix | Purpose |
 |------|------|------|------|------|------|
-| 7552 | API Mediation Layer | api-catalog | ZWE1AC | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
-| 7553 | API Mediation Layer | discovery | ZWE1AD | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
-| 7554 | API Mediation Layer | gateway | ZWE1AG | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
-| 7555 | API Mediation Layer | caching-service | ZWE1CS | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
-| 7556 | App Framework | app-server | ZWE1DS | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
-| 7557 | App Framework | zss | ZWE1SZ | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
-| 7558 | | jobs-api | ZWE1EJ | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
-| 7559 | | files-api | ZWE1EF | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7552 | API Mediation Layer | api-catalog | ZWE1**AC** | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
+| 7553 | API Mediation Layer | discovery | ZWE1**AD** | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
+| 7554 | API Mediation Layer | gateway | ZWE1**AG** | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
+| 7555 | API Mediation Layer | caching-service | ZWE1**CS** | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
+| 7556 | App Framework | app-server | ZZWE1**DS** & ZWE1SV | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
+| 7557 | App Framework | zss | ZWE1**SZ** | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
+| 7558 | | jobs-api | ZWE1**EJ** | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7559 | | files-api | ZWE1**EF** | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+
+## Application Server Jobname for Port
+The jobnames associated with the component "app-server" varies depending on whether cluster mode is enabled or not (default: enabled). 
+
+| Cluster mode | Jobname for listener port | Jobname for worker processes |
+|---|---|---
+| Enabled (Default) | Name of STC (default: ZWE1SV) | `zowe.job.prefix` + DS (default: ZWE1**DS**) |
+| Disabled | `zowe.job.prefix` + DS (default: ZWE1**DS**) | Not Applicable |
+
+To enable or disable cluster mode, see the [Advanced Application Framework Configuration Guide](./mvd-configuration.md).
 
 ## Caching Service Infinispan ports
 
@@ -47,7 +57,8 @@ When `zowe.job.prefix` is "ZWE1", An example of port reservations with a fixed I
    7553 TCP ZWE1AD BIND 10.11.12.13 ; Zowe Discovery
    7554 TCP ZWE1AG BIND 10.11.12.13 ; Zowe Gateway
    7555 TCP ZWE1CS BIND 10.11.12.13 ; Zowe Caching Service
-   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server
+   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server without Cluster
+   7556 TCP ZWE1SV BIND 10.11.12.13 ; Zowe App Server with Cluster (Default)
    7557 TCP ZWE1SZ BIND 10.11.12.13 ; Zowe ZSS
 ```
 

--- a/versioned_docs/version-v2.18.x/user-guide/address-network-requirements.md
+++ b/versioned_docs/version-v2.18.x/user-guide/address-network-requirements.md
@@ -16,14 +16,24 @@ Each Jobname has a default prefix of ZWE1, but that can be customized via the `z
 
 | Port number | Category | Component | Default Jobname | Log Suffix | Purpose |
 |------|------|------|------|------|------|
-| 7552 | API Mediation Layer | api-catalog | ZWE1AC | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
-| 7553 | API Mediation Layer | discovery | ZWE1AD | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
-| 7554 | API Mediation Layer | gateway | ZWE1AG | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
-| 7555 | API Mediation Layer | caching-service | ZWE1CS | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
-| 7556 | App Framework | app-server | ZWE1DS | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
-| 7557 | App Framework | zss | ZWE1SZ | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
-| 7558 | | jobs-api | ZWE1EJ | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
-| 7559 | | files-api | ZWE1EF | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7552 | API Mediation Layer | api-catalog | ZWE1**AC** | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. 
+| 7553 | API Mediation Layer | discovery | ZWE1**AD** | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.
+| 7554 | API Mediation Layer | gateway | ZWE1**AG** | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway.
+| 7555 | API Mediation Layer | caching-service | ZWE1**CS** | ACS | Port of the caching service that is used to share state between different Zowe instances in a high availability topology.
+| 7556 | App Framework | app-server | ZZWE1**DS** & ZWE1SV | D | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.
+| 7557 | App Framework | zss | ZWE1**SZ** | SZ | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.
+| 7558 | | jobs-api | ZWE1**EJ** | EJ |Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+| 7559 | | files-api | ZWE1**EF** | EF | Disabled by default, as it duplicates APIs found in zOSMF, and is only retained if needed by extensions.
+
+## Application Server Jobname for Port
+The jobnames associated with the component "app-server" varies depending on whether cluster mode is enabled or not (default: enabled). 
+
+| Cluster mode | Jobname for listener port | Jobname for worker processes |
+|---|---|---
+| Enabled (Default) | Name of STC (default: ZWE1SV) | `zowe.job.prefix` + DS (default: ZWE1**DS**) |
+| Disabled | `zowe.job.prefix` + DS (default: ZWE1**DS**) | Not Applicable |
+
+To enable or disable cluster mode, see the [Advanced Application Framework Configuration Guide](./mvd-configuration.md).
 
 ## Caching Service Infinispan ports
 
@@ -47,7 +57,8 @@ When `zowe.job.prefix` is "ZWE1", An example of port reservations with a fixed I
    7553 TCP ZWE1AD BIND 10.11.12.13 ; Zowe Discovery
    7554 TCP ZWE1AG BIND 10.11.12.13 ; Zowe Gateway
    7555 TCP ZWE1CS BIND 10.11.12.13 ; Zowe Caching Service
-   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server
+   7556 TCP ZWE1DS BIND 10.11.12.13 ; Zowe App Server without Cluster
+   7556 TCP ZWE1SV BIND 10.11.12.13 ; Zowe App Server with Cluster (Default)
    7557 TCP ZWE1SZ BIND 10.11.12.13 ; Zowe ZSS
 ```
 


### PR DESCRIPTION
The table that shows which jobs to associate with which ports for Zowe server networking is missing detail on a quirk of NodeJS+zOS by which the jobname of the app-server that uses the stated port may not be what's intended, depending on configuration.

I've updated the table to show 2 jobnames for app-server, and then added a section directly below to clarify when and how these jobnames take affect, and what the defaults are.