### PR TITLE
`systemrequirements-zos.md`: SDSF is required for `zwe init security | vsam`

### DIFF
--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -31,6 +31,7 @@ Be sure your z/OS system meets the following prerequisites:
 
   | Task | Command utilizing SDSF | Alternatives |
   |-----------|-------------------------------|-------------|
+  | [Security setup](configuring-security.md) | `zwe init security` | Submit `ZWESECUR` or `ZWENOSEC` manually or use `zwe init security --jcl` |
   | [Certificate setup](configure-certificates.md) | `zwe init certificate` | z/OSMF workflow "ZWEKRING", or the JCL samples "ZWEKRING" and those that begin with "ZWEIKR" can be used to create keyrings. |
   | [Authorize library](../appendix/zwe_server_command_reference/zwe/init/zwe-init-apfauth.md) | `zwe init apfauth` | Products that can issue the MVS `SETPROG APF` command or update `SYS1.PARMLIB(PROGxx)`. See examples in [`SZWESAMP(ZWESIPRG)`](https://github.com/zowe/zowe-install-packaging/blob/v3.x/staging/files/SZWESAMP/ZWESIPRG). |
   | [Starting Zowe](start-zowe-zos.md) | `zwe start` | Products that can issue the MVS `START` command upon Zowe's STC such as Sysview or EJES can be used instead. |

--- a/docs/user-guide/systemrequirements-zos.md
+++ b/docs/user-guide/systemrequirements-zos.md
@@ -34,6 +34,7 @@ Be sure your z/OS system meets the following prerequisites:
   | [Security setup](configuring-security.md) | `zwe init security` | Submit `ZWESECUR` or `ZWENOSEC` manually or use `zwe init security --jcl` |
   | [Certificate setup](configure-certificates.md) | `zwe init certificate` | z/OSMF workflow "ZWEKRING", or the JCL samples "ZWEKRING" and those that begin with "ZWEIKR" can be used to create keyrings. |
   | [Authorize library](../appendix/zwe_server_command_reference/zwe/init/zwe-init-apfauth.md) | `zwe init apfauth` | Products that can issue the MVS `SETPROG APF` command or update `SYS1.PARMLIB(PROGxx)`. See examples in [`SZWESAMP(ZWESIPRG)`](https://github.com/zowe/zowe-install-packaging/blob/v3.x/staging/files/SZWESAMP/ZWESIPRG). |
+  | [VSAM setup](initialize-vsam-dataset.md) | `zwe init vsam` | Submit `ZWECSRVS` or `ZWECSVSM` manually or use `zwe init vsam --jcl` |
   | [Starting Zowe](start-zowe-zos.md) | `zwe start` | Products that can issue the MVS `START` command upon Zowe's STC such as Sysview or EJES can be used instead. |
   | [Stopping Zowe](start-zowe-zos.md) | `zwe stop` | Products that can issue the MVS `STOP` command upon Zowe's STC such as Sysview or EJES can be used instead. |
   


### PR DESCRIPTION
Describe your pull request here:
Missing requirement, `zwe init security` and `zwe init vsam` always required `SDSF`.

List the file(s) included in this PR:
docs/user-guide/systemrequirements-zos.md

After creating the PR, follow the instructions in the comments.
