### PR TITLE
Document extension naming and reservations

### DIFF
--- a/docs/appendix/server-component-identification.md
+++ b/docs/appendix/server-component-identification.md
@@ -1,0 +1,41 @@
+# Server Component Identification
+
+The following table details properties of the Zowe server-side components that can be used to identify the source of a message, job, or network activity.
+Values presented in the table are default values. You can change the values by updating variable values in the `zowe.yaml` file.
+
+For more information about variable names in the following table, see the [Zowe YAML configuration file reference](./zowe-yaml-configuration.md) in the References section.
+
+Most Components of Zowe are HTTPS servers. The ports of each and their default jobnames are listed below.
+The ports can be customized for each component by editing the value of `components.<component-name>.port` within the Zowe YAML file.
+Each Jobname has a default prefix of ZWE1, but that can be customized via the `zowe.job.prefix` value in the Zowe YAML file. The ports used are different between single-service deployment and multi-service deployment.
+
+
+| Port number | Category | Component(s) | Default Jobname     | Log Suffix | Purpose                                                                                                                                                                                                              |
+|------|------|--------------|---------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 7553 | API Mediation Layer | discovery    | ZWE1**AG**          | AGW        | Discovery server port which dynamic API services can issue APIs to register or unregister themselves.                                                                                                                |
+| 7554 | API Mediation Layer | gateway      | ZWE1**AG**          | AGW        | The northbound edge of the API Gateway used to accept client requests.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway. |
+| 7556 | App Framework | app-server   | ZWE1**DS** & ZWE1SV | D          | The Zowe Desktop (also known as ZLUX) port used to log in through web browsers.                                                                                                                                      |
+| 7557 | App Framework | zss          | ZWE1**SZ**          | SZ         | Z Secure Services (ZSS) provides REST API services to ZLUX, used by the File Editor application and other ZLUX applications in the Zowe Desktop.                                                                     |
+## Older, Multi-service APIML
+
+In versions prior to Zowe v3.4, APIML was composed of multiple jobs instead of just ZWE1AG operating on ports 7553 & 7554.
+This is seen when the Zowe YAML property "components.apiml.enabled: false" but other components such as gateway are enabled. It is no longer recommended.
+
+| Port number | Category | Component | Default Jobname | Log Suffix | Purpose |
+|------|------|------|------|------|------|
+| 7552 | API Mediation Layer | api-catalog | ZWE1**AC** | AAC | Used to view API swagger / openAPI specifications for registered API services in the API Catalog. |
+| 7553 | API Mediation Layer | discovery | ZWE1**AD** | ADS | Discovery server port which dynamic API services can issue APIs to register or unregister themselves. |
+| 7554 | API Mediation Layer | gateway | ZWE1**AG** | AGW | The northbound edge of the API Gateway used to accept client requests before routing them to registered API services.  This port must be exposed outside the z/OS network so clients (web browsers, VS Code, processes running the Zowe CLI) can reach the gateway. |
+| 7555 | API Mediation Layer | Caching Service | ZWE1**CS** | ACS | Port of the Caching Service that is used to share state between different Zowe instances in a high availability topology. |
+| 7558 | API Mediation Layer | zaas | ZWE1**AZ** | AZ | Used for the Zowe Authentication and Authorization Service. This port receives internal connections only. |
+
+
+## Application Server Jobname for Port
+
+The jobnames associated with the component "app-server" varies depending on whether cluster mode is enabled or not (default: enabled).
+
+| Cluster mode | Jobname for listener port | Jobname for worker processes |
+|---|---|---|
+| Enabled (Default) | Name of STC (default: ZWE1SV) | `zowe.job.prefix` + DS (default: ZWE1**DS**) |
+| Disabled | `zowe.job.prefix` + DS (default: ZWE1**DS**) | Not Applicable |
+

