### PR TITLE
removing zowe demo links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,10 +117,6 @@ module.exports = {
               href: "https://www.zowe.org/download.html",
             },
             {
-              label: "Try Zowe",
-              href: "https://early-access.ibm.com/software/support/trial/cst/welcomepage.wss?siteId=936&tabId=2216&w=1",
-            },
-            {
               label: "Features",
               href: "https://docs.zowe.org/stable/getting-started/overview.html",
             },

--- a/src/components/PopularResources/PopularResources.js
+++ b/src/components/PopularResources/PopularResources.js
@@ -15,12 +15,6 @@ const data = [
       </>
     ),
   },
-  {
-    title: "Try Zowe",
-    link: "https://www.openmainframeproject.org/projects/zowe/ztrial",
-    icon: "img/try_zowe-icon.png",
-    description: <>Get your hands on a Zowe trial on demand at no charge.</>,
-  },
 ];
 
 function Resource({ title, link, icon, description }) {


### PR DESCRIPTION
Describe your pull request here: Removing links to the Zowe demo site from the homepage as the demo is no longer available

List the file(s) included in this PR: docusaurus.config.js +

After creating the PR, follow the instructions in the comments.
