### PR TITLE
fixing sidebar links to release notes

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -9,6 +9,7 @@ module.exports = {
       link: { type: "doc", id: "whats-new/release-notes/release-notes-overview" },
       collapsed: false,
       items: [
+        "whats-new/release-notes/v3_1_0",
         "whats-new/release-notes/v3_0_0",
       ],
     },
@@ -18,8 +19,6 @@ module.exports = {
       className: "ToCheadercolor",
       collapsed: true,
       items: [
-        "whats-new/release-notes/v3_1_0",
-        "whats-new/release-notes/v3_0_0",
         "whats-new/release-notes/v2_18_0",
         "whats-new/release-notes/v2_17_0",
         "whats-new/release-notes/v2_16_0",


### PR DESCRIPTION
Describe your pull request here: Relocating links to 3.0, 3.1 release notes in the sidebar to the correct location

List the file(s) included in this PR: sidebar.md

After creating the PR, follow the instructions in the comments.
