### PR TITLE
Inform developers of defaults YAML option

### DIFF
--- a/docs/extend/packaging-zos-extensions.md
+++ b/docs/extend/packaging-zos-extensions.md
@@ -35,7 +35,7 @@ A typical component package consists of the following files and directories:
 
    For examples of manifests thoughout Zowe GitHub repositories, see the following links:
   
-     - [API Catalog manifest.yaml](https://github.com/zowe/api-layer/blob/v2.x.x/api-catalog-package/src/main/resources/manifest.yaml)
+     - [API Catalog manifest.yaml](https://github.com/zowe/api-layer/blob/v3.x.x/api-catalog-package/src/main/resources/manifest.yaml)
      - [Sample Node API and API Catalog extension manifest.yaml](https://github.com/zowe/sample-node-api/blob/master/manifest.yaml)
      - [Sample Zowe App Framework extension manifest.yaml](https://github.com/zowe/sample-trial-app/blob/master/manifest.yaml)
    


### PR DESCRIPTION
This is a small update to suggest a pattern I've seen extenders do that has been useful to them.
By shipping their own defaults YAML file, and telling users to append it to the overall config, they can reduce user actions upon installing an extension.

files changed
[docs/extend/packaging-zos-extensions.md](https://github.com/zowe/docs-site/pull/4525/files#diff-388b86598a43590a411488b297bc9583b1fcf194eb552bca1934351c23852dd7)