### PR TITLE
docs: Document advertisedIpAddress property and DVIPA hot-standby setup — GH#4409

### DIFF
--- a/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
+++ b/docs/extend/extend-apiml/onboard-spring-boot-enabler.md
@@ -275,6 +275,7 @@ apiml:
         hostname: <fill-your-hostname>                           # hostname can be externalized by specifying -Dapiml.service.hostname command line parameter
         port: <fill-your-port>                                    # port can be externalized by specifying -Dapiml.service.port command line parameter
         serviceIpAddress: <fill-your-ipAddress>                    # serviceIpAddress can be externalized by specifying -Dapiml.service.ipAddress command line parameter
+        advertisedIpAddress: <fill-your-ipAddress>               # (Optional) Overrides the Eureka-advertised IP address. Falls back to serviceIpAddress if not set. Use for DVIPA hot-standby deployments to advertise an LPAR-specific address different from the listen address.
 
         baseUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${apiml.service.port}
         contextPath: /${apiml.service.serviceId}      # By default the contextPath is set to be the same as apiml.service.serviceId, but doesn't have to be the same

--- a/docs/user-guide/configure-sysplex.md
+++ b/docs/user-guide/configure-sysplex.md
@@ -70,3 +70,99 @@ VIPADYNAMIC
         x.x.x.B  BACKUP                                         
 ENDVIPADYNAMIC
 ```
+
+## Configuring API ML for DVIPA hot-standby
+
+In a DVIPA hot-standby setup, all API ML Gateway instances in the Sysplex must listen on the same DVIPA address and port (so the Sysplex Distributor can route traffic to whichever LPAR is active). However, each instance must register with Eureka Discovery using a **unique, LPAR-specific address** so that all instances are independently discoverable.
+
+To support this, API ML introduces a new configuration property `apiml.service.advertisedIpAddress` that decouples the listen (bind) address from the Eureka-advertised address:
+
+| Property | Purpose |
+|---|---|
+| `apiml.service.ipAddress` | The network interface the server **binds to** for listening. In DVIPA hot-standby, this should be the DVIPA address. |
+| `apiml.service.advertisedIpAddress` | The IP address **advertised to Eureka Discovery**. In DVIPA hot-standby, this should be the LPAR-specific home address. |
+
+### Fallback behavior
+
+When `advertisedIpAddress` is not explicitly set, the system falls back in this order:
+
+1. `apiml.service.advertisedIpAddress` (if set, used as the Eureka-advertised address)
+2. `apiml.service.ipAddress` (fallback — preserves backward compatibility)
+3. `apiml.service.hostname` resolution (final fallback)
+
+This means **existing non-HA configurations continue to work without any changes** — the system behaves identically to previous versions when `advertisedIpAddress` is not set.
+
+### DVIPA hot-standby configuration example
+
+Suppose you have two LPARs in a Sysplex with these addresses:
+
+- **DVIPA:** `192.168.100.50` (shared, routes to the active Gateway)
+- **LPAR A home address:** `192.168.10.1`
+- **LPAR B home address:** `192.168.20.1`
+
+Configure the Zowe YAML for each LPAR as follows:
+
+**LPAR A (`zowe.yaml`):**
+```yaml
+haInstances:
+  lparA:
+    hostname: SYS1
+    components:
+      gateway:
+        apiml:
+          service:
+            ipAddress: 192.168.100.50
+            advertisedIpAddress: 192.168.10.1
+        port: 7554
+      discovery:
+        apiml:
+          service:
+            ipAddress: 192.168.100.50
+            advertisedIpAddress: 192.168.10.1
+```
+
+**LPAR B (`zowe.yaml`):**
+```yaml
+haInstances:
+  lparB:
+    hostname: SYS2
+    components:
+      gateway:
+        apiml:
+          service:
+            ipAddress: 192.168.100.50
+            advertisedIpAddress: 192.168.20.1
+        port: 7554
+      discovery:
+        apiml:
+          service:
+            ipAddress: 192.168.100.50
+            advertisedIpAddress: 192.168.20.1
+```
+
+**Key points:**
+- `apiml.service.ipAddress` is set to the same DVIPA (`192.168.100.50`) on both LPARs — the Tomcat server binds to the DVIPA.
+- `apiml.service.advertisedIpAddress` is set to each LPAR's **unique home address** (`192.168.10.1` for LPAR A, `192.168.20.1` for LPAR B) — Eureka receives distinct addresses and can track each instance independently.
+- The port must match the port configured in the Sysplex Distributor (`7554` in this example).
+
+### Verification
+
+After starting Zowe on both LPARs, verify that both Gateway instances are registered in Eureka Discovery:
+
+1. Open the Eureka Discovery dashboard at `https://<hostname>:<discovery-port>`.
+2. Under **Instances currently registered with Eureka**, look for `GATEWAY` in the Application column.
+3. You should see two Gateway instances listed with distinct instance IDs (e.g., `SYS1:gateway:7554` and `SYS2:gateway:7554`), confirming that both instances have successfully registered despite sharing the same DVIPA listen address.
+
+### Zowe YAML configuration paths
+
+The `advertisedIpAddress` property can be set per component at these YAML paths:
+
+| Component | YAML path |
+|---|---|
+| Gateway | `components.gateway.apiml.service.advertisedIpAddress` |
+| Discovery Service | `components.discovery.apiml.service.advertisedIpAddress` |
+| API Catalog | `components.catalog.apiml.service.advertisedIpAddress` |
+| ZAAS | `components.zaas.apiml.service.advertisedIpAddress` |
+| Caching Service | `components.caching-service.apiml.service.advertisedIpAddress` |
+
+For HA deployments, set these under the appropriate `haInstances.<instance>.components.<service>.apiml.service.advertisedIpAddress` path.

