### PR TITLE
Repairing_Broken_Links_in_Use_section_ZoweDocs

### DIFF
--- a/docs/user-guide/cli-using-integrating-apiml.md
+++ b/docs/user-guide/cli-using-integrating-apiml.md
@@ -34,7 +34,7 @@ Follow these steps to request a token and log in to API ML:
     - Host
     - Port for the API ML instance
 
-    <br/>A [base profile](../appendix/zowe-glossary#base-profile) is created or updated with your token, which is stored on your computer in place of a username and password. When you issue commands, you can omit your username, password, host, and port.
+    <br/>A [base profile](../appendix/zowe-glossary.md#base-profile) is created or updated with your token, which is stored on your computer in place of a username and password. When you issue commands, you can omit your username, password, host, and port.
 
     If you do not want to store the token on your PC, append the `--show-token` option to the `login` command.
 
@@ -130,7 +130,7 @@ Use the following steps to specify a base path with Zowe V1 profiles:
 
     The format of base path can vary based on how API ML is configured at your site.
 
-2. Access the API ML instance by creating a [service profile](../user-guide/cli-using-using-profiles-v1#zowe-cli-v1-profile-types) (or issuing a command) with the `--base-path` value of `ibmzosmf/api/v1`. Your service profile uses the token and credentials stored in your default base profile.
+2. Access the API ML instance by creating a [service profile](../user-guide/cli-using-using-profiles-v1.md#zowe-cli-v1-profile-types) (or issuing a command) with the `--base-path` value of `ibmzosmf/api/v1`. Your service profile uses the token and credentials stored in your default base profile.
 
     Using the preceding example, you would issue the following command with your profile name:
 
@@ -146,7 +146,7 @@ If multiple services are registered to the API Mediation Layer at your site, Zow
 
 When you are logged in, supply the `--base-path` option on commands for each service. Ensure that you do not provide username, password, host, or port directly on your service commands or profiles. Supplying those options causes the CLI to ignore the token in your base profile and directly access the service. You might need to remove those options from existing profiles to use SSO.
 
-For information about registering an API service at your site, see [Developing for API Mediation Layer](../extend/extend-apiml/onboard-overview).
+For information about registering an API service at your site, see [Developing for API Mediation Layer](../extend/extend-apiml/onboard-overview.md).
 
 ## Accessing services through SSO and a service not through API ML
 

--- a/docs/user-guide/cli-using-team-managing-credential-security.md
+++ b/docs/user-guide/cli-using-team-managing-credential-security.md
@@ -34,7 +34,7 @@ Create a configuration file and set its secure properties (such as usernames and
     ```
     A configuration file is created, if one does not already exist.
     
-    Additionally, the `user` and `password` fields are added to the generated base profile's `secure` array for that configuration file. Zowe CLI stores the username and password in the [secure credential store](../appendix/zowe-glossary#secure-credential-store).
+    Additionally, the `user` and `password` fields are added to the generated base profile's `secure` array for that configuration file. Zowe CLI stores the username and password in the [secure credential store](../appendix/zowe-glossary.md#secure-credential-store).
 
 3. If needed, add other fields to the secure array.
     - Use a text editor or an IDE (such as Visual Studio Code) to edit the configuration file.

--- a/versioned_docs/version-v3.0.x/user-guide/cli-using-benefits-of-team-config.md
+++ b/versioned_docs/version-v3.0.x/user-guide/cli-using-benefits-of-team-config.md
@@ -1,6 +1,6 @@
 # Benefits of team configuration
 
-[Team configuration](../appendix/zowe-glossary#team-configuration) can make the initial setup of Zowe CLI more efficient by making service connection details easier to share and maintain within your organization.
+[Team configuration](../appendix/zowe-glossary.md#team-configuration) can make the initial setup of Zowe CLI more efficient by making service connection details easier to share and maintain within your organization.
 
 Consider the following benefits of using team configuration for roles across your dev team:
 

--- a/versioned_docs/version-v3.0.x/user-guide/cli-using-command-precedence.md
+++ b/versioned_docs/version-v3.0.x/user-guide/cli-using-command-precedence.md
@@ -8,7 +8,7 @@ When you issue a command, the CLI *searches* for your command arguments in the f
 
 2. **Environment variables** that you define in the computer's operating system.
 
-    For more information, see [Using environment variables](../user-guide/cli-using-using-environment-variables).
+    For more information, see [Using environment variables](../user-guide/cli-using-using-environment-variables.md).
 3. **[Service profiles](../appendix/zowe-glossary.md#service-profile)** that you create (that is, a z/OSMF profile or another mainframe service).
 4. **[Base profiles](../appendix/zowe-glossary.md#base-profile)** that you create.
     These can contain credentials for use with multiple services and/or an API ML login token.

--- a/versioned_docs/version-v3.0.x/user-guide/cli-using-editing-team-configuration.md
+++ b/versioned_docs/version-v3.0.x/user-guide/cli-using-editing-team-configuration.md
@@ -1,6 +1,6 @@
 # Editing team configurations
 
-After you [initialize team configuration](../user-guide/cli-using-initializing-team-configuration), the newly created team profiles need additional details before they can be shared and applied in your environment. This could include information such as a port number or user credentials.
+After you [initialize team configuration](../user-guide/cli-using-initializing-team-configuration.md), the newly created team profiles need additional details before they can be shared and applied in your environment. This could include information such as a port number or user credentials.
 
 You might also need to modify the configuration file to [create new profiles](../user-guide/cli-using-creating-profiles.md) for accessing mainframe services.
 

--- a/versioned_docs/version-v3.0.x/user-guide/cli-using-understanding-core-command-groups.md
+++ b/versioned_docs/version-v3.0.x/user-guide/cli-using-understanding-core-command-groups.md
@@ -258,7 +258,7 @@ The `zosmf` command group lets you work with Zowe CLI profiles and get general i
 
 With the `zosmf` command group, you can perform the following tasks:
 
-* Verify that your profiles are set up correctly to communicate with z/OSMF on your system. For more information, see [Testing connections to z/OSMF](../user-guide/_cli-using-test-zosmf-connection.md).
+* Verify that your profiles are set up correctly to communicate with z/OSMF on your system. For more information, see [Testing connections to z/OSMF](../user-guide/cli-install-verify-your-installation.md#testing-connections-to-zosmf).
 * Get information about the current z/OSMF version, host, port, and plug-ins installed on your system.
 
 :::note

--- a/versioned_docs/version-v3.0.x/user-guide/cli-using-using-team-profiles.md
+++ b/versioned_docs/version-v3.0.x/user-guide/cli-using-using-team-profiles.md
@@ -52,6 +52,6 @@ To change an existing username or password used by a team config profile, use th
 
 3. Respond to prompts as needed. Press `Enter` to leave the value unchanged.
 
-    New values are saved in the [secure credential store](../appendix/zowe-glossary#secure-credential-store). After the last secure value is submitted, the user returns to the system command prompt.
+    New values are saved in the [secure credential store](../appendix/zowe-glossary.md#secure-credential-store). After the last secure value is submitted, the user returns to the system command prompt.
 
-For more ways to secure credentials in config profiles, see [Managing credential security](../user-guide/cli-using-team-managing-credential-security).
+For more ways to secure credentials in config profiles, see [Managing credential security](../user-guide/cli-using-team-managing-credential-security.md).

--- a/versioned_docs/version-v3.0.x/user-guide/mvd-using.md
+++ b/versioned_docs/version-v3.0.x/user-guide/mvd-using.md
@@ -134,16 +134,16 @@ Use the Languages setting in the Preferences panel to change the desktop languag
 
 Application plugins are applications that you can use to access the mainframe and to perform various tasks. Zowe's official server download contains some built-in plugins as described below. 
 
-Additional plugins can be added to the Desktop, and are packaged and installed as Extensions to Zowe. [See here for how to install extensions](install-configure-zos-extensions).
+Additional plugins can be added to the Desktop, and are packaged and installed as Extensions to Zowe. [See here for how to install extensions](install-configure-zos-extensions.md).
 
-Developers can create application plug-ins to put into extensions, and developers should [read the extending guide for more information](../extend/extend-desktop/mvd-extendingzlux).
+Developers can create application plug-ins to put into extensions, and developers should [read the extending guide for more information](../extend/extend-desktop/mvd-extendingzlux.md).
 
 ### VT Terminal 
 The VT Terminal plugin provides a user interface that emulates the basic functions of DEC VT family terminals. On the "back end," the plugin and the Zowe Application Server connect to VT compatible hosts, such as z/OS UNIX System Services (USS), using SSH or Telnet.
 
 This terminal display emulator operates as a "Three-Tier" program. Due to web browsers being unable to supply TCP networking that terminals require, this terminal display emulator does not connect directly to your SSH or Telnet server. Instead, the Zowe Application Server acts as a bridge, and uses websockets between it and the browser for terminal communication. As a result, terminal connections only work when the stack of network programs supports websockets and the TN3270 server destination is visible to the Zowe Application Server.
 
-The terminal connection can be customized per-user and saved for future sessions using the connection toolbar of the application. The preferences are stored within [the configuration dataservice storage](../extend/extend-desktop/mvd-configdataservice), which can also be used to set instance-wide defaults for multiple users.
+The terminal connection can be customized per-user and saved for future sessions using the connection toolbar of the application. The preferences are stored within [the configuration dataservice storage](../extend/extend-desktop/mvd-configdataservice.md), which can also be used to set instance-wide defaults for multiple users.
 
 ### API Catalog
 The API Catalog plugin lets you view API services that have been discovered by the API Mediation Layer. For more information about the API Mediation Layer, Discovery Service, and API Catalog, see [API Mediation Layer Overview](../getting-started/overview.md).


### PR DESCRIPTION
Describe your pull request here:
I added the missing syntax that should repair the problem of the broken links.

List the file(s) included in this PR:
I added the missing syntax in the following files:
- cli-using-integrating-apiml.md
- cli-using-team-managing-credential-security.md
- cli-using-benefits-of-team-config.md
- cli-using-command-precedence.md
- cli-using-editing-team-configuration.md
- cli-using-understanding-core-command-groups.md
- cli-using-using-team-profiles.md
- mvd-using.md

After creating the PR, follow the instructions in the comments.
