### PR TITLE
zowe-yaml-configuration.md: haInstance name is always lowercased

### DIFF
--- a/docs/appendix/zowe-yaml-configuration.md
+++ b/docs/appendix/zowe-yaml-configuration.md
@@ -693,6 +693,12 @@ All Zowe high availability instances should have a dedicated section under the `
 
 In this section, _ha-instance_ represents any Zowe high availability instance ID.
 
+:::note
+
+Each _ha-instance_ must be unique: the identification of every _ha-instance_ is done based on the lowercased name.
+
+:::
+
 For all high availability instances, these are the common definitions.
 
 - **haInstances._ha-instance_.hostname**  


### PR DESCRIPTION
Describe your pull request here:
This is valid (no schema errors detected) configuration:
```yaml
zowe:
  runtimeDirectory: /zowe
haInstances:
  FOO:
    sysname: abc
    hostname: example1.com
  foo:
    sysname: xyz
    hostname: example2.com
```
However due to the technical limitations, `FOO` and `foo` are not valid - case insensitive match is not expected for haInstaces.

List the file(s) included in this PR:
docs/appendix/zowe-yaml-configuration.md

After creating the PR, follow the instructions in the comments.
