### PR TITLE
6951_Update roadmap-contribute.md

### DIFF
--- a/docs/contribute/roadmap-contribute.md
+++ b/docs/contribute/roadmap-contribute.md
@@ -53,7 +53,7 @@ Check out the contribution guidelines for different components and squads to lea
   - [Zowe Explorer](https://github.com/zowe/zowe-explorer-vscode/blob/master/CONTRIBUTING.md)
   - [Zowe Client SDKs](https://github.com/zowe/zowe-cli/blob/master/docs/SDKGuidelines.md)
   - [Zowe Explorer plug-in for IntelliJ IDEA](https://github.com/zowe/zowe-explorer-intellij/blob/main/CONTRIBUTING.md)
-  - [Zowe Docs](./contributing)
+  - [Zowe Docs](./contributing.md)
   
 ## Promote Zowe
 
@@ -62,6 +62,6 @@ Check out the contribution guidelines for different components and squads to lea
 
 ## Helpful resources
 
-- [General code guidelines](./guidelines-code/categories)
-- [UI guidelines](./guidelines-ui/ui)
-- [Zowe learning resources](../getting-started/zowe-resources)
+- [General code guidelines](./guidelines-code/categories.md)
+- [UI guidelines](./guidelines-ui/ui.md)
+- [Zowe learning resources](../getting-started/zowe-resources.md)


### PR DESCRIPTION
I added the missing syntax (.md) to repair the issue of the broken links.
The syntax (.md) was added at the end of the following links:
- [Zowe Docs](./contributing.md)
- [General code guidelines](./guidelines-code/categories.md)
- [UI guidelines](./guidelines-ui/ui.md)
- [Zowe learning resources](../getting-started/zowe-resources.md)


Describe your pull request here:

List the file(s) included in this PR:
roadmap-contribute.md

After creating the PR, follow the instructions in the comments.
