### PR TITLE
removing V2 sys demo link

### DIFF
--- a/docs/whats-new/release-notes/v3_2_0.md
+++ b/docs/whats-new/release-notes/v3_2_0.md
@@ -10,12 +10,6 @@ See [New features and enhancements](#new-features-and-enhancements) for a full l
 
 Zowe Version 3.2.0 contains the enhancements that are described in the following topics.
 
-:::info find out more
-To watch a demo of new enhancements and updated features included in a Zowe minor release, look for the release demo recording in the [Zowe V2 System Demo playlist](https://www.youtube.com/playlist?list=PL8REpLGaY9QGjSTAqZaWxLG_g-jW1qGmo) on YouTube.
-
-System demos are typically held the week after a minor release becomes available. Check the [Open Mainframe Project Calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/zowe) for the latest schedule.
-:::
-
 ### Server Install
 
 - Added an enhancement so that the `zwe` support command collects more environment details.

--- a/docs/whats-new/release-notes/v3_2_0.md
+++ b/docs/whats-new/release-notes/v3_2_0.md
@@ -41,11 +41,6 @@ This is an enhancement on its own, all it means is there is more flexibility ava
 
 ### Zowe CLI
 
-#### Zowe CLI (Core)
-
-#### Zowe CLI Imperative Framework
-
-
 #### DB2 Plug-in for Zowe CLI
 
 - Search data sets with regex patterns by passing the new `--regex` option into the search command. ([#2432](https://github.com/zowe/zowe-cli/issues/2432))
@@ -133,10 +128,6 @@ Zowe Version 3.2.0 contains the bug fixes that are described in the following to
 * HA instance ID is now used in the path to infinispan storage location (v3). ([#3960](https://github.com/zowe/api-layer/issues/3960))
 
 ### Zowe CLI
-
-#### Zowe CLI (Core)
-
-#### Zowe CLI Imperative Framework
 
 #### CICS Plug-in for Zowe CLI
 


### PR DESCRIPTION
Describe your pull request here: Removing old link for V2 system demos from release notes

List the file(s) included in this PR: docs\whats-new\release-notes\v3_2_0.md

After creating the PR, follow the instructions in the comments.
