### PR TITLE
Fix RBAC setup suggestion for wrong directory

### DIFF
--- a/docs/user-guide/mvd-configuration.md
+++ b/docs/user-guide/mvd-configuration.md
@@ -330,7 +330,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
    ```
 3. Copy the `allowedPlugins.json` file and paste it in the following location:
    ```
-   <zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/instance/ZLUX/pluginStorage
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 4. Open the copied `allowedPlugins.json` file and perform either of the following steps:
     - To make an app unavailable, delete it from the list of objects.
@@ -344,7 +344,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
 
 2. In the user's ID directory path, in the `\pluginStorage` directory, create `\org.zowe.zlux.bootstrap\plugins` directories. For example:
     ```
-    <zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/instance/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
+    <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
     ```
 
 3. In the `/plugins` directory, create an `allowedPlugins.json` file. You can use the default `allowedPlugins.json` file as a template by copying it from the following location:

--- a/versioned_docs/version-v2.15.x/user-guide/mvd-configuration.md
+++ b/versioned_docs/version-v2.15.x/user-guide/mvd-configuration.md
@@ -483,7 +483,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
    ```
 3. Copy the `allowedPlugins.json` file and paste it in the following location:
    ```
-   <zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/instance/ZLUX/pluginStorage
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 4. Open the copied `allowedPlugins.json` file and perform either of the following steps:
     - To make an app unavailable, delete it from the list of objects.
@@ -502,7 +502,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
 
 3. In the `/plugins` directory, create an `allowedPlugins.json` file. You can use the default `allowedPlugins.json` file as a template by copying it from the following location:
    ```
-   <zpwe.runtimeDirectory>/components/app-server/share/zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
+   <zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/instance/ZLUX/pluginStorage
    ```
 6. Open the `allowedPlugins.json` file and specify apps that user can access. For example:
     ```json

--- a/versioned_docs/version-v2.16.x/user-guide/mvd-configuration.md
+++ b/versioned_docs/version-v2.16.x/user-guide/mvd-configuration.md
@@ -483,7 +483,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
    ```
 3. Copy the `allowedPlugins.json` file and paste it in the following location:
    ```
-   <zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/instance/ZLUX/pluginStorage
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 4. Open the copied `allowedPlugins.json` file and perform either of the following steps:
     - To make an app unavailable, delete it from the list of objects.
@@ -502,7 +502,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
 
 3. In the `/plugins` directory, create an `allowedPlugins.json` file. You can use the default `allowedPlugins.json` file as a template by copying it from the following location:
    ```
-   <zpwe.runtimeDirectory>/components/app-server/share/zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 6. Open the `allowedPlugins.json` file and specify apps that user can access. For example:
     ```json

--- a/versioned_docs/version-v2.17.x/user-guide/mvd-configuration.md
+++ b/versioned_docs/version-v2.17.x/user-guide/mvd-configuration.md
@@ -483,7 +483,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
    ```
 3. Copy the `allowedPlugins.json` file and paste it in the following location:
    ```
-   <zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/instance/ZLUX/pluginStorage
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 4. Open the copied `allowedPlugins.json` file and perform either of the following steps:
     - To make an app unavailable, delete it from the list of objects.
@@ -502,7 +502,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
 
 3. In the `/plugins` directory, create an `allowedPlugins.json` file. You can use the default `allowedPlugins.json` file as a template by copying it from the following location:
    ```
-   <zpwe.runtimeDirectory>/components/app-server/share/zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 6. Open the `allowedPlugins.json` file and specify apps that user can access. For example:
     ```json

--- a/versioned_docs/version-v2.18.x/user-guide/mvd-configuration.md
+++ b/versioned_docs/version-v2.18.x/user-guide/mvd-configuration.md
@@ -483,7 +483,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
    ```
 3. Copy the `allowedPlugins.json` file and paste it in the following location:
    ```
-   <zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/instance/ZLUX/pluginStorage
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 4. Open the copied `allowedPlugins.json` file and perform either of the following steps:
     - To make an app unavailable, delete it from the list of objects.
@@ -502,7 +502,7 @@ By default, RBAC is disabled and all authenticated Zowe users can access all dat
 
 3. In the `/plugins` directory, create an `allowedPlugins.json` file. You can use the default `allowedPlugins.json` file as a template by copying it from the following location:
    ```
-   <zpwe.runtimeDirectory>/components/app-server/share/zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
+   <zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
    ```
 6. Open the `allowedPlugins.json` file and specify apps that user can access. For example:
     ```json


### PR DESCRIPTION
The file docs/user-guide/mvd-configuration.md suggested users edit a file "allowedPlugins.json" within a directory 
<zowe.runtimeDirectory>/components/app-server/share/zlux-app-server/deploy/...

This directory does not exist. It was a developer directory long ago.

I have updated the incorrect references to the valid folder 
<zowe.workspaceDirectory>/app-server/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins

This is applicable for all of v2 and v3. It may be that the old directory was valid for v1, but as that is out of support now I'm not digging too deep into that.