### PR TITLE
Fix: typo in zowe-architecture.md

### DIFF
--- a/docs/contribute/contributing.md
+++ b/docs/contribute/contributing.md
@@ -10,7 +10,7 @@ Before contributing a documentation change to the repository, you should be fami
 * Slack: The Zowe Documentation team communicates using the Slack application. To learn about Slack, refer to the [Slack Help Center](https://slack.com/help). The Zowe team is part of the [Open Mainframe Project](https://openmainframeproject.slack.com) channel.
 * Markdown Language: The Zowe documentation is written in Markdown language. To learn about Markdown, refer to  [The Markdown Guide](https://www.markdownguide.org/).
 
-Contributions to Zowe documentation are reviewed before being committed to the repository. Commits needs to have Developer Certificate of Origin (DCO). Committing changes to the Zowe repository requires additional access rights. See https://github.com/zowe/community/blob/master/COMMITTERS.md. Also see Participating in Zowe Documentation for more details about roles and permissions.
+Contributions to Zowe documentation are reviewed before being committed to the repository. Commits need to have Developer Certificate of Origin (DCO). Committing changes to the Zowe repository requires additional access rights. See https://github.com/zowe/community/blob/master/COMMITTERS.md. Also see Participating in Zowe Documentation for more details about roles and permissions.
 
 ## Getting started checklist
 
@@ -102,7 +102,7 @@ Style:
     Example:
     - put &lt;pax-file-name&gt;.pax
 
-    - Where _pax-file-name_ is a variable that indicates the full name of the PAX file you download. For example, zoe-0.8.1.pax.
+    - Where _pax-file-name_ is a variable that indicates the full name of the PAX file you downloaded. For example, zoe-0.8.1.pax.
 
 #### Message text and prompts to the user
 

--- a/docs/contribute/contributing.md
+++ b/docs/contribute/contributing.md
@@ -10,7 +10,7 @@ Before contributing a documentation change to the repository, you should be fami
 * Slack: The Zowe Documentation team communicates using the Slack application. To learn about Slack, refer to the [Slack Help Center](https://slack.com/help). The Zowe team is part of the [Open Mainframe Project](https://openmainframeproject.slack.com) channel.
 * Markdown Language: The Zowe documentation is written in Markdown language. To learn about Markdown, refer to  [The Markdown Guide](https://www.markdownguide.org/).
 
-Contributions to Zowe documentation are reviewed before being committed to the repository. Commits need to have Developer Certificate of Origin (DCO). Committing changes to the Zowe repository requires additional access rights. See https://github.com/zowe/community/blob/master/COMMITTERS.md. Also see Participating in Zowe Documentation for more details about roles and permissions.
+Contributions to Zowe documentation are reviewed before being committed to the repository. Commits needs to have Developer Certificate of Origin (DCO). Committing changes to the Zowe repository requires additional access rights. See https://github.com/zowe/community/blob/master/COMMITTERS.md. Also see Participating in Zowe Documentation for more details about roles and permissions.
 
 ## Getting started checklist
 
@@ -102,7 +102,7 @@ Style:
     Example:
     - put &lt;pax-file-name&gt;.pax
 
-    - Where _pax-file-name_ is a variable that indicates the full name of the PAX file you downloaded. For example, zoe-0.8.1.pax.
+    - Where _pax-file-name_ is a variable that indicates the full name of the PAX file you download. For example, zoe-0.8.1.pax.
 
 #### Message text and prompts to the user
 

--- a/docs/getting-started/zowe-architecture.md
+++ b/docs/getting-started/zowe-architecture.md
@@ -21,7 +21,7 @@ The following diagram illustrates the high-level Zowe architecture using multi-s
 
 ![Zowe Architecture Diagram](../images/common/zowe-architecture.png)
 
-As with the single-service architecture diagram, the diagram for multi-service deplayment shows the default port numbers that are used by Zowe. These ports are dependent on each instance of Zowe and are held in the Zowe YAML configuration file.
+As with the single-service architecture diagram, the diagram for multi-service deployment shows the default port numbers that are used by Zowe. These ports are dependent on each instance of Zowe and are held in the Zowe YAML configuration file.
 
 </details>
 


### PR DESCRIPTION
fixes #5016 

Describe your pull request here:
Spelling mistake in docs/getting-started/zowe-architecture.md
'deplayment' -> 'deployment'

List the file(s) included in this PR:
docs/getting-started/zowe-architecture.md
