### PR TITLE
fix: use latestVersion instead of current for version string

### DIFF
--- a/src/components/DownloadableFiles/DownloadableFiles.js
+++ b/src/components/DownloadableFiles/DownloadableFiles.js
@@ -234,7 +234,11 @@ function DownloadableFiles() {
   const { preferredVersion } = useDocsPreferredVersion();
   
   // Get the selected version - use preferred version if set, otherwise use latest
-  const selectedVersion = preferredVersion?.name || siteConfig.customFields.latestVersion;
+  // Note: "current" is Docusaurus's internal name for the latest version, so we map it to the actual version
+  const preferredVersionName = preferredVersion?.name;
+  const selectedVersion = (!preferredVersionName || preferredVersionName === "current") 
+    ? siteConfig.customFields.latestVersion 
+    : preferredVersionName;
 
   return (
     <>


### PR DESCRIPTION
Describe your pull request here:

Docusaurus returns `current` for the latest version, but this is not sufficient for building strings for the Zowe Docs PDF and other links in the "Downloadable files" section.

This fixes the downloadable files area so the latest version is printed as such (e.g. latest 3.4.x shows "v3.4.x"), and the links are now properly formatted.

List the file(s) included in this PR:

`src/components/DownloadableFiles/DownloadableFiles.js`
