### PR TITLE
Clarify location of zowe.config.json and zowe.config.user.json in glossary

### DIFF
--- a/docs/appendix/zowe-glossary.md
+++ b/docs/appendix/zowe-glossary.md
@@ -120,8 +120,7 @@ Services are deployed using one or more service instances, which share the same 
 #### Team configuration
 
 A method of storing and managing Zowe CLI and Zowe Explorer *team* and *user* profiles introduced in Zowe Version 2.
-
-This method saves team-specific profiles in the `zowe.config.json` configuration file and user-specific profiles in the `zowe.config.user.json` configuration file. The location of the configuration file determines whether these profiles are applied *globally* or *per project*.
+This method saves team-specific profiles in the *zowe.config.json* configuration file and user-specific profiles in the *zowe.config.user.json* configuration file. These profiles are stored locally on the user's client system (e.g., in Visual Studio Code) and determine whether they are applied *globally* (to all projects) or *per project*. This configuration is for managing Zowe CLI and Explorer settings on the local client and does not store or affect z/OS configurations.
 
 #### Web Explorers
 

--- a/docs/appendix/zowe-glossary.md
+++ b/docs/appendix/zowe-glossary.md
@@ -119,8 +119,7 @@ Services are deployed using one or more service instances, which share the same 
 
 #### Team configuration
 
-A method of storing and managing Zowe CLI and Zowe Explorer *team* and *user* profiles introduced in Zowe Version 2.
-This method saves team-specific profiles in the *zowe.config.json* configuration file and user-specific profiles in the *zowe.config.user.json* configuration file. These profiles are stored locally on the user's client system (e.g., in Visual Studio Code) and determine whether they are applied *globally* (to all projects) or *per project*. This configuration is for managing Zowe CLI and Explorer settings on the local client and does not store or affect z/OS configurations.
+This method saves team-specific profiles in the `zowe.config.json` configuration file and user-specific profiles in the `zowe.config.user.json` configuration file. These profiles are stored locally in the user's client OS file system (for example, when using Zowe Explorer for Visual Studio Code or IntelliJ IDEA) and determine whether they are applied *globally* (to all projects) or *per project*. This configuration manages Zowe CLI and Explorer settings on the local client and does not store or affect z/OS configurations.
 
 #### Web Explorers
 


### PR DESCRIPTION
Signed-off-by: Saurabh.saurabhsingh050806@gmail.com

Describe your pull request here:
This pull request updates the Zowe glossary documentation to clarify the explanation of team configuration and its context, specifically addressing whether the profiles are stored in VSCode or z/OS. Additionally, I have added a more detailed explanation to help users understand where these configurations are stored and how they are applied globally or per project.

List the file(s) included in this PR:
docs/stable/appendix/zowe-glossary.md (Updated the section related to team configuration and clarified the storage locations of configuration files

After creating the PR, follow the instructions in the comments.
* Review the changes made to the glossary documentation.
 * Check the clarity of the explanation regarding the storage of team and user profiles in the configuration files (zowe.config.json and zowe.config.user.json).
* If approved, proceed with merging this PR.
/labels doc glossary V2
