### PR TITLE
Remove duplicate mvd-server-config entry to fix PDF generation

### DIFF
--- a/versioned_sidebars/version-v3.0.x-sidebars.json
+++ b/versioned_sidebars/version-v3.0.x-sidebars.json
@@ -985,7 +985,6 @@
             "extend/extend-desktop/mvd-apptoappcommunication",
             "extend/extend-desktop/mvd-iframecomm",
             "extend/extend-desktop/mvd-errorreportingui",
-            "extend/extend-desktop/mvd-server-config",
             "extend/extend-desktop/mvd-logutility"
           ]
         }


### PR DESCRIPTION
Describe your pull request here:
Remove duplicate `mvd-server-config` entry in the 3.0.x sidebar file (already present on L973) to prevent PDF generation from looping infinitely.

List the file(s) included in this PR:
versioned_sidebars/version-v3.0.x-sidebars.json

After creating the PR, follow the instructions in the comments.