--- a/docs/extend/extend-zowe-overview.md
+++ b/docs/extend/extend-zowe-overview.md
@@ -22,11 +22,14 @@ To assist with extension development, see the following [Sample extensions](#sam
 
 ## Extending the server side
 
+Server extensions are delivered as a package that can contain one or more plug-ins to any part of the Zowe server install.
+To learn how to create a package based on the extension types below, see [Packing z/OS Extensions](./pacagking-zos-extensions).
+
 ### Extending Zowe API Mediation Layer 
 
 The API Mediation Layer extension primarily focuses on extending via onboarding services running as standalone services. These services are subsequently available in the API Catalog and can be accessed through the API Gateway. For more information about onboarding a service to the API Mediation Layer, see the [Onboarding Overview](./extend-apiml/onboard-overview.md). The API Mediation Layer squad also provides libraries to simplify the integration for multiple programming languages and different frameworks.
 
-### Developing for Zowe Application Framework
+### Extending Zowe Application Framework
 
 You can create application plug-ins to extend the capabilities of the Zowe™ Application Framework. An application plug-in is an installable set of files that present resources in a web-based user interface, as a set of RESTful services, or in a web-based user interface and as a set of RESTful services.
 

--- a/docs/extend/server-extension-identification.md
+++ b/docs/extend/server-extension-identification.md
@@ -1,0 +1,39 @@
+# Choosing an Identification
+
+Components and extensions within the Zowe server install are distinguished by their package ID, package name, log ID and jobname suffixes. This page documents each and provides recommendations.
+
+## Packaging
+
+### Manifest
+
+An extension's manifest file starts with `name` and `id` fields such as in this example
+
+```yaml
+name: log-viewer
+id: com.example.logview
+description: Log viewing product from Example Company
+```
+
+These fields should align with other extension content, such as Application Framework pluginDefinition.json fields or API Mediation Layer registration and API Catalog fields.
+
+See more about the manifest fields within the [Server component manifest file reference](../appendix/server-component-manifest.md).
+
+### Application Framework pluginDefinition.json
+
+Application Framework plug-ins have pluginDefinition.json files which describe their properties. Each plug-in is identified by the `identifier` field within that file, and it is recommended that this field be related to the manifest `id` field.
+
+See more about the pluginDefinition.json fields within the [Plug-ins definition and structure](./extend-desktop/mvd-plugindefandstruct.md).
+
+## Job Identification
+
+On z/OS, the Zowe servers have jobnames derived from the Zowe YAML property `zowe.job.prefix` and a jobname suffix that is related to the section of Zowe that each server belongs to, such as 'A' for APIML, and 'D' for the app-server component that provides the Desktop. You can see more about 
+
+Given the default job prefix of "ZWE1", the APIML gateway job would be named "ZWE1AG", and the app-server Desktop component would be named "ZWE1DS".
+
+The letter 'X' is reserved for eXtensions. You may have a job named for example ZWE1XABC.
+
+## Log Identification
+
+Similar to job identification, Zowe server components have log IDs that begin with "ZWE" and a letter related to the section of Zowe the server belongs to, such as where logs beginning with "ZWEA" belonging to the APIML components.
+
+Extension log IDs are recommended to start with the 3 letter prefix of their z/OS product code. The prefix "ZWEX" is also reserved for extension use if needed.

--- a/sidebars.js
+++ b/sidebars.js
@@ -674,6 +674,7 @@ module.exports = {
           label: "Fundamentals",
           items: [
             "extend/packaging-zos-extensions",
+            "extend/server-extension-identification",
             "extend/server-schemas",
             "extend/component-registries",
             "extend/lifecycling-with-zwesvstc",
@@ -932,6 +933,7 @@ module.exports = {
   ],
   "reference": [
     "appendix/server-datasets",
+    "appendix/server-component-identification",
     "appendix/server-component-manifest",
     "appendix/zowe-api-reference",
 


### PR DESCRIPTION
It was forgotten to document the reserved extension letter 'X' within the Zowe jobname naming convention as far as I can tell. This is used in products today, so I want to be sure people remember and leverage as needed.

This PR contains new sections detailing naming and identification that extensions can have, as well as some related pages to help connect the dots for readers.