### PR TITLE
Update zowe-v3-migration.md

### DIFF
--- a/versioned_docs/version-v3.0.x/whats-new/zowe-v3-migration.md
+++ b/versioned_docs/version-v3.0.x/whats-new/zowe-v3-migration.md
@@ -171,6 +171,8 @@ components:
 #### Keyrings
 
 If you are using keyrings, verify that Zowe YAML references to `safkeyring` use 2 slashes, not 4, such as `safkeyring://` instead of `safkeyring:////`.
+:::info After you edit the configuration parameters in your Zowe YAML file, reinstall and reinitialize Zowe.
+:::
 
 #### Gateway z/OSMF service configuration
 


### PR DESCRIPTION
A note is added.
Location: Migrating from Zowe Vx to Zowe V3 page --> Updated Configuration Parameters section -->
Keyrings section --> Note is after the line.
Here's the **Note**: After you edit the configuration parameters in your Zowe YAML file, reinstall and reinitialize Zowe.

Describe your pull request here:

List the file(s) included in this PR: zowe-v3-migration.md

After creating the PR, follow the instructions in the comments.
