### PR TITLE
7018_Repair_broken_links_in_Reference_section_Zowe_Docs

### DIFF
--- a/docs/appendix/zowe-chat-command-reference/zos/command/command-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/command/command-article.md
@@ -1,6 +1,6 @@
 # zos command
 
-**[zos](../zos-article) > [command](command-article)**
+**[zos](../zos-article.md) > [command](command-article.md)**
 
 Interact with z/OS command related services, including z/OSMF Console services, etc.
 
@@ -10,17 +10,17 @@ Interact with z/OS command related services, including z/OSMF Console services, 
 
 ## Action
 
-- [`issue`](./issue/issue-article)
+- [`issue`](./issue/issue-article.md)
 
 ## Positional Arguments
 
-- [zos command issue console](./issue/zos-command-issue-console#positional-arguments)
+- [zos command issue console](./issue/zos-command-issue-console.md#positional-arguments)
 
     - `commandString`
 
 ## Options
 
-- [zos command issue console](./issue/zos-command-issue-console#options)
+- [zos command issue console](./issue/zos-command-issue-console.md#options)
 
     | Full name  | Alias| Type |
     | :---- | :---- | :---- |

--- a/docs/appendix/zowe-chat-command-reference/zos/command/issue/issue-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/command/issue/issue-article.md
@@ -1,6 +1,6 @@
 # `zos command issue`
 
-**[zos](../../zos-article) > [command](../command-article)**
+**[zos](../../zos-article.md) > [command](../command-article.md)**
 
 Issue z/OS commands.
 
@@ -10,4 +10,4 @@ Issue z/OS commands.
 
 ## Object
 
-- [console](zos-command-issue-console)
+- [console](zos-command-issue-console.md)

--- a/docs/appendix/zowe-chat-command-reference/zos/command/issue/zos-command-issue-console.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/command/issue/zos-command-issue-console.md
@@ -1,6 +1,6 @@
 # zos command issue console
 
-**[zos](../../zos-article) > [command](../command-article) > [issue](./issue-article) > [console](zos-command-issue-console)**
+**[zos](../../zos-article.md) > [command](../command-article.md) > [issue](./issue-article.md) > [console](zos-command-issue-console.md)**
 
 Issue a z/OS console command and print the response. In general, when issuing a z/OS console command, z/OS applications route responses to the originating console. Zowe Chat attempts to get the solicited messages immediately after the command is issued. If there is no message available within a certain time interval, approximately 3 seconds if your system workload is not high, Zowe Chat returns null. Usually it means that there is no command response. However, it is possible that the command response arrives after 3 seconds. In this case, you can click the command response URL in the response to retrieve the command response.
 

--- a/docs/appendix/zowe-chat-command-reference/zos/dataset/dataset-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/dataset/dataset-article.md
@@ -1,6 +1,6 @@
 # zos dataset
 
-**[zos](.././zos-article) > [dataset](dataset-article)**
+**[zos](.././zos-article.md) > [dataset](dataset-article.md)**
 
 Manages z/OS data sets. <!--dataset-description-->
 
@@ -12,21 +12,21 @@ Manages z/OS data sets. <!--dataset-description-->
 
 ## Action
 
-- [`list`](./list/list-article)
+- [`list`](./list/list-article.md)
 
 ## Positional Arguments
 
-- [zos dataset list status](./list/zos-dataset-list-status#positional-arguments)
+- [zos dataset list status](./list/zos-dataset-list-status.md#positional-arguments)
 
     - `datasetName*`
 
-- [zos dataset list member](./list/zos-dataset-list-member#positional-arguments)
+- [zos dataset list member](./list/zos-dataset-list-member.md#positional-arguments)
 
     - `datasetMemberName*`
 
 ## Options
 
-- [zos dataset list status](./list/zos-dataset-list-status#options)
+- [zos dataset list status](./list/zos-dataset-list-status.md#options)
 
     | Full name  | Alias | Type |
     | :---- | :----  | :---- |
@@ -35,7 +35,7 @@ Manages z/OS data sets. <!--dataset-description-->
     | --start | -s | string |
     | --limit |  | number |
 
-- [zos dataset list member](./list/zos-dataset-list-member#options)
+- [zos dataset list member](./list/zos-dataset-list-member.md#options)
 
     | Full name  | Alias | Type |
     | :---- | :----  | :---- |

--- a/docs/appendix/zowe-chat-command-reference/zos/dataset/list/list-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/dataset/list/list-article.md
@@ -1,6 +1,6 @@
 # `zos dataset list`
 
-**[zos](../../zos-article) > [dataset](../dataset-article) > [list](list-article)**
+**[zos](../../zos-article.md) > [dataset](../dataset-article.md) > [list](list-article.md)**
 
 Show status of data sets. <!--dataset-list-description-->
 
@@ -12,6 +12,6 @@ Show status of data sets. <!--dataset-list-description-->
 
 ## Object
 
-- [status](zos-dataset-list-status)
+- [status](zos-dataset-list-status.md)
 
-- [member](zos-dataset-list-member)
+- [member](zos-dataset-list-member.md)

--- a/docs/appendix/zowe-chat-command-reference/zos/dataset/list/zos-dataset-list-member.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/dataset/list/zos-dataset-list-member.md
@@ -1,6 +1,6 @@
 # `zos dataset list member`
 
-**[zos](../../zos-article) > [dataset](../dataset-article) > [list](./list-article) > [member](zos-dataset-list-member)**
+**[zos](../../zos-article.md) > [dataset](../dataset-article.md) > [list](./list-article.md) > [member](zos-dataset-list-member.md)**
 
 Show all members of a partitioned data set. <!--dataset-list-member-description-->
 

--- a/docs/appendix/zowe-chat-command-reference/zos/dataset/list/zos-dataset-list-status.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/dataset/list/zos-dataset-list-status.md
@@ -1,6 +1,6 @@
 # zos dataset list status
 
-**[zos](../../zos-article) > [dataset](../dataset-article) > [list](list-article) > [status](zos-dataset-list-status)**
+**[zos](../../zos-article.md) > [dataset](../dataset-article.md) > [list](list-article.md) > [status](zos-dataset-list-status.md)**
 
 Show status or details of data sets. <!--dataset-list-status-description-->
 

--- a/docs/appendix/zowe-chat-command-reference/zos/file/file-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/file/file-article.md
@@ -1,6 +1,6 @@
 # `zos file`
 
-**[zos](.././zos-article) > [file](file-article)**
+**[zos](.././zos-article.md) > [file](file-article.md)**
 
 Manage USS files in a z/OS system. <!--file-description-->
 
@@ -12,27 +12,27 @@ Manage USS files in a z/OS system. <!--file-description-->
 
 ## Action
 
-- [`list`](./list/list-article)
+- [`list`](./list/list-article.md)
 
 ## Positional Argument
 
-- [zos file list status](./list/zos-file-list-status#positional-arguments)
+- [zos file list status](./list/zos-file-list-status.md#positional-arguments)
 
     - `fileName*`
 
-- [zos file list mounts](./list/zos-file-list-mounts#positional-arguments)
+- [zos file list mounts](./list/zos-file-list-mounts.md#positional-arguments)
 
     - `fileSystemName*`
 ## Option
 
-- [zos file list status](./list/zos-file-list-status#options)
+- [zos file list status](./list/zos-file-list-status.md#options)
 
     | Full name  | Alias | Type |
     | :---- | :----  | :---- |
     | --path | -p | string |
     | --limit |  | number |
 
-- [zos file list mounts](./list/zos-file-list-mounts#options)
+- [zos file list mounts](./list/zos-file-list-mounts.md#options)
 
     | Full name  | Alias | Type |
     | :---- | :----  | :---- |

--- a/docs/appendix/zowe-chat-command-reference/zos/file/list/list-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/file/list/list-article.md
@@ -1,6 +1,6 @@
 # zos file list
 
-**[zos](../../zos-article) > [file](../file-article) > [list](list-article)**
+**[zos](../../zos-article.md) > [file](../file-article.md) > [list](list-article.md)**
 
 ## Usage
 
@@ -10,6 +10,6 @@
 
 ## Objects
 
-- [status](zos-file-list-status)
+- [status](zos-file-list-status.md)
 
-- [mounts](zos-file-list-mounts)
+- [mounts](zos-file-list-mounts.md)

--- a/docs/appendix/zowe-chat-command-reference/zos/file/list/zos-file-list-mounts.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/file/list/zos-file-list-mounts.md
@@ -1,6 +1,6 @@
 # zos file list mounts
 
-**[zos](../../zos-article) > [file](../file-article) > [list](./list-article) > [mounts](zos-file-list-mounts)** 
+**[zos](../../zos-article.md) > [file](../file-article.md) > [list](./list-article.md) > [mounts](zos-file-list-mounts.md)** 
 
 Show status or details of mounted z/OS file systems. <!--file-list-mounts-description-->
 

--- a/docs/appendix/zowe-chat-command-reference/zos/file/list/zos-file-list-status.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/file/list/zos-file-list-status.md
@@ -1,6 +1,6 @@
 # zos file list status
 
-**[zos](../../zos-article) > [file](../file-article) > [list](./list-article) > [status](zos-file-list-status)** 
+**[zos](../../zos-article.md) > [file](../file-article.md) > [list](./list-article.md) > [status](zos-file-list-status.md)** 
 
 Show status or details of USS files. <!--file-list-status-description-->
 

--- a/docs/appendix/zowe-chat-command-reference/zos/help/help-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/help/help-article.md
@@ -1,6 +1,6 @@
 # `zos help`
 
-**[zos](.././zos-article) > [help](help-article)**
+**[zos](.././zos-article.md) > [help](help-article.md)**
 
 Show help information of commands.
 
@@ -12,11 +12,11 @@ Show help information of commands.
 
 ## Action
 
-- [`list`](./list/list-article)
+- [`list`](./list/list-article.md)
 
 ## Positional Arguments
 
-- [zos help list command](./list/zos-help-list-command#positional-arguments)
+- [zos help list command](./list/zos-help-list-command.md#positional-arguments)
 
     - `fileName`
 

--- a/docs/appendix/zowe-chat-command-reference/zos/help/list/list-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/help/list/list-article.md
@@ -1,6 +1,6 @@
 # zos help list
 
-**[zos](../../zos-article) > [help](../help-article) > [list](list-article)**
+**[zos](../../zos-article.md) > [help](../help-article.md) > [list](list-article.md)**
 
 List help information of the command.
 
@@ -10,4 +10,4 @@ List help information of the command.
 
 ## Object 
 
-- [`command`](zos-help-list-command)
+- [`command`](zos-help-list-command.md)

--- a/docs/appendix/zowe-chat-command-reference/zos/help/list/zos-help-list-command.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/help/list/zos-help-list-command.md
@@ -1,6 +1,6 @@
 # zos help list command
 
-**[zos](../../zos-article) > [help](../help-article) > [list](./list-article) > [command](zos-help-list-command)**
+**[zos](../../zos-article.md) > [help](../help-article.md) > [list](./list-article.md) > [command](zos-help-list-command.md)**
 
 List help information of the command.
 

--- a/docs/appendix/zowe-chat-command-reference/zos/job/job-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/job/job-article.md
@@ -1,6 +1,6 @@
 # zos job
 
-**[zos](../zos-article) > [job](job-article)**
+**[zos](../zos-article.md) > [job](job-article.md)**
 
 Manage z/OS jobs.  <!--job-description-->
 
@@ -10,11 +10,11 @@ Manage z/OS jobs.  <!--job-description-->
 
 ## Action
 
-- [`list`](./list/list-article)
+- [`list`](./list/list-article.md)
 
 ## Positional Arguments
 
--  [zos job list status](./list/zos-job-list-status#positional-arguments)
+-  [zos job list status](./list/zos-job-list-status.md#positional-arguments)
 
     - `jobID`
 

--- a/docs/appendix/zowe-chat-command-reference/zos/job/list/list-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/job/list/list-article.md
@@ -1,6 +1,6 @@
 # `zos job list`
 
-**[zos](../../zos-article) > [job](../job-article) > [list](list-article)**
+**[zos](../../zos-article.md) > [job](../job-article.md) > [list](list-article.md)**
 
 List job status. <!--job-list-description-->
 
@@ -10,4 +10,4 @@ List job status. <!--job-list-description-->
 
 ## Object
 
-- [status](zos-job-list-status)
+- [status](zos-job-list-status.md)

--- a/docs/appendix/zowe-chat-command-reference/zos/job/list/zos-job-list-status.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/job/list/zos-job-list-status.md
@@ -1,6 +1,6 @@
 # zos job list status
 
-**[zos](../../zos-article) > [job](../job-article) > [list](./list-article) > [status](zos-job-list-status)**
+**[zos](../../zos-article.md) > [job](../job-article.md) > [list](./list-article.md) > [status](zos-job-list-status.md)**
 
 Show status or detail of jobs. <!--job-list-status-description-->
 

--- a/docs/appendix/zowe-chat-command-reference/zos/zos-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/zos-article.md
@@ -4,12 +4,12 @@ Manages z/OS resources including jobs, data sets, USS files, and mounted filesys
 
 ## Resources
 
-- [job](./job/job-article) - Manage z/OS jobs
+- [job](./job/job-article.md) - Manage z/OS jobs
 
-- [dataset](./dataset/dataset-article) - Manage z/OS data sets
+- [dataset](./dataset/dataset-article.md) - Manage z/OS data sets
 
-- [file](./file/file-article) - Manage z/OS USS files
+- [file](./file/file-article.md) - Manage z/OS USS files
 
-- [command](./command/command-article) - Perform z/OS console commands
+- [command](./command/command-article.md) - Perform z/OS console commands
 
-- [help](./help/help-article) - Request help for z/OS commands
+- [help](./help/help-article.md) - Request help for z/OS commands

--- a/docs/appendix/zowe-chat-command-reference/zos/zowe-chat-command-reference.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/zowe-chat-command-reference.md
@@ -6,4 +6,4 @@ Zowe Chat currently supports users to perform interactions with Zowe Chat bot.
 
 Check out the commands that Zowe Chat supports.
 
-- [z/OS commands](zos-article)
+- [z/OS commands](zos-article.md)

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-clean.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-clean.md
@@ -1,6 +1,6 @@
 # zwe certificate keyring-jcl clean
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [keyring-jcl](././zwe-certificate-keyring-jcl) > [clean](./zwe-certificate-keyring-jcl-clean)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [keyring-jcl](././zwe-certificate-keyring-jcl.md) > [clean](./zwe-certificate-keyring-jcl-clean.md)
 
 	zwe certificate keyring-jcl clean [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-connect.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-connect.md
@@ -1,6 +1,6 @@
 # zwe certificate keyring-jcl connect
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [keyring-jcl](././zwe-certificate-keyring-jcl) > [connect](./zwe-certificate-keyring-jcl-connect)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [keyring-jcl](././zwe-certificate-keyring-jcl.md) > [connect](./zwe-certificate-keyring-jcl-connect.md)
 
 	zwe certificate keyring-jcl connect [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-generate.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-generate.md
@@ -1,6 +1,6 @@
 # zwe certificate keyring-jcl generate
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [keyring-jcl](././zwe-certificate-keyring-jcl) > [generate](./zwe-certificate-keyring-jcl-generate)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [keyring-jcl](././zwe-certificate-keyring-jcl.md) > [generate](./zwe-certificate-keyring-jcl-generate.md)
 
 	zwe certificate keyring-jcl generate [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-import-ds.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl-import-ds.md
@@ -1,6 +1,6 @@
 # zwe certificate keyring-jcl import-ds
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [keyring-jcl](././zwe-certificate-keyring-jcl) > [import-ds](./zwe-certificate-keyring-jcl-import-ds)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [keyring-jcl](././zwe-certificate-keyring-jcl.md) > [import-ds](./zwe-certificate-keyring-jcl-import-ds.md)
 
 	zwe certificate keyring-jcl import-ds [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/keyring-jcl/zwe-certificate-keyring-jcl.md
@@ -1,6 +1,6 @@
 # zwe certificate keyring-jcl
 
-[zwe](../.././zwe) > [certificate](.././zwe-certificate) > [keyring-jcl](./zwe-certificate-keyring-jcl)
+[zwe](../.././zwe.md) > [certificate](.././zwe-certificate.md) > [keyring-jcl](./zwe-certificate-keyring-jcl.md)
 
 	zwe certificate keyring-jcl [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/create/zwe-certificate-pkcs12-create-ca.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/create/zwe-certificate-pkcs12-create-ca.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12 create ca
 
-[zwe](./../../.././zwe) > [certificate](./../.././zwe-certificate) > [pkcs12](./.././zwe-certificate-pkcs12) > [create](././zwe-certificate-pkcs12-create) > [ca](./zwe-certificate-pkcs12-create-ca)
+[zwe](./../../.././zwe.md) > [certificate](./../.././zwe-certificate.md) > [pkcs12](./.././zwe-certificate-pkcs12.md) > [create](././zwe-certificate-pkcs12-create.md) > [ca](./zwe-certificate-pkcs12-create-ca.md)
 
 	zwe certificate pkcs12 create ca [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/create/zwe-certificate-pkcs12-create-cert.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/create/zwe-certificate-pkcs12-create-cert.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12 create cert
 
-[zwe](./../../.././zwe) > [certificate](./../.././zwe-certificate) > [pkcs12](./.././zwe-certificate-pkcs12) > [create](././zwe-certificate-pkcs12-create) > [cert](./zwe-certificate-pkcs12-create-cert)
+[zwe](./../../.././zwe.md) > [certificate](./../.././zwe-certificate.md) > [pkcs12](./.././zwe-certificate-pkcs12.md) > [create](././zwe-certificate-pkcs12-create.md) > [cert](./zwe-certificate-pkcs12-create-cert.md)
 
 	zwe certificate pkcs12 create cert [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/create/zwe-certificate-pkcs12-create.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/create/zwe-certificate-pkcs12-create.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12 create
 
-[zwe](../../.././zwe) > [certificate](../.././zwe-certificate) > [pkcs12](.././zwe-certificate-pkcs12) > [create](./zwe-certificate-pkcs12-create)
+[zwe](../../.././zwe.md) > [certificate](../.././zwe-certificate.md) > [pkcs12](.././zwe-certificate-pkcs12.md) > [create](./zwe-certificate-pkcs12-create.md)
 
 	zwe certificate pkcs12 create [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-export.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-export.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12 export
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [pkcs12](././zwe-certificate-pkcs12) > [export](./zwe-certificate-pkcs12-export)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [pkcs12](././zwe-certificate-pkcs12.md) > [export](./zwe-certificate-pkcs12-export.md)
 
 	zwe certificate pkcs12 export [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-import.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-import.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12 import
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [pkcs12](././zwe-certificate-pkcs12) > [import](./zwe-certificate-pkcs12-import)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [pkcs12](././zwe-certificate-pkcs12.md) > [import](./zwe-certificate-pkcs12-import.md)
 
 	zwe certificate pkcs12 import [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-lock.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-lock.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12 lock
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [pkcs12](././zwe-certificate-pkcs12) > [lock](./zwe-certificate-pkcs12-lock)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [pkcs12](././zwe-certificate-pkcs12.md) > [lock](./zwe-certificate-pkcs12-lock.md)
 
 	zwe certificate pkcs12 lock [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-trust-service.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12-trust-service.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12 trust-service
 
-[zwe](./../.././zwe) > [certificate](./.././zwe-certificate) > [pkcs12](././zwe-certificate-pkcs12) > [trust-service](./zwe-certificate-pkcs12-trust-service)
+[zwe](./../.././zwe.md) > [certificate](./.././zwe-certificate.md) > [pkcs12](././zwe-certificate-pkcs12.md) > [trust-service](./zwe-certificate-pkcs12-trust-service.md)
 
 	zwe certificate pkcs12 trust-service [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/pkcs12/zwe-certificate-pkcs12.md
@@ -1,6 +1,6 @@
 # zwe certificate pkcs12
 
-[zwe](../.././zwe) > [certificate](.././zwe-certificate) > [pkcs12](./zwe-certificate-pkcs12)
+[zwe](../.././zwe.md) > [certificate](.././zwe-certificate.md) > [pkcs12](./zwe-certificate-pkcs12.md)
 
 	zwe certificate pkcs12 [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/zwe-certificate-verify-service.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/zwe-certificate-verify-service.md
@@ -1,6 +1,6 @@
 # zwe certificate verify-service
 
-[zwe](./.././zwe) > [certificate](././zwe-certificate) > [verify-service](./zwe-certificate-verify-service)
+[zwe](./.././zwe.md) > [certificate](././zwe-certificate.md) > [verify-service](./zwe-certificate-verify-service.md)
 
 	zwe certificate verify-service [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/certificate/zwe-certificate.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/certificate/zwe-certificate.md
@@ -1,6 +1,6 @@
 # zwe certificate
 
-[zwe](.././zwe) > [certificate](./zwe-certificate)
+[zwe](.././zwe.md) > [certificate](./zwe-certificate.md)
 
 	zwe certificate [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/install/zwe-components-install-extract.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/install/zwe-components-install-extract.md
@@ -1,6 +1,6 @@
 # zwe components install extract
 
-[zwe](./../.././zwe) > [components](./.././zwe-components) > [install](././zwe-components-install) > [extract](./zwe-components-install-extract)
+[zwe](./../.././zwe.md) > [components](./.././zwe-components.md) > [install](././zwe-components-install.md) > [extract](./zwe-components-install-extract.md)
 
 	zwe components install extract [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/install/zwe-components-install-process-hook.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/install/zwe-components-install-process-hook.md
@@ -1,6 +1,6 @@
 # zwe components install process-hook
 
-[zwe](./../.././zwe) > [components](./.././zwe-components) > [install](././zwe-components-install) > [process-hook](./zwe-components-install-process-hook)
+[zwe](./../.././zwe.md) > [components](./.././zwe-components.md) > [install](././zwe-components-install.md) > [process-hook](./zwe-components-install-process-hook.md)
 
 	zwe components install process-hook [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/install/zwe-components-install.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/install/zwe-components-install.md
@@ -1,6 +1,6 @@
 # zwe components install
 
-[zwe](../.././zwe) > [components](.././zwe-components) > [install](./zwe-components-install)
+[zwe](../.././zwe.md) > [components](.././zwe-components.md) > [install](./zwe-components-install.md)
 
 	zwe components install [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-disable.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-disable.md
@@ -1,6 +1,6 @@
 # zwe components disable
 
-[zwe](./.././zwe) > [components](././zwe-components) > [disable](./zwe-components-disable)
+[zwe](./.././zwe.md) > [components](././zwe-components.md) > [disable](./zwe-components-disable.md)
 
 	zwe components disable [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-enable.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-enable.md
@@ -1,6 +1,6 @@
 # zwe components enable
 
-[zwe](./.././zwe) > [components](././zwe-components) > [enable](./zwe-components-enable)
+[zwe](./.././zwe.md) > [components](././zwe-components.md) > [enable](./zwe-components-enable.md)
 
 	zwe components enable [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-search.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-search.md
@@ -1,6 +1,6 @@
 # zwe components search
 
-[zwe](./.././zwe) > [components](././zwe-components) > [search](./zwe-components-search)
+[zwe](./.././zwe.md) > [components](././zwe-components.md) > [search](./zwe-components-search.md)
 
 	zwe components search [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-uninstall.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-uninstall.md
@@ -1,6 +1,6 @@
 # zwe components uninstall
 
-[zwe](./.././zwe) > [components](././zwe-components) > [uninstall](./zwe-components-uninstall)
+[zwe](./.././zwe.md) > [components](././zwe-components.md) > [uninstall](./zwe-components-uninstall.md)
 
 	zwe components uninstall [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-upgrade.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components-upgrade.md
@@ -1,6 +1,6 @@
 # zwe components upgrade
 
-[zwe](./.././zwe) > [components](././zwe-components) > [upgrade](./zwe-components-upgrade)
+[zwe](./.././zwe.md) > [components](././zwe-components.md) > [upgrade](./zwe-components-upgrade.md)
 
 	zwe components upgrade [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/components/zwe-components.md
@@ -1,6 +1,6 @@
 # zwe components
 
-[zwe](.././zwe) > [components](./zwe-components)
+[zwe](.././zwe.md) > [components](./zwe-components.md)
 
 	zwe components [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/config/zwe-config-get.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/config/zwe-config-get.md
@@ -1,6 +1,6 @@
 # zwe config get
 
-[zwe](./.././zwe) > [config](././zwe-config) > [get](./zwe-config-get)
+[zwe](./.././zwe.md) > [config](././zwe-config.md) > [get](./zwe-config-get.md)
 
 	zwe config get [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/config/zwe-config-validate.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/config/zwe-config-validate.md
@@ -1,6 +1,6 @@
 # zwe config validate
 
-[zwe](./.././zwe) > [config](././zwe-config) > [validate](./zwe-config-validate)
+[zwe](./.././zwe.md) > [config](././zwe-config.md) > [validate](./zwe-config-validate.md)
 
 	zwe config validate [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/config/zwe-config.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/config/zwe-config.md
@@ -1,6 +1,6 @@
 # zwe config
 
-[zwe](.././zwe) > [config](./zwe-config)
+[zwe](.././zwe.md) > [config](./zwe-config.md)
 
 	zwe config [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-apfauth.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-apfauth.md
@@ -1,6 +1,6 @@
 # zwe init apfauth
 
-[zwe](./.././zwe) > [init](././zwe-init) > [apfauth](./zwe-init-apfauth)
+[zwe](./.././zwe.md) > [init](././zwe-init.md) > [apfauth](./zwe-init-apfauth.md)
 
 	zwe init apfauth [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-certificate.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-certificate.md
@@ -1,6 +1,6 @@
 # zwe init certificate
 
-[zwe](./.././zwe) > [init](././zwe-init) > [certificate](./zwe-init-certificate)
+[zwe](./.././zwe.md) > [init](././zwe-init.md) > [certificate](./zwe-init-certificate.md)
 
 	zwe init certificate [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-mvs.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-mvs.md
@@ -1,6 +1,6 @@
 # zwe init mvs
 
-[zwe](./.././zwe) > [init](././zwe-init) > [mvs](./zwe-init-mvs)
+[zwe](./.././zwe.md) > [init](././zwe-init.md) > [mvs](./zwe-init-mvs.md)
 
 	zwe init mvs [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-security.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-security.md
@@ -1,6 +1,6 @@
 # zwe init security
 
-[zwe](./.././zwe) > [init](././zwe-init) > [security](./zwe-init-security)
+[zwe](./.././zwe.md) > [init](././zwe-init.md) > [security](./zwe-init-security.md)
 
 	zwe init security [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-stc.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-stc.md
@@ -1,6 +1,6 @@
 # zwe init stc
 
-[zwe](./.././zwe) > [init](././zwe-init) > [stc](./zwe-init-stc)
+[zwe](./.././zwe.md) > [init](././zwe-init.md) > [stc](./zwe-init-stc.md)
 
 	zwe init stc [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-vsam.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init-vsam.md
@@ -1,6 +1,6 @@
 # zwe init vsam
 
-[zwe](./.././zwe) > [init](././zwe-init) > [vsam](./zwe-init-vsam)
+[zwe](./.././zwe.md) > [init](././zwe-init.md) > [vsam](./zwe-init-vsam.md)
 
 	zwe init vsam [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/init/zwe-init.md
@@ -1,6 +1,6 @@
 # zwe init
 
-[zwe](.././zwe) > [init](./zwe-init)
+[zwe](.././zwe.md) > [init](./zwe-init.md)
 
 	zwe init [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config-get.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config-get.md
@@ -1,6 +1,6 @@
 # zwe internal config get
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [config](././zwe-internal-config) > [get](./zwe-internal-config-get)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [config](././zwe-internal-config.md) > [get](./zwe-internal-config-get.md)
 
 	zwe internal config get [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config-output.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config-output.md
@@ -1,6 +1,6 @@
 # zwe internal config output
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [config](././zwe-internal-config) > [output](./zwe-internal-config-output)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [config](././zwe-internal-config.md) > [output](./zwe-internal-config-output.md)
 
 	zwe internal config output [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config-set.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config-set.md
@@ -1,6 +1,6 @@
 # zwe internal config set
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [config](././zwe-internal-config) > [set](./zwe-internal-config-set)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [config](././zwe-internal-config.md) > [set](./zwe-internal-config-set.md)
 
 	zwe internal config set [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/config/zwe-internal-config.md
@@ -1,6 +1,6 @@
 # zwe internal config
 
-[zwe](../.././zwe) > [internal](.././zwe-internal) > [config](./zwe-internal-config)
+[zwe](../.././zwe.md) > [internal](.././zwe-internal.md) > [config](./zwe-internal-config.md)
 
 	zwe internal config [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container-cleanup.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container-cleanup.md
@@ -1,6 +1,6 @@
 # zwe internal container cleanup
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [container](././zwe-internal-container) > [cleanup](./zwe-internal-container-cleanup)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [container](././zwe-internal-container.md) > [cleanup](./zwe-internal-container-cleanup.md)
 
 	zwe internal container cleanup [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container-init.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container-init.md
@@ -1,6 +1,6 @@
 # zwe internal container init
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [container](././zwe-internal-container) > [init](./zwe-internal-container-init)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [container](././zwe-internal-container.md) > [init](./zwe-internal-container-init.md)
 
 	zwe internal container init [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container-prestop.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container-prestop.md
@@ -1,6 +1,6 @@
 # zwe internal container prestop
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [container](././zwe-internal-container) > [prestop](./zwe-internal-container-prestop)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [container](././zwe-internal-container.md) > [prestop](./zwe-internal-container-prestop.md)
 
 	zwe internal container prestop [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/container/zwe-internal-container.md
@@ -1,6 +1,6 @@
 # zwe internal container
 
-[zwe](../.././zwe) > [internal](.././zwe-internal) > [container](./zwe-internal-container)
+[zwe](../.././zwe.md) > [internal](.././zwe-internal.md) > [container](./zwe-internal-container.md)
 
 	zwe internal container [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/start/zwe-internal-start-component.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/start/zwe-internal-start-component.md
@@ -1,6 +1,6 @@
 # zwe internal start component
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [start](././zwe-internal-start) > [component](./zwe-internal-start-component)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [start](././zwe-internal-start.md) > [component](./zwe-internal-start-component.md)
 
 	zwe internal start component [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/start/zwe-internal-start-prepare.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/start/zwe-internal-start-prepare.md
@@ -1,6 +1,6 @@
 # zwe internal start prepare
 
-[zwe](./../.././zwe) > [internal](./.././zwe-internal) > [start](././zwe-internal-start) > [prepare](./zwe-internal-start-prepare)
+[zwe](./../.././zwe.md) > [internal](./.././zwe-internal.md) > [start](././zwe-internal-start.md) > [prepare](./zwe-internal-start-prepare.md)
 
 	zwe internal start prepare [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/start/zwe-internal-start.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/start/zwe-internal-start.md
@@ -1,6 +1,6 @@
 # zwe internal start
 
-[zwe](../.././zwe) > [internal](.././zwe-internal) > [start](./zwe-internal-start)
+[zwe](../.././zwe.md) > [internal](.././zwe-internal.md) > [start](./zwe-internal-start.md)
 
 	zwe internal start [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/zwe-internal-get-launch-components.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/zwe-internal-get-launch-components.md
@@ -1,6 +1,6 @@
 # zwe internal get-launch-components
 
-[zwe](./.././zwe) > [internal](././zwe-internal) > [get-launch-components](./zwe-internal-get-launch-components)
+[zwe](./.././zwe.md) > [internal](././zwe-internal.md) > [get-launch-components](./zwe-internal-get-launch-components.md)
 
 	zwe internal get-launch-components [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/internal/zwe-internal.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/internal/zwe-internal.md
@@ -1,6 +1,6 @@
 # zwe internal
 
-[zwe](.././zwe) > [internal](./zwe-internal)
+[zwe](.././zwe.md) > [internal](./zwe-internal.md)
 
 	zwe internal [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/migrate/for/zwe-migrate-for-kubernetes.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/migrate/for/zwe-migrate-for-kubernetes.md
@@ -1,6 +1,6 @@
 # zwe migrate for kubernetes
 
-[zwe](./../.././zwe) > [migrate](./.././zwe-migrate) > [for](././zwe-migrate-for) > [kubernetes](./zwe-migrate-for-kubernetes)
+[zwe](./../.././zwe.md) > [migrate](./.././zwe-migrate.md) > [for](././zwe-migrate-for.md) > [kubernetes](./zwe-migrate-for-kubernetes.md)
 
 	zwe migrate for kubernetes [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/migrate/for/zwe-migrate-for.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/migrate/for/zwe-migrate-for.md
@@ -1,6 +1,6 @@
 # zwe migrate for
 
-[zwe](../.././zwe) > [migrate](.././zwe-migrate) > [for](./zwe-migrate-for)
+[zwe](../.././zwe.md) > [migrate](.././zwe-migrate.md) > [for](./zwe-migrate-for.md)
 
 	zwe migrate for [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/migrate/zwe-migrate.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/migrate/zwe-migrate.md
@@ -1,6 +1,6 @@
 # zwe migrate
 
-[zwe](.././zwe) > [migrate](./zwe-migrate)
+[zwe](.././zwe.md) > [migrate](./zwe-migrate.md)
 
 	zwe migrate [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/sample/sub/zwe-sample-sub-deep.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/sample/sub/zwe-sample-sub-deep.md
@@ -1,6 +1,6 @@
 # zwe sample sub deep
 
-[zwe](./../.././zwe) > [sample](./.././zwe-sample) > [sub](././zwe-sample-sub) > [deep](./zwe-sample-sub-deep)
+[zwe](./../.././zwe.md) > [sample](./.././zwe-sample.md) > [sub](././zwe-sample-sub.md) > [deep](./zwe-sample-sub-deep.md)
 
 	zwe sample sub deep [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/sample/sub/zwe-sample-sub-second.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/sample/sub/zwe-sample-sub-second.md
@@ -1,6 +1,6 @@
 # zwe sample sub second
 
-[zwe](./../.././zwe) > [sample](./.././zwe-sample) > [sub](././zwe-sample-sub) > [second](./zwe-sample-sub-second)
+[zwe](./../.././zwe.md) > [sample](./.././zwe-sample.md) > [sub](././zwe-sample-sub.md) > [second](./zwe-sample-sub-second.md)
 
 	zwe sample sub second [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/sample/sub/zwe-sample-sub.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/sample/sub/zwe-sample-sub.md
@@ -1,6 +1,6 @@
 # zwe sample sub
 
-[zwe](../.././zwe) > [sample](.././zwe-sample) > [sub](./zwe-sample-sub)
+[zwe](../.././zwe.md) > [sample](.././zwe-sample.md) > [sub](./zwe-sample-sub.md)
 
 	zwe sample sub [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/sample/zwe-sample-test.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/sample/zwe-sample-test.md
@@ -1,6 +1,6 @@
 # zwe sample test
 
-[zwe](./.././zwe) > [sample](././zwe-sample) > [test](./zwe-sample-test)
+[zwe](./.././zwe.md) > [sample](././zwe-sample.md) > [test](./zwe-sample-test.md)
 
 	zwe sample test [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/sample/zwe-sample.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/sample/zwe-sample.md
@@ -1,6 +1,6 @@
 # zwe sample
 
-[zwe](.././zwe) > [sample](./zwe-sample)
+[zwe](.././zwe.md) > [sample](./zwe-sample.md)
 
 	zwe sample [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/support/zwe-support-verify-fingerprints.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/support/zwe-support-verify-fingerprints.md
@@ -1,6 +1,6 @@
 # zwe support verify-fingerprints
 
-[zwe](./.././zwe) > [support](././zwe-support) > [verify-fingerprints](./zwe-support-verify-fingerprints)
+[zwe](./.././zwe.md) > [support](././zwe-support.md) > [verify-fingerprints](./zwe-support-verify-fingerprints.md)
 
 	zwe support verify-fingerprints [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/support/zwe-support.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/support/zwe-support.md
@@ -1,6 +1,6 @@
 # zwe support
 
-[zwe](.././zwe) > [support](./zwe-support)
+[zwe](.././zwe.md) > [support](./zwe-support.md)
 
 	zwe support [sub-command [sub-command]...] [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/zwe-diagnose.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/zwe-diagnose.md
@@ -1,6 +1,6 @@
 # zwe diagnose
 
-[zwe](././zwe) > [diagnose](./zwe-diagnose)
+[zwe](././zwe.md) > [diagnose](./zwe-diagnose.md)
 
 	zwe diagnose [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/zwe-install.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/zwe-install.md
@@ -1,6 +1,6 @@
 # zwe install
 
-[zwe](././zwe) > [install](./zwe-install)
+[zwe](././zwe.md) > [install](./zwe-install.md)
 
 	zwe install [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/zwe-start.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/zwe-start.md
@@ -1,6 +1,6 @@
 # zwe start
 
-[zwe](././zwe) > [start](./zwe-start)
+[zwe](././zwe.md) > [start](./zwe-start.md)
 
 	zwe start [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/zwe-stop.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/zwe-stop.md
@@ -1,6 +1,6 @@
 # zwe stop
 
-[zwe](././zwe) > [stop](./zwe-stop)
+[zwe](././zwe.md) > [stop](./zwe-stop.md)
 
 	zwe stop [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/zwe-version.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/zwe-version.md
@@ -1,6 +1,6 @@
 # zwe version
 
-[zwe](././zwe) > [version](./zwe-version)
+[zwe](././zwe.md) > [version](./zwe-version.md)
 
 	zwe version [parameter [parameter]...]
 

--- a/docs/appendix/zwe_server_command_reference/zwe/zwe.md
+++ b/docs/appendix/zwe_server_command_reference/zwe/zwe.md
@@ -1,6 +1,6 @@
 # zwe
 
-[zwe](./zwe)
+[zwe](./zwe.md)
 
 	zwe [sub-command [sub-command]...] [parameter [parameter]...]
 


### PR DESCRIPTION
Describe your pull request here:
The files that form the Reference section of Zowe Docs are updated. A markdown syntax is added to the links in those files to prevent the links from breaking.
There are approximately 270 instances.

List the file(s) included in this PR:
zwe-init-apfauth.md
zwe-init-certificate.md +
many.md +

CC: @Gautham-coder @gauravs-20 @ArooshLele @anaxceron @janan07 @balhar-jakub 

After creating the PR, follow the instructions in the comments.
