### PR TITLE
DRAFT: Reference for apiml.gateway.servicesToDisableRetry

### DIFF
--- a/docs/appendix/zowe-yaml-configuration.md
+++ b/docs/appendix/zowe-yaml-configuration.md
@@ -487,8 +487,8 @@ These configurations can be used under the `components.gateway` section:
   Specifies if the health check endpoint is accessible with or without authentication.  
 - **apiml.gateway.timeoutMillis**  
  Specifies the timeout for the connection to the services in milliseconds.
-- **apiml.gateway.servicesToDisableRetry**
- Specifies a comma-separated list of service IDs for which automatic retries are disabled. Disabling retry for particular service helps prevent potential memory issues when handling requests with large payloads to the service. This parameter applies to Zowe version 3.3.0 and later versions. 
+- **apiml.gateway.servicesToDisableRetry**  
+ Specifies a comma-separated list of service IDs for which automatic retries are disabled. Disabling retry for services where retries are not required helps prevent potential memory issues when handling requests with large payloads to the service. This parameter applies to Zowe version 3.3.0 and later versions. 
 - **apiml.security.x509.enabled**  
  Specifies if client certificate authentication functionality through ZSS is enabled. Set this parameter to `true` to enable the client certificate authentication functionality through ZSS.
 - **apiml.security.x509.externalMapperUrl**  


### PR DESCRIPTION
Reference for apiml.gateway.servicesToDisableRetry

TODO: 
- If there will be Zowe v3.3.0 RC2, it should go to v3.3.0, otherwise to 3.4.0
- Changelog for the corresponding version must be updated 