### PR TITLE
removing "technical preview" from Python SDK references

### DIFF
--- a/docs/getting-started/install-zowe-sdks.md
+++ b/docs/getting-started/install-zowe-sdks.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK
 
 ## Fundamentals
 
@@ -22,7 +22,7 @@ For detailed SDK documentation, see the following:
 - [Zowe Client Java SDK](https://github.com/Zowe-Java-SDK)
 - [Zowe Client Kotlin SDK](https://zowe.github.io/zowe-client-kotlin-sdk/)
 - [Zowe Client Node.js SDK](https://docs.zowe.org/stable/typedoc/index.html)
-- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/) *technical preview*
+- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/)
 - [Zowe SDK Sample Scripts](https://github.com/zowe/zowe-sdk-sample-scripts/)
 
 ## SDK software requirements and dependencies
@@ -71,7 +71,7 @@ npm install imperative.tgz
 npm install core-for-zowe-sdk.tgz
 ```
 
-### Python SDK *technical preview*
+### Python SDK
 
 If you install Python SDK packages from the [online registry](#installing-an-sdk-from-an-online-registry), the required dependencies are installed automatically.
 

--- a/docs/user-guide/providing-feedback-and-contributing-client-side.md
+++ b/docs/user-guide/providing-feedback-and-contributing-client-side.md
@@ -64,6 +64,6 @@ Go to the [Zowe Client Kotlin SDK issue list](https://github.com/zowe/zowe-clien
 
 Go to the [Zowe Client Node.js SDK issue list](https://github.com/zowe/zowe-cli/issues) to file an issue. Include all relevant information.
 
-### Filing an issue for Zowe Client Python SDK *technical preview*
+### Filing an issue for Zowe Client Python SDK
 
 Go to the [Zowe Client Python SDK issue list](https://github.com/zowe/zowe-client-python-sdk/issues) to file an issue. Include all relevant information.

--- a/docs/user-guide/sdks-using.md
+++ b/docs/user-guide/sdks-using.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK
 
 ## SDK documentation
 

--- a/versioned_docs/version-v3.0.x/getting-started/install-zowe-sdks.md
+++ b/versioned_docs/version-v3.0.x/getting-started/install-zowe-sdks.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK 
 
 ## Fundamentals
 
@@ -22,7 +22,7 @@ For detailed SDK documentation, see the following:
 - [Zowe Client Java SDK](https://github.com/Zowe-Java-SDK)
 - [Zowe Client Kotlin SDK](https://zowe.github.io/zowe-client-kotlin-sdk/)
 - [Zowe Client Node.js SDK](https://docs.zowe.org/stable/typedoc/index.html)
-- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/) *technical preview*
+- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/) 
 - [Zowe SDK Sample Scripts](https://github.com/zowe/zowe-sdk-sample-scripts/)
 
 ## SDK software requirements and dependencies
@@ -71,7 +71,7 @@ npm install imperative.tgz
 npm install core-for-zowe-sdk.tgz
 ```
 
-### Python SDK *technical preview*
+### Python SDK 
 
 If you install Python SDK packages from the [online registry](#installing-an-sdk-from-an-online-registry), the required dependencies are installed automatically.
 

--- a/versioned_docs/version-v3.0.x/user-guide/providing-feedback-and-contributing-client-side.md
+++ b/versioned_docs/version-v3.0.x/user-guide/providing-feedback-and-contributing-client-side.md
@@ -65,7 +65,7 @@ Go to the [Zowe Client Kotlin SDK issue list](https://github.com/zowe/zowe-clien
 
 Go to the [Zowe Client Node.js SDK issue list](https://github.com/zowe/zowe-cli/issues) to file an issue. Include all relevant information.
 
-### Filing an issue for Zowe Client Python SDK *technical preview*
+### Filing an issue for Zowe Client Python SDK 
 
 Go to the [Zowe Client Python SDK issue list](https://github.com/zowe/zowe-client-python-sdk/issues) to file an issue. Include all relevant information.
 

--- a/versioned_docs/version-v3.0.x/user-guide/sdks-using.md
+++ b/versioned_docs/version-v3.0.x/user-guide/sdks-using.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK 
 
 ## SDK documentation
 

--- a/versioned_docs/version-v3.1.x/getting-started/install-zowe-sdks.md
+++ b/versioned_docs/version-v3.1.x/getting-started/install-zowe-sdks.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK 
 
 ## Fundamentals
 
@@ -22,7 +22,7 @@ For detailed SDK documentation, see the following:
 - [Zowe Client Java SDK](https://github.com/Zowe-Java-SDK)
 - [Zowe Client Kotlin SDK](https://zowe.github.io/zowe-client-kotlin-sdk/)
 - [Zowe Client Node.js SDK](https://docs.zowe.org/stable/typedoc/index.html)
-- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/) *technical preview*
+- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/) 
 - [Zowe SDK Sample Scripts](https://github.com/zowe/zowe-sdk-sample-scripts/)
 
 ## SDK software requirements and dependencies
@@ -71,7 +71,7 @@ npm install imperative.tgz
 npm install core-for-zowe-sdk.tgz
 ```
 
-### Python SDK *technical preview*
+### Python SDK 
 
 If you install Python SDK packages from the [online registry](#installing-an-sdk-from-an-online-registry), the required dependencies are installed automatically.
 

--- a/versioned_docs/version-v3.1.x/user-guide/providing-feedback-and-contributing-client-side.md
+++ b/versioned_docs/version-v3.1.x/user-guide/providing-feedback-and-contributing-client-side.md
@@ -65,7 +65,7 @@ Go to the [Zowe Client Kotlin SDK issue list](https://github.com/zowe/zowe-clien
 
 Go to the [Zowe Client Node.js SDK issue list](https://github.com/zowe/zowe-cli/issues) to file an issue. Include all relevant information.
 
-### Filing an issue for Zowe Client Python SDK *technical preview*
+### Filing an issue for Zowe Client Python SDK 
 
 Go to the [Zowe Client Python SDK issue list](https://github.com/zowe/zowe-client-python-sdk/issues) to file an issue. Include all relevant information.
 

--- a/versioned_docs/version-v3.1.x/user-guide/sdks-using.md
+++ b/versioned_docs/version-v3.1.x/user-guide/sdks-using.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK 
 
 ## SDK documentation
 

--- a/versioned_docs/version-v3.2.x/getting-started/install-zowe-sdks.md
+++ b/versioned_docs/version-v3.2.x/getting-started/install-zowe-sdks.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK
 
 ## Fundamentals
 
@@ -22,7 +22,7 @@ For detailed SDK documentation, see the following:
 - [Zowe Client Java SDK](https://github.com/Zowe-Java-SDK)
 - [Zowe Client Kotlin SDK](https://zowe.github.io/zowe-client-kotlin-sdk/)
 - [Zowe Client Node.js SDK](https://docs.zowe.org/stable/typedoc/index.html)
-- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/) *technical preview*
+- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/)
 - [Zowe SDK Sample Scripts](https://github.com/zowe/zowe-sdk-sample-scripts/)
 
 ## SDK software requirements and dependencies
@@ -71,7 +71,7 @@ npm install imperative.tgz
 npm install core-for-zowe-sdk.tgz
 ```
 
-### Python SDK *technical preview*
+### Python SDK
 
 If you install Python SDK packages from the [online registry](#installing-an-sdk-from-an-online-registry), the required dependencies are installed automatically.
 

--- a/versioned_docs/version-v3.2.x/user-guide/providing-feedback-and-contributing-client-side.md
+++ b/versioned_docs/version-v3.2.x/user-guide/providing-feedback-and-contributing-client-side.md
@@ -65,7 +65,7 @@ Go to the [Zowe Client Kotlin SDK issue list](https://github.com/zowe/zowe-clien
 
 Go to the [Zowe Client Node.js SDK issue list](https://github.com/zowe/zowe-cli/issues) to file an issue. Include all relevant information.
 
-### Filing an issue for Zowe Client Python SDK *technical preview*
+### Filing an issue for Zowe Client Python SDK
 
 Go to the [Zowe Client Python SDK issue list](https://github.com/zowe/zowe-client-python-sdk/issues) to file an issue. Include all relevant information.
 

--- a/versioned_docs/version-v3.2.x/user-guide/sdks-using.md
+++ b/versioned_docs/version-v3.2.x/user-guide/sdks-using.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK 
 
 ## SDK documentation
 

--- a/versioned_docs/version-v3.3.x/getting-started/install-zowe-sdks.md
+++ b/versioned_docs/version-v3.3.x/getting-started/install-zowe-sdks.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK
 
 ## Fundamentals
 
@@ -22,7 +22,7 @@ For detailed SDK documentation, see the following:
 - [Zowe Client Java SDK](https://github.com/Zowe-Java-SDK)
 - [Zowe Client Kotlin SDK](https://zowe.github.io/zowe-client-kotlin-sdk/)
 - [Zowe Client Node.js SDK](https://docs.zowe.org/stable/typedoc/index.html)
-- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/) *technical preview*
+- [Zowe Client Python SDK](https://zowe-client-python-sdk.readthedocs.io/en/latest/)
 - [Zowe SDK Sample Scripts](https://github.com/zowe/zowe-sdk-sample-scripts/)
 
 ## SDK software requirements and dependencies
@@ -71,7 +71,7 @@ npm install imperative.tgz
 npm install core-for-zowe-sdk.tgz
 ```
 
-### Python SDK *technical preview*
+### Python SDK
 
 If you install Python SDK packages from the [online registry](#installing-an-sdk-from-an-online-registry), the required dependencies are installed automatically.
 

--- a/versioned_docs/version-v3.3.x/user-guide/providing-feedback-and-contributing-client-side.md
+++ b/versioned_docs/version-v3.3.x/user-guide/providing-feedback-and-contributing-client-side.md
@@ -64,7 +64,7 @@ Go to the [Zowe Client Kotlin SDK issue list](https://github.com/zowe/zowe-clien
 
 Go to the [Zowe Client Node.js SDK issue list](https://github.com/zowe/zowe-cli/issues) to file an issue. Include all relevant information.
 
-### Filing an issue for Zowe Client Python SDK *technical preview*
+### Filing an issue for Zowe Client Python SDK
 
 Go to the [Zowe Client Python SDK issue list](https://github.com/zowe/zowe-client-python-sdk/issues) to file an issue. Include all relevant information.
 

--- a/versioned_docs/version-v3.3.x/user-guide/sdks-using.md
+++ b/versioned_docs/version-v3.3.x/user-guide/sdks-using.md
@@ -8,7 +8,7 @@ The following SDKs are available.
 - Zowe Client Java SDK
 - Zowe Client Kotlin SDK
 - Zowe Client Node.js SDK
-- Zowe Client Python SDK *technical preview*
+- Zowe Client Python SDK
 
 ## SDK documentation
 


### PR DESCRIPTION
Describe your pull request here: Removing "technical preview" from references to Python SDK in Zowe V3 releases

List the file(s) included in this PR: many.md

After creating the PR, follow the instructions in the comments.
