### PR TITLE
update release notes to call out z/os 3.2 support

### DIFF
--- a/docs/whats-new/release-notes/v2_18_2.md
+++ b/docs/whats-new/release-notes/v2_18_2.md
@@ -2,6 +2,8 @@
 
 Welcome to the Zowe Version 2.18.2 release!
 
+This release includes compatibility changes for the upcoming z/OS 3.2.
+
 See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 
 **Download v2.18.2 build**: Want to try new features as soon as possible? You can download the v2.18.2 build from [Zowe.org](https://www.zowe.org/download.html).
@@ -9,6 +11,11 @@ See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 ## New features and enhancements
 
 Zowe Version 2.18.2 contains the enhancements that are described in the following topics.
+
+### Zowe Application Framework
+
+#### ZSS
+* z/OS 3.2 is now supported. ([#538](https://github.com/zowe/zowe-common-c/pull/538))
 
 ### Zowe API Mediation Layer
 

--- a/versioned_docs/version-v2.18.x/whats-new/release-notes/v2_18_2.md
+++ b/versioned_docs/version-v2.18.x/whats-new/release-notes/v2_18_2.md
@@ -2,6 +2,8 @@
 
 Welcome to the Zowe Version 2.18.2 release!
 
+This release includes compatibility changes for the upcoming z/OS 3.2.
+
 See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 
 **Download v2.18.2 build**: Want to try new features as soon as possible? You can download the v2.18.2 build from [Zowe.org](https://www.zowe.org/download.html).
@@ -10,10 +12,16 @@ See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 
 Zowe Version 2.18.2 contains the enhancements that are described in the following topics.
 
+### Zowe Application Framework
+
+#### ZSS
+* z/OS 3.2 is now supported. ([#538](https://github.com/zowe/zowe-common-c/pull/538))
+
 ### Zowe API Mediation Layer
 
+- The configuration property `apiml.security.forwardHeader.trustedProxies` has been added to specify the regular expression pattern used to identify trusted proxies from which `X-Forwarded-*` headers are accepted and forwarded. This mitigates CVE-2025-41235. The API ML gateways (including cloud gateways) in [Multitenancy Configuration](/user-guide/api-mediation/api-mediation-multi-tenancy) are trusted by default. ([#4148](https://github.com/zowe/api-layer/pull/4148) and [#4188](https://github.com/zowe/api-layer/pull/4188))
 - A Java sample app has been added to assist users to authenticate client certificates. ([#4009](https://github.com/zowe/api-layer/issues/4009))
-- Users can now configure the connect and read timeout for Eureka HTTP client. ([#4046](https://github.com/zowe/api-layer/issues/4046))
+- Users can now configure the `connectTimeout` and `readTimeout` for Eureka HTTP client. ([#4046](https://github.com/zowe/api-layer/issues/4046))
 - Java 21 is now supported. ([#4027](https://github.com/zowe/api-layer/issues/4027))
 
 ## Bug fixes
@@ -22,6 +30,11 @@ Zowe Version 2.18.2 contains the bug fixes that are described in the following t
 
 ### Zowe API Mediation Layer
 
+- Fixed gateway returning empty auth keys from z/OSMF when `apiml.security.auth.zosmf.jwtAutoconfiguration` is set to `jwt`. ([#4092](https://github.com/zowe/api-layer/issues/4092))
+- Fixed an error where NPE in `ApimlPeerEurekaNode` stops heartbeats. ([#4195](https://github.com/zowe/api-layer/pull/4195))
+- Fixed logout implementation in API Catalog in which cookies from the browser were deleted but JWT against the Gateway instance of the Zowe installation are not invalidated. ([#4185](https://github.com/zowe/api-layer/pull/4185))
+- Applied fix for disabling infinispan diagnostics by default. ([#4170](https://github.com/zowe/api-layer/pull/4170))
+- Fixed a resource leak in the http client, whereby all objects are now closed after use. ([#4153](https://github.com/zowe/api-layer/pull/4153))
 - Added HSTS header when AT-TLS enabled for V2. ([#4071](https://github.com/zowe/api-layer/issues/4071))
 - Changed error code SERVICE_UNAVAILABLE to INTERNAL_SERVER_ERROR when ticket generation fails. ([#4043](https://github.com/zowe/api-layer/issues/4043))
 
@@ -30,7 +43,23 @@ Zowe Version 2.18.2 contains the bug fixes that are described in the following t
 #### DB2 Plug-in for Zowe CLI
 
 - Updated `tar-fs` transitive dependency to resolve technical debt. ([#177](https://github.com/zowe/zowe-cli-db2-plugin/pull/177))
-
 - Updated `axios` transitive dependency to resolve technical debt. ([#175](https://github.com/zowe/zowe-cli-db2-plugin/pull/175))
 
+### Zowe Explorer
+
+#### Zowe Explorer (Core)
+
+- See the [Zowe Explorer](https://github.com/zowe/zowe-explorer-vscode/blob/main/packages/zowe-explorer/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer API
+
+- See the [Zowe Explorer API](https://github.com/zowe/zowe-explorer-vscode/blob/main/packages/zowe-explorer-api/CHANGELOG.md) changelog for updates included in this release.
+
+####  Zowe Explorer FTP Extension
+
+- See the [Zowe Explorer FTP Extension](https://github.com/zowe/zowe-explorer-vscode/blob/main/packages/zowe-explorer-ftp-extension/CHANGELOG.md) changelog for updates included in this release.
+
+#### Zowe Explorer ESLint Plug-in
+
+- See the [Zowe Explorer ESLint Plug-in](https://github.com/zowe/zowe-explorer-vscode/blob/main/packages/eslint-plugin-zowe-explorer/CHANGELOG.md) changelog for updates included in this release.
 


### PR DESCRIPTION
Describe your pull request here:

This adds a soft compatibility claim for z/OS 3.2 with Zowe version 2.18.2.

List the file(s) included in this PR:

After creating the PR, follow the instructions in the comments.
