### PR TITLE
Infinispan doc updates

### DIFF
--- a/docs/extend/extend-apiml/api-mediation-infinispan.md
+++ b/docs/extend/extend-apiml/api-mediation-infinispan.md
@@ -33,26 +33,22 @@ Configure Infinispan as a storage solution through the Caching service by settin
   This property specifies the list of cluster nodes (members). In case of multiple instances, the value for each Caching Service instance can be 
   either a list of all the members, separated by a comma, or just the replica. The format is `${haInstance.hostname}[${zowe.components.caching-service.storage.infinispan.jgroups.port}]`.
 
-* **`zowe.components.caching-service.storage.infinispan.persistence.dataLocation`**
-
-  The path where the service keeps its data files for the Infinispan Soft-Index Cache Store. 
-  The default value is `data`. If you run the Caching Service in HA and the instances use the same filesystem, you have to specify a different value of the data property for each instance. For more information, see the [Soft-Index File Store](https://infinispan.org/blog/2014/10/31/soft-index-file-store).
-
-
-* **`zowe.components.caching-service.storage.infinispan.persistence.indexLocation`**
-
-  The path where the service keeps its index data for the Infinispan Soft-Index Cache Store. 
-  The default value is `index`. If you run the Caching Service in HA and the instances use the same filesystem, you have to specify a different value of the index property for each instance. For more information, see the [Soft-Index File Store](https://infinispan.org/blog/2014/10/31/soft-index-file-store).
-
 
 * **`zowe.components.caching-service.storage.infinispan.jgroups.port`**
 
   (OPTIONAL)The default value is `7098`. The port number used by Infinispan to synchronise data among cahing-service instances.
 
+:::note
+We highly recommend to define this value even it is optional, because it is more resistance for future upgrading of Zowe.
+:::
+
 * **`zowe.components.caching-service.storage.infinispan.jgroups.host`**
 
   (OPTIONAL)The default value is taken from zowe hostname. The hostname used by Infinispan to synchronise data among cahing-service instances. 
 
+:::note
+We highly recommend to define this value even it is optional, because it is more resistance for future upgrading of Zowe.
+:::
 
 * **`zowe.components.caching-service.storage.infinispan.keyExchange.port`**
 
@@ -68,19 +64,15 @@ Configure Infinispan as a storage solution through the Caching service by settin
         caching-service:
           storage:
             mode: infinispan
-            infinispan: 
+            infinispan:
+              jgroups.port: 7098
               initialHosts: lpar2[7098]
-              persistence:
-                dataLocation: /global/zowe/workspace/caching-service/data01
-                indexLocation: /global/zowe/workspace/caching-service/index01
     lpar2:
       components:
         caching-service:
           storage:
             mode: infinispan
-            infinispan: 
+            infinispan:
+              jgroups.port: 7098
               initialHosts: lpar1[7098]
-              persistence:
-                dataLocation: /global/zowe/workspace/caching-service/data02
-                indexLocation: /global/zowe/workspace/caching-service/index02
   ```

--- a/versioned_docs/version-v3.0.x/extend/extend-apiml/api-mediation-infinispan.md
+++ b/versioned_docs/version-v3.0.x/extend/extend-apiml/api-mediation-infinispan.md
@@ -36,28 +36,44 @@ Configure Infinispan as a storage solution through the Caching service by settin
 * **`zowe.components.caching-service.storage.infinispan.persistence.dataLocation`**
 
   The path where the service keeps its data files for the Infinispan Soft-Index Cache Store. 
-  The default value is `data`. If you run the Caching Service in HA and the instances use the same filesystem, you have to specify a different value of the data property for each instance. For more information, see the [Soft-Index File Store](https://infinispan.org/blog/2014/10/31/soft-index-file-store).
+  The default value is `data`. If you run the Caching Service in HA you have to configure in this way:
+
+   - The value should be the same for each instance
+   - The location should point to non-shared filesystem, each instance requires a unique storage
+   - For more information, see the [Soft-Index File Store](https://infinispan.org/blog/2014/10/31/soft-index-file-store).
 
 
 * **`zowe.components.caching-service.storage.infinispan.persistence.indexLocation`**
 
   The path where the service keeps its index data for the Infinispan Soft-Index Cache Store. 
-  The default value is `index`. If you run the Caching Service in HA and the instances use the same filesystem, you have to specify a different value of the index property for each instance. For more information, see the [Soft-Index File Store](https://infinispan.org/blog/2014/10/31/soft-index-file-store).
+  The default value is `index`. If you run the Caching Service in HA you have to configure in this way:
+
+  - The value should be the same for each instance
+  - The location should point to non-shared filesystem, each instance requires a unique storage
+  - For more information, see the [Soft-Index File Store](https://infinispan.org/blog/2014/10/31/soft-index-file-store).
 
 
 * **`zowe.components.caching-service.storage.infinispan.jgroups.port`**
 
-  (OPTIONAL)The default value is `7098`. The port number used by Infinispan to synchronise data among cahing-service instances.
+  (OPTIONAL)The default value is `7600`. The port number used by Infinispan to synchronise data among cahing-service instances.
+
+:::note
+We highly recommend to define this value even it is optional, because it is more resistance between upgrading, especially 
+from version 2.x - 3.1 to 3.2 and newer.
+:::
 
 * **`zowe.components.caching-service.storage.infinispan.jgroups.host`**
 
   (OPTIONAL)The default value is taken from zowe hostname. The hostname used by Infinispan to synchronise data among cahing-service instances. 
 
-
 * **`zowe.components.caching-service.storage.infinispan.keyExchange.port`**
 
-  (OPTIONAL)The default value is `7118`. The port number used by Infinispan to exchange encryption key among cahing-service instances.
+  (OPTIONAL)The default value is `7601`. The port number used by Infinispan to exchange encryption key among cahing-service instances.
 
+:::note
+We highly recommend to define this value even it is optional, because it is more resistance between upgrading, especially
+from version 2.x - 3.1 to 3.2 and newer.
+:::
 
   **Example of Caching service HA configuration using Infinispan:**
 
@@ -68,19 +84,21 @@ Configure Infinispan as a storage solution through the Caching service by settin
         caching-service:
           storage:
             mode: infinispan
-            infinispan: 
+            infinispan:
+              jgroups.port: 7098
               initialHosts: lpar2[7098]
               persistence:
-                dataLocation: /global/zowe/workspace/caching-service/data01
-                indexLocation: /global/zowe/workspace/caching-service/index01
+                dataLocation: /global/zowe/workspace/caching-service/data
+                indexLocation: /global/zowe/workspace/caching-service/index
     lpar2:
       components:
         caching-service:
           storage:
             mode: infinispan
-            infinispan: 
+            infinispan:
+              jgroups.port: 7098
               initialHosts: lpar1[7098]
               persistence:
-                dataLocation: /global/zowe/workspace/caching-service/data02
-                indexLocation: /global/zowe/workspace/caching-service/index02
+                dataLocation: /global/zowe/workspace/caching-service/data
+                indexLocation: /global/zowe/workspace/caching-service/index
   ```


### PR DESCRIPTION
This PR contains two versions on new file `api-mediation-infinispan.md`.

The updates is to respect changes from these PRs:
- https://github.com/zowe/zowe-install-packaging/pull/4158
- https://github.com/zowe/api-layer/pull/3960

The text in `versioned_docs/version-v3.0.x/extend/extend-apiml/api-mediation-infinispan.md` is valid for 3.0 and 3.1.
The text in `docs/extend/extend-apiml/api-mediation-infinispan.md` will be valid since 3.2.