### PR TITLE
Add missing md to zowe-chat doc

### DIFF
--- a/docs/appendix/zowe-chat-command-reference/zos/job/job-article.md
+++ b/docs/appendix/zowe-chat-command-reference/zos/job/job-article.md
@@ -20,7 +20,7 @@ Manage z/OS jobs.  <!--job-description-->
 
 ## Options
 
-- [zos job list status](./list/zos-job-list-status#options)
+- [zos job list status](./list/zos-job-list-status.md#options)
 
     | Full name  | Alias | Type |
     | :---- | :----  | :---- |


### PR DESCRIPTION
This should fix a failing links issue.