### PR TITLE
Add details on when password setup for user is required

### DIFF
--- a/docs/user-guide/address-authentication-requirements.md
+++ b/docs/user-guide/address-authentication-requirements.md
@@ -40,3 +40,7 @@ Requirements:
 Zowe requires **ACF2 APAR LU01316** to be applied when using the ACF2 security manager.
 
 For more information about OIDC authentication, see [Zowe API Mediation Layer OIDC Authentication](../extend/extend-apiml/api-mediation-oidc-authentication.md).
+
+## Client certificates and password requirements
+
+When using client certificate authentication, password requirements differ depending on whether you use the z/OSMF or SAF authentication provider. For details, see [Authenticating with client certificates](./authenticating-with-client-certificates.md#configure-your-zos-system-to-support-client-certificate-authentication-for-specific-users) and [Addressing UNIX System Services (USS) Requirements](./configure-uss.md#baseline-user-id-requirements).

--- a/docs/user-guide/authenticating-with-client-certificates.md
+++ b/docs/user-guide/authenticating-with-client-certificates.md
@@ -30,7 +30,7 @@ In order for a user to be valid for certificate authentication, ensure that the 
 
   * **z/OSMF authentication provider**: The user ID must have a password assigned. The password can be expired. Users without a password (NOPASSWORD/PROTECTED) or suspended users cannot authenticate with client certificates. Ensure that PassTickets are enabled for z/OSMF.
 
-  * **SAF authentication provider (e.g., RACF, ACF2, Top Secret)**: The user ID does not require a password for client certificate login or JWT token generation. However, a password must be set if the user needs to call services that rely on PassTickets (such as z/OSMF REST APIs or downstream services that use PassTicket authentication). Suspended users cannot authenticate in either case.
+  * **SAF authentication provider (RACF, ACF2, Top Secret)**: The user ID does not require a password for client certificate login or JWT token generation. However, a password must be set if the user needs to call services that rely on PassTickets (such as z/OSMF REST APIs or downstream services that use PassTicket authentication). Suspended users cannot authenticate in either case.
   
 * The user must have a valid OMVS segment defined and password set, and include a unique User ID (UID). This segment is required to allow access to Zowe and Unix System Services (USS) resources. For details about defining the OMVS segment, see [OMVS segment](../user-guide/configure-uss.md#omvs-segment) in _Addressing UNIX System Services (USS) Requirements_.
 

--- a/docs/user-guide/authenticating-with-client-certificates.md
+++ b/docs/user-guide/authenticating-with-client-certificates.md
@@ -26,7 +26,11 @@ Register the client certificate with the user IDs in your ESM.
 ### User prerequisites
 
 In order for a user to be valid for certificate authentication, ensure that the following prerequisites are met:
-* The user ID must have a password assigned. Note that while the user does not enter the password during certificate login, a valid password status is required by the ESM to map the identity and generate security tokens (like PassTickets).
+* Password requirements depend on your authentication provider:
+
+  * **z/OSMF authentication provider**: The user ID must have a password assigned. The password can be expired. Users without a password (NOPASSWORD/PROTECTED) or suspended users cannot authenticate with client certificates. Ensure that PassTickets are enabled for z/OSMF.
+
+  * **SAF authentication provider (e.g., RACF, ACF2, Top Secret)**: The user ID does not require a password for client certificate login or JWT token generation. However, a password must be set if the user needs to call services that rely on PassTickets (such as z/OSMF REST APIs or downstream services that use PassTicket authentication). Suspended users cannot authenticate in either case.
   
 * The user must have a valid OMVS segment defined and password set, and include a unique User ID (UID). This segment is required to allow access to Zowe and Unix System Services (USS) resources. For details about defining the OMVS segment, see [OMVS segment](../user-guide/configure-uss.md#omvs-segment) in _Addressing UNIX System Services (USS) Requirements_.
 

--- a/docs/user-guide/configure-uss.md
+++ b/docs/user-guide/configure-uss.md
@@ -38,9 +38,10 @@ To ensure successful authentication and operation through Zowe, verify that user
 
 * **Password Status**  
 Password requirements depend on your authentication provider:
+
   * **z/OSMF provider**: The user ID must have a password or passphrase enabled (not NOPASSWORD), even if using certificate-based authentication.
-  * **SAF provider (e.g., RACF, ACF2, Top Secret)**: Users authenticating with client certificates are not required to have a password for login. However, a password is required if the user needs PassTicket-based access to z/OSMF or downstream services. Suspended users cannot authenticate with client certificates in either case.
-  * For Zowe service IDs (e.g., `ZWESVUSR`, `ZWESIUSR`), ensure the password is set to non-expire to avoid service interruptions, regardless of provider.
+  * **SAF provider (RACF, ACF2, Top Secret)**: Users authenticating with client certificates are not required to have a password for login. However, a password is required if the user needs PassTicket-based access to z/OSMF or downstream services. Suspended users cannot authenticate with client certificates in either case.
+  * For Zowe service IDs (for example, `ZWESVUSR`, `ZWESIUSR`), ensure the password is set to `non-expire` to avoid service interruptions, regardless of the provider.
 
 * **TSO/OMVS Segment**  
 The ID must have a valid OMVS segment assigned.

--- a/docs/user-guide/configure-uss.md
+++ b/docs/user-guide/configure-uss.md
@@ -37,7 +37,10 @@ For information about OMVS segments, see the article _The OMVS segment in user p
 To ensure successful authentication and operation through Zowe, verify that user profiles meet the following criteria:
 
 * **Password Status**  
-The user ID must have a password or passphrase enabled (not NOPASSWORD), even if using certificate-based authentication. For Zowe service IDs, ensure the password is set to non-expire to avoid service interruptions.
+Password requirements depend on your authentication provider:
+  * **z/OSMF provider**: The user ID must have a password or passphrase enabled (not NOPASSWORD), even if using certificate-based authentication.
+  * **SAF provider (e.g., RACF, ACF2, Top Secret)**: Users authenticating with client certificates are not required to have a password for login. However, a password is required if the user needs PassTicket-based access to z/OSMF or downstream services. Suspended users cannot authenticate with client certificates in either case.
+  * For Zowe service IDs (e.g., `ZWESVUSR`, `ZWESIUSR`), ensure the password is set to non-expire to avoid service interruptions, regardless of provider.
 
 * **TSO/OMVS Segment**  
 The ID must have a valid OMVS segment assigned.


### PR DESCRIPTION
Co-Authored-By: Hermes (Various Models)

Describe your pull request here:
Depending on details such as authentication providers, it is possible that even when password is not directly user, the user needs to have a password.
This PR outlines when exactly is this happening

List the file(s) included in this PR:
docs/user-guide/address-authentication-requirements.md
docs/user-guide/authenticating-with-client-certificates.md
docs/user-guide/configure-uss.md

After creating the PR, follow the instructions in the comments.
