### PR TITLE
API ML: Adding info about APIML_ATTLS_LOAD_KEYRING

### DIFF
--- a/docs/user-guide/configuring-at-tls-for-zowe-server.md
+++ b/docs/user-guide/configuring-at-tls-for-zowe-server.md
@@ -46,11 +46,13 @@ The Discovery Service endpoints are not reachable by standard API Gateway routin
 Zowe v3 includes a new component named ZAAS (Zowe Authentication and Authorization Service). In AT-TLS-aware mode, calls to this service are all internal between API ML components. These must include the X.509 Client Certificate.
 :::
 
-### Limitations
+### AT-TLS with ICSF Hardware keyring
 
 If using AT-TLS with a z/OS Keyring backed by an ICSF hardware module, the only supported configuration is Zowe with z/OSMF authentication provider in JWT mode.
-A LTPA token and SAF provider cannot be used in this configuration because API ML cannot access the hardware key to sign its own tokens.
-Personal Access Tokens (PAT) are not supported in this configuration because API ML cannot access the hardware key to sign the tokens.
+An LTPA token, SAF provider and Personal Access Tokens (PAT) cannot be used in this configuration because API ML cannot access the hardware key to sign the tokens.
+Also, ensure you set the `APIML_ATTLS_LOAD_KEYRING` environment variable to `true` to prevent API ML from trying to read the keyring.
+
+If you want to use LTPA, SAF provider, or Personal Access Tokens you can configure zowe.yaml to use a keyring that is different from the one in AT-TLS, one that is not backed by an ICSF hardware module.
 
 ## AT-TLS rules
 

--- a/docs/user-guide/configuring-at-tls-for-zowe-server.md
+++ b/docs/user-guide/configuring-at-tls-for-zowe-server.md
@@ -48,19 +48,25 @@ Zowe v3 includes a new component named ZAAS (Zowe Authentication and Authorizati
 
 ### Limitations when using AT-TLS with ICSF Hardware keyring
 
-API Mediation Layer cannot currently read private keys if they are backed in a hardware module. When using AT-TLS with a z/OS Keyring backed by an ICSF hardware module, use one of the following options:
+API ML cannot currently read private keys if they reside in a hardware module. When using AT-TLS with a z/OS Keyring that resides by an ICSF hardware module, use one of the following options:
 
-#### 1. Prevent API Mediation Layer from reading the private key
+* [Prevent API Mediation Layer from reading the private key](#prevent-api-ml-from-reading-the-private-key)
+* [Use an alternative non-hardware keyring](#use-an-alternative-non-hardware-keyring)
 
-Set `environments.APIML_ATTLS_LOAD_KEYRING: true` in zowe.yaml to prevent API Mediation Layer from loading the keyring.
-The only supported configuration is Zowe with z/OSMF authentication provider in JWT mode.
-This mode requires both server and client AT-TLS enabled in zowe.yaml with full coverage of Inbound and Outbound rules.
+#### Prevent API ML from reading the private key
 
-**Note:** z/OSMF LTPA token, SAF native authentication provider and Personal Access Tokens (PAT) cannot be used in this configuration due to lack of a private key.
+Set `environments.APIML_ATTLS_LOAD_KEYRING: true` in zowe.yaml to prevent API ML from loading the keyring.
+The only supported configuration is Zowe with the z/OSMF authentication provider in JWT mode.
+This mode requires both server and client AT-TLS enabled in the zowe.yaml with full coverage of Inbound and Outbound rules.
 
-#### 2. Use an alternative non-hardware keyring
+:::note  
+The z/OSMF LTPA token, SAF native authentication provider, and Personal Access Tokens (PAT) cannot be used in this configuration as there is not a private key.
 
-Since handshakes are handled by AT-TLS, API Mediation Layer only requires a private key access to sign its own tokens when the configuration requires it:
+:::
+
+#### Use an alternative non-hardware keyring
+
+Since handshakes are handled by AT-TLS, API ML only requires private key access to sign API ML's own tokens when the configuration requires it:
 - Personal Access Tokens
 - SAF native provider (API ML signs its own JWT token in this scenario)
 - z/OSMF in LTPA mode: in this scenario z/OSMF does not issue a JWT token, so API ML signs a JWT that contains the LTPA token.

--- a/docs/user-guide/configuring-at-tls-for-zowe-server.md
+++ b/docs/user-guide/configuring-at-tls-for-zowe-server.md
@@ -48,7 +48,7 @@ Zowe v3 includes a new component named ZAAS (Zowe Authentication and Authorizati
 
 ### Limitations when using AT-TLS with ICSF Hardware keyring
 
-API ML cannot currently read private keys if they reside in a hardware module. When using AT-TLS with a z/OS Keyring that resides by an ICSF hardware module, use one of the following options:
+ API ML cannot currently read private keys if they reside in a hardware module. When using AT-TLS with a z/OS Keyring with private keys stored or managed by ICSF, use one of the following options:
 
 * [Prevent API Mediation Layer from reading the private key](#prevent-api-ml-from-reading-the-private-key)
 * [Use an alternative non-hardware keyring](#use-an-alternative-non-hardware-keyring)
@@ -66,10 +66,10 @@ The z/OSMF LTPA token, SAF native authentication provider, and Personal Access T
 
 #### Use an alternative non-hardware keyring
 
-Since handshakes are handled by AT-TLS, API ML only requires private key access to sign API ML's own tokens when the configuration requires it:
+Since handshakes are handled by AT-TLS, API ML only requires access to the private key to sign API ML's own tokens when the configuration requires it. The following scenarios require a private key so that API ML is able to sign these types of tokens:
 - Personal Access Tokens
-- SAF native provider (API ML signs its own JWT token in this scenario)
-- z/OSMF in LTPA mode: in this scenario z/OSMF does not issue a JWT token, so API ML signs a JWT that contains the LTPA token.
+- SAF native provider (API ML signs its own JWT  in this scenario)
+- z/OSMF in LTPA mode: in this scenario z/OSMF does not issue a JWT. API ML signs the JWT that contains the LTPA token.
 
 ## AT-TLS rules
 

--- a/docs/user-guide/configuring-at-tls-for-zowe-server.md
+++ b/docs/user-guide/configuring-at-tls-for-zowe-server.md
@@ -66,9 +66,9 @@ The z/OSMF LTPA token, SAF native authentication provider, and Personal Access T
 
 #### Use an alternative non-hardware keyring
 
-Since handshakes are handled by AT-TLS, API ML only requires access to the private key to sign API ML's own tokens when the configuration requires it. The following scenarios require a private key so that API ML is able to sign these types of tokens:
+Since handshakes are handled by AT-TLS, API ML only requires access to the private key to sign API ML's own tokens when the configuration requires it. The following scenarios require a private key so that API ML is able to sign API ML's own tokens:
 - Personal Access Tokens
-- SAF native provider (API ML signs its own JWT  in this scenario)
+- SAF native provider (API ML signs its own JWT in this scenario)
 - z/OSMF in LTPA mode: in this scenario z/OSMF does not issue a JWT. API ML signs the JWT that contains the LTPA token.
 
 ## AT-TLS rules


### PR DESCRIPTION
Describe your pull request here:
Adding information about AT-TLS running with keyring that is backed by ICSF hardware module.

List the file(s) included in this PR:
[docs/user-guide/configuring-at-tls-for-zowe-server.md](https://github.com/zowe/docs-site/compare/docs-staging...reboot/attls_load_keyring?expand=1#diff-08430cb4e9fa8f0e858d7cf5d97b92ba4fe47b35d1aa5cf0d99f45d7adb4c205)

After creating the PR, follow the instructions in the comments.