--- a/docs/user-guide/zowe-ha-overview.md
+++ b/docs/user-guide/zowe-ha-overview.md
@@ -15,11 +15,13 @@ Do not attempt a Zowe HA setup until you have a non-HA Zowe setup that works.
 - z/OSMF is an optional prerequisite of Zowe. If your Zowe instance works with z/OSMF, it's recommended to [configure z/OSMF for high availability in Sysplex](./systemrequirements-zosmf-ha.md).
 - The `haInstances` section must be defined in the Zowe YAML configuration. Check [Zowe YAML Configuration File Reference](../appendix/zowe-yaml-configuration.md) for more details.
 - Zowe caching service is required to convert stateful component to stateless component. Check [Configuring the Caching Service for HA](./configure-caching-service-ha.md) for details.
+- For DVIPA hot-standby deployments, API ML services must be configured with the `advertisedIpAddress` property to decouple the listen address from the Eureka registration address. See [Configuring API ML for DVIPA hot-standby](./configure-sysplex.md#configuring-api-ml-for-dvipa-hot-standby) for the setup procedure.
 
 ### Known limitations
 
 - To allow Sysplex Distributor to route traffic to the Gateway, you can only start one Gateway in each LPAR within the Sysplex. All Gateways instances should be started on the same port configured on Sysplex Distributor.
 - Zowe App Server should be accessed through the Gateway with a URL like `https://<dvipa-domain>:<external-port>/zlux/ui/v1`.
+- **Hot-standby only:** Only one Gateway instance serves traffic at a time (the preferred LPAR). The backup Gateway instance is registered in Eureka but does not receive requests unless the preferred LPAR fails.
 
 ## Enable high availability when Zowe runs in Kubernetes
 


### PR DESCRIPTION
Closes https://github.com/zowe/api-layer/issues/4409

## Summary

Documents the new `apiml.service.advertisedIpAddress` property introduced in api-layer to support DVIPA hot-standby HA deployments on z/OS Sysplex.

## Changes

- **configure-sysplex.md:** Added new section "Configuring API ML for DVIPA hot-standby" with:
  - Property reference table (`ipAddress` vs `advertisedIpAddress`)
  - Fallback behavior description
  - Step-by-step DVIPA hot-standby configuration example for two LPARs
  - Verification steps using Eureka dashboard
  - Zowe YAML configuration path reference for all API ML components

- **zowe-ha-overview.md:** Added reference to the new DVIPA hot-standby configuration and noted the hot-standby limitation

- **onboard-spring-boot-enabler.md:** Added optional `advertisedIpAddress` property to the onboarding YAML example