### PR TITLE
Fix Netlify deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Deploy to Netlify
         id: deploy
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
         uses: nwtgck/actions-netlify@v3
         with:
           publish-dir: build


### PR DESCRIPTION
Describe your pull request here:

Updates build workflow to skips "Deploy to Netlify" step for Dependabot PRs. Since Dependabot doesn't have access to regular secrets, we can deploy w/o them same as we do for fork PRs.

The method for detecting that a PR is opened by Dependabot is based on [GitHub docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#fetching-metadata-about-a-pull-request).

List the file(s) included in this PR: build-docs.yml

After creating the PR, follow the instructions in the comments.
