### PR TITLE
fix: look for typedoc ending in .zip

### DIFF
--- a/scripts/updateTypedoc.sh
+++ b/scripts/updateTypedoc.sh
@@ -20,7 +20,7 @@ rm -rf typedoc
 rm -f zowe-nodejs-sdk-typedoc.zip
 
 # Download and extract new files
-filename=$(curl https://zowe.jfrog.io/artifactory/libs-release-local/org/zowe/sdk/zowe-nodejs-sdk/$ZOWE_VERSION/ | grep -o 'zowe-nodejs-sdk-typedoc-[^"<]\+' | tail -1)
+filename=$(curl https://zowe.jfrog.io/artifactory/libs-release-local/org/zowe/sdk/zowe-nodejs-sdk/$ZOWE_VERSION/ | grep -o 'zowe-nodejs-sdk-typedoc-[^"<]\+\.zip' | tail -1)
 curl -L -o zowe-nodejs-sdk-typedoc.zip https://zowe.jfrog.io/artifactory/libs-release-local/org/zowe/sdk/zowe-nodejs-sdk/$ZOWE_VERSION/$filename
 unzip zowe-nodejs-sdk-typedoc.zip
 


### PR DESCRIPTION
Describe your pull request here:

Recently, the typedoc was updated so that a `.zip.bundle` file is packaged alongside the other files in the Zowe release folder. However, this broke the grep check in `updateTypedoc.sh` that looks for the typedoc ZIP and it grabs the bundle instead, causing `unzip` to fail on line 25 of the script. This PR updates the check so it grabs the ZIP rather than the `.zip.bundle` file.

List the file(s) included in this PR:

`scripts/updateTypedoc.sh`
