### PR TITLE
Document Node 22 server support

### DIFF
--- a/docs/appendix/zowe-yaml-configuration.md
+++ b/docs/appendix/zowe-yaml-configuration.md
@@ -421,9 +421,9 @@ Ensure the value of `node.home` in the `zowe.yaml` is visible to the Zowe STC us
 **Example:**
 ```
 node:
-  home: "/usrlppSysplex/nodejs/node-v12.16.1"
+  home: "/usrlppSysplex/nodejs/node-v18.18.2"
 ```
-The above value is valid only when the path `/usrlppSysplex/nodejs/node-v12.16.1/bin/node` exists. If you observe output of `node:...FSUM7351 not found`, check to ensure that the value contains `bin/node`.
+The above value is valid only when the path `/usrlppSysplex/nodejs/node-v18.18.2/bin/node` exists. If you observe output of `node:...FSUM7351 not found`, check to ensure that the value contains `bin/node`.
 :::
 
 ### YAML configurations - zOSMF

--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -35,7 +35,11 @@ IBM SDK for Node.js withdrew v16 from marketing on September 4, 2023. The v14 se
    - z/OS V2R4: PTFs UI80106, UI81096, UI78103, UI80155, UI83490
    - z/OS V2R5: PTFs UI78912, UI81095, UI80156, UI83424
    - z/OS V3R1: No PTFs needed.
- 
+
+ - V22.x
+   - z/OS V2R5: PTFs UI78912, UI81095, UI80156, UI83424
+   - z/OS V3R1: No PTFs needed.
+
 
 ## How to obtain IBM SDK for Node.js - z/OS
 

--- a/docs/user-guide/install-nodejs-zos.md
+++ b/docs/user-guide/install-nodejs-zos.md
@@ -89,7 +89,7 @@ Follow these steps to install the PAX edition of Node.js - z/OS to run Zowe.
     ```
 
     If Node.js is installed correctly, the version of Node.js is displayed. If it is intalled correctly, you will see the version information on your device.
-1. After you install Node.js, set the `NODE_HOME` environment variable to the directory where Node.js is installed. For example, `NODE_HOME=/proj/mvd/node/installs/node-v6.14.4-os390-s390x`.
+1. After you install Node.js, set the `NODE_HOME` environment variable to the directory where Node.js is installed. For example, `NODE_HOME=/proj/mvd/node/installs/node-v18.18.2-os390-s390x`.
 
 ## Installing the SMP/E edition of Node.js - z/OS
 

--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -81,7 +81,7 @@ Zowe consumption reference data were measured with the default Zowe configuratio
 
 ### Node.js
 
-- Node.js v18.x, or v20.x is required during installation. After installation, it is only required when running the app-server component.
+- Node.js v18.x, v20.x, or v22.x is required during installation. After installation, it is only required when running the app-server component.
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Addressing Node.js requirements](install-nodejs-zos.md).
   

--- a/versioned_docs/version-v2.18.x/user-guide/install-nodejs-zos.md
+++ b/versioned_docs/version-v2.18.x/user-guide/install-nodejs-zos.md
@@ -27,16 +27,16 @@ IBM SDK for Node.js withdrew v16 from marketing on September 4, 2023. The v14 se
 :::
 
 
-- v16.x
-   - z/OS V2R4: PTFs [UI64830](https://www.ibm.com/support/pages/apar/PH14560), [UI64837](https://www.ibm.com/support/pages/apar/PH14560), [UI64839](https://www.ibm.com/support/pages/apar/PH14559), [UI64940](https://www.ibm.com/support/pages/apar/PH16038), [UI65567](https://www.ibm.com/support/pages/apar/PH17481).
-   - z/OS V2R5: PTFs [UI64830](https://www.ibm.com/support/pages/apar/PH14560), [UI64837](https://www.ibm.com/support/pages/apar/PH15674),[UI64940](https://www.ibm.com/support/pages/apar/PH16038).
-
 - v18.x
    - z/OS V2R4: PTFs UI78913, UI81096, UI78103, UI80155, UI83490
    - z/OS V2R5: PTFs UI78912, UI81095, UI80156, UI83424
 
 - V20.x
    - z/OS V2R4: PTFs UI80106, UI81096, UI78103, UI80155, UI83490
+   - z/OS V2R5: PTFs UI78912, UI81095, UI80156, UI83424
+   - z/OS V3R1: No PTFs needed.
+ 
+ - V22.x
    - z/OS V2R5: PTFs UI78912, UI81095, UI80156, UI83424
    - z/OS V3R1: No PTFs needed.
  

--- a/versioned_docs/version-v2.18.x/user-guide/systemrequirements-zos.md
+++ b/versioned_docs/version-v2.18.x/user-guide/systemrequirements-zos.md
@@ -81,7 +81,7 @@ Zowe consumption reference data were measured with the default Zowe configuratio
 
 ### Node.js
 
-- Node.js v16.x, v18.x, or v20.x is required during installation. After installation, it is only required when running the app-server component, unless you are running a version of Zowe older than v2.16.0
+- Node.js v18.x, v20.x, or v22.x is required during installation. After installation, it is only required when running the app-server component, unless you are running a version of Zowe older than v2.16.0
 
   Node is not included with z/OS so must be installed separately.  To install Node.js on z/OS, follow the instructions in [Addressing Node.js requirements](install-nodejs-zos.md).
   


### PR DESCRIPTION
Because Zowe community infrastructure tests node v22, and no issues have been reported, it seems the only task left is to write into documentation that node v22 is allowed to be used with Zowe.
I have also removed node v16 from documentation where applicable as it is no longer in support.

I made doc changes for v3 and v2.18 because there are no changes that made 22 support possible, so, it will work for both just fine.