### PR TITLE
Add registered trademark to Zowe where appropriate

### DIFF
--- a/docs/extend/zowe-conformance-program.md
+++ b/docs/extend/zowe-conformance-program.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Administered by the Open Mainframe Project, the Zowe&trade; Conformance Program aims to give users the confidence that when they use a product, app, or distribution that leverages Zowe, they can expect a high level of common functionality, interoperability, and user experience.  
+Administered by the Open Mainframe Project, the Zowe&reg; Conformance Program aims to give users the confidence that when they use a product, app, or distribution that leverages Zowe, they can expect a high level of common functionality, interoperability, and user experience.  
 
 Conformance provides Independent Software Vendors (ISVs), System Integrators (SIs), and end users greater confidence that their software will behave as expected. Just like Zowe, the Zowe Conformance Program will continue to evolve and is being developed by committers and contributors in the Zowe community.
 

--- a/docs/whats-new/release-notes/v2_18_0.md
+++ b/docs/whats-new/release-notes/v2_18_0.md
@@ -1,6 +1,6 @@
 # Version 2.18.0 (August 2024)
 
-Welcome to the Zowe Version 2.18.0 release!
+Welcome to the Zowe&reg; Version 2.18.0 release!
 
 See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 

--- a/docs/whats-new/release-notes/v2_18_1.md
+++ b/docs/whats-new/release-notes/v2_18_1.md
@@ -1,6 +1,6 @@
 # Version 2.18.1 (March 2025)
 
-Welcome to the Zowe Version 2.18.1 release!
+Welcome to the Zowe&reg; Version 2.18.1 release!
 
 See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 

--- a/docs/whats-new/release-notes/v2_18_2.md
+++ b/docs/whats-new/release-notes/v2_18_2.md
@@ -1,6 +1,6 @@
 # Version 2.18.2 (July 2025)
 
-Welcome to the Zowe Version 2.18.2 release!
+Welcome to the Zowe&reg; Version 2.18.2 release!
 
 This release includes compatibility changes for the upcoming z/OS 3.2.
 

--- a/docs/whats-new/release-notes/v2_18_3.md
+++ b/docs/whats-new/release-notes/v2_18_3.md
@@ -1,6 +1,6 @@
 # Version 2.18.3 (October 2025)
 
-Welcome to the Zowe Version 2.18.3 release!
+Welcome to the Zowe&reg; Version 2.18.3 release!
 
 See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 

--- a/docs/whats-new/release-notes/v3_0_0.md
+++ b/docs/whats-new/release-notes/v3_0_0.md
@@ -1,6 +1,6 @@
 # Version 3.0.0 (October 2024)
 
-Welcome to the Version 3.0.0 release of Zowe!
+Welcome to the Zowe&reg; Version 3.0.0 release!
 
 Version 3.0 introduced breaking changes and a number of new features.
 

--- a/docs/whats-new/release-notes/v3_1_0.md
+++ b/docs/whats-new/release-notes/v3_1_0.md
@@ -1,6 +1,6 @@
 # Version 3.1.0 (February 2025)
 
-Welcome to the Zowe Version 3.1.0 release!
+Welcome to the Zowe&reg; Version 3.1.0 release!
 
 See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 

--- a/docs/whats-new/release-notes/v3_1_1.md
+++ b/docs/whats-new/release-notes/v3_1_1.md
@@ -1,6 +1,6 @@
 # Version 3.1.1 (April 2025)
 
-Welcome to the Zowe Version 3.1.1 release!
+Welcome to the Zowe&reg; Version 3.1.1 release!
 
 See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 

--- a/docs/whats-new/release-notes/v3_2_0.md
+++ b/docs/whats-new/release-notes/v3_2_0.md
@@ -1,6 +1,6 @@
 # Version 3.2.0 (May 2025)
 
-Welcome to the Zowe Version 3.2.0 release!
+Welcome to the Zowe&reg; Version 3.2.0 release!
 
 See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 

--- a/docs/whats-new/release-notes/v3_3_0.md
+++ b/docs/whats-new/release-notes/v3_3_0.md
@@ -1,6 +1,6 @@
 # Version 3.3.0 (September 2025)
 
-Welcome to the Zowe Version 3.3.0 release!
+Welcome to the Zowe&reg; Version 3.3.0 release!
 
 See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 

--- a/docs/whats-new/release-notes/v3_3_1.md
+++ b/docs/whats-new/release-notes/v3_3_1.md
@@ -1,6 +1,6 @@
 # Version 3.3.1 (October 2025)
 
-Welcome to the Zowe Version 3.3.1 release!
+Welcome to the Zowe&reg; Version 3.3.1 release!
 
 See [New features and enhancements](#new-features-and-enhancements) for a full list of changes to the functionality. See [Bug fixes](#bug-fixes) for a list of issues addressed in this release.
 


### PR DESCRIPTION
Describe your pull request here: Add registered trademark to Zowe where appropriate. 
the Linux Foundation page of legal trademarks lists Zowe as a Registered Trademark and not TM:
https://www.linuxfoundation.org/legal/trademarks

This PR update appropriate pages in Zowe Docs to reflect Linux Foundation trademark standards

List the file(s) included in this PR:

After creating the PR, follow the instructions in the comments.
