### PR TITLE
Update authenticating-with-client-certificates.md

### DIFF
--- a/docs/user-guide/authenticating-with-client-certificates.md
+++ b/docs/user-guide/authenticating-with-client-certificates.md
@@ -68,18 +68,11 @@ If using the internal API ML mapper (default from Zowe v3) and the MAP / CERTMAP
   SETROPTS RACLIST(DIGTCERT, DIGTRING) REFRESH
   ```
 
-  :::tip
+  :::NOTE
+  In API Mediation Layer, the Internal mapper is enabled by default. The API Mediation Layer hence supports `DIGTNMAP` and adding the certificate to the user, whereas the 
+  `ZSS` mapper only supports adding the certificate to the user.
   To disable the API ML mapper, ensure that you set the parameter `components.gateway.apiml.security.useInternalMapper` to `false`.
-  If the internal mapper is disabled, then API ML only supports DIGTNMAP for certificate-to-user mapping.
-  If the internal mapper is enabled, then API ML supports the following:
-  - DIGTNMAP for certificate-to-user mapping.
-  - Adding the certificate to the user.
   :::
-
-  :::note
-  API ML currently only supports `DIGTNMAP` for certificate-to-user mapping.
-  :::
-
 
 </details>
 


### PR DESCRIPTION
List the file(s) included in this PR: authenticating-with-client-certificates.md
Describe your pull request here: Updated a Note for V3.

Here's the updated text:
In API Mediation Layer, the Internal mapper is enabled by default. The API Mediation Layer hence supports DIGTNMAP and adding the certificate to the user, whereas the ZSS mapper only supports adding the certificate to the user.
After creating the PR, follow the instructions in the comments.

CC: @ArooshLele @gauravs-20 