### PR TITLE
Create Configuring PassTickets for z/OSMF auth

### DIFF
--- a/docs/extend/extend-apiml/api-medation-sso-integration-extenders.md
+++ b/docs/extend/extend-apiml/api-medation-sso-integration-extenders.md
@@ -94,6 +94,10 @@ It is necessary to provide a service APPLID in the `authentication.applid` param
 * If the downstream service needs to consume the user ID and the PassTicket from custom HTTP request headers (for example, to participate in the Zowe SSO), it is possible to provide the headers in the Gateway configuration.
 * The HTTP headers are then added to each request towards the downstream service. The headers contain the user ID and the PassTicket to be consumed by the service. For more information about the custom HTTP request headers, see [Adding a custom HTTP Auth header to store Zowe JWT](../../user-guide/api-mediation/configuration-extender-jwt.md#adding-a-custom-http-auth-header-to-store-zowe-jwt). 
 
+:::note
+Starting in Zowe v3.4.0, when the default SAF authentication provider is active, Zowe automatically configures its internal z/OSMF static routing definitions to use this exact `httpBasicPassTicket` scheme with the default z/OSMF APPLID (`IZUDFLT`).
+:::
+
 ```yaml
 authentication:
     scheme: httpBasicPassTicket
@@ -101,9 +105,13 @@ authentication:
 ```
 
 - `<applid>`  
-Specifies the APPLID value that is used by the API service for PassTicket support (for example, `OMVSAPPL`).
+Specifies the APPLID value that is used by the API service for PassTicket support. For standard z/OSMF routing under the SAF default authentication provider, this defaults to `IZUDFLT`. For custom extending services, this matches your specific service application ID (for example, `OMVSAPPL`).
 
-For more information, see [Enabling single sign on for extending services via PassTicket configuration](../../user-guide/api-mediation/configuration-extender-passtickets.md).
+Use the configuration that applies to your use case:
+
+* To configure PassTickets for core Zowe and z/OSMF functionality, see [Configuring PassTickets for z/OSMF Authentication](../../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md)
+
+* To configure PassTickets for an external extending service onboarding to API Mediation Layer, see [Enabling single sign on for extending services via PassTicket configuration](../../user-guide/api-mediation/configuration-extender-passtickets.md).
 
 ## Bypassing authentication for the service
 

--- a/docs/extend/extend-apiml/api-medation-sso-integration-extenders.md
+++ b/docs/extend/extend-apiml/api-medation-sso-integration-extenders.md
@@ -109,7 +109,7 @@ Specifies the APPLID value that is used by the API service for PassTicket suppor
 
 Use the configuration that applies to your use case:
 
-* To configure PassTickets for core Zowe and z/OSMF functionality, see [Configuring PassTickets for z/OSMF Authentication](../../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md)
+* To configure PassTickets for core Zowe and z/OSMF functionality, see [Addressing z/OSMF PassTicket and authentication requirements](../../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md)
 
 * To configure PassTickets for an external extending service onboarding to API Mediation Layer, see [Enabling single sign on for extending services via PassTicket configuration](../../user-guide/api-mediation/configuration-extender-passtickets.md).
 

--- a/docs/extend/extend-apiml/api-mediation-passtickets.md
+++ b/docs/extend/extend-apiml/api-mediation-passtickets.md
@@ -1,7 +1,12 @@
 # This article was changed and moved
 
-The information that used to be in the article **Configuring Zowe to use PassTickets** has been reorganized and is available in following articles: 
+The information that used to be in the article **Configuring Zowe to use PassTickets** has been reorganized and relocated based on your specific use case: 
 
-- For detailed information about configuring Zowe to use PassTickets, and to enable Zowe to use PassTickets to authenticate towards specific extending services, see [Enabling single sign on for extending services via PassTicket configuration](https://docs.zowe.org/stable/user-guide/api-mediation/configuration-extender-passtickets).
+* **Core Zowe Infrastructure & z/OSMF Setup (Zowe v3.4+)**  
+If you are installing or configuring Zowe v3.4.0 or higher with the default SAF authentication provider, configuring PassTickets for z/OSMF is a mandatory system requirement. For more information, see Configuring PassTickets for z/OSMF Authentication.
 
-- For detailed information about authentication parameters to enable a service to accept a Zowe JWT or client certificate, see [Authentication parameters](https://docs.zowe.org/stable/extend/extend-apiml/onboard-direct-eureka-call/#authentication-parameters) in the article _Onboarding a service with the Zowe API Mediation Layer without an onboarding enabler_.
+* **Extending Services Setup**  
+For detailed information about configuring API ML to generate PassTickets for custom, third-party extending REST API services onboarding onto Zowe, see [Enabling single sign on for extending services via PassTicket configuration](https://docs.zowe.org/stable/user-guide/api-mediation/configuration-extender-passtickets).
+
+* **Service Onboarding Parameters**  
+For detailed information about authentication parameters to enable a service to accept a Zowe JWT or client certificate, see [Authentication parameters](https://docs.zowe.org/stable/extend/extend-apiml/onboard-direct-eureka-call/#authentication-parameters) in the article _Onboarding a service with the Zowe API Mediation Layer without an onboarding enabler_.

--- a/docs/extend/extend-apiml/api-mediation-passtickets.md
+++ b/docs/extend/extend-apiml/api-mediation-passtickets.md
@@ -3,7 +3,7 @@
 The information that used to be in the article **Configuring Zowe to use PassTickets** has been reorganized and relocated based on your specific use case: 
 
 * **Core Zowe Infrastructure & z/OSMF Setup (Zowe v3.4+)**  
-If you are installing or configuring Zowe v3.4.0 or higher with the default SAF authentication provider, configuring PassTickets for z/OSMF is a mandatory system requirement. For more information, see Configuring PassTickets for z/OSMF Authentication.
+If you are installing or configuring Zowe v3.4.0 or higher with the default SAF authentication provider, configuring PassTickets for z/OSMF is a mandatory system requirement. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 
 * **Extending Services Setup**  
 For detailed information about configuring API ML to generate PassTickets for custom, third-party extending REST API services onboarding onto Zowe, see [Enabling single sign on for extending services via PassTicket configuration](https://docs.zowe.org/stable/user-guide/api-mediation/configuration-extender-passtickets).

--- a/docs/extend/extend-apiml/zaas-client.md
+++ b/docs/extend/extend-apiml/zaas-client.md
@@ -132,7 +132,7 @@ In return, this method provides a valid pass ticket as a String to the authorize
 :::tip
 Depending on whether you are requesting a PassTicket for core Zowe functions or a custom application, see the following resources for ESM setup instructions:
 
-* For core z/OSMF configuration (required for Zowe v3.4+ installations utilizing the default SAF authentication provider), see [Configuring PassTickets for z/OSMF Authentication](../../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md)
+* For core z/OSMF configuration (required for Zowe v3.4+ installations utilizing the default SAF authentication provider), see [Addressing z/OSMF PassTicket and authentication requirements](../../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md)
 
 * For third-party downstream services onboarding to API ML, see [Enabling single sign on for extending services via PassTicket configuration](../../user-guide/api-mediation/configuration-extender-passtickets.md).
 :::

--- a/docs/extend/extend-apiml/zaas-client.md
+++ b/docs/extend/extend-apiml/zaas-client.md
@@ -10,13 +10,15 @@ for detailed knowledge of the REST API calls presented in this section. The Clie
 
 This article contains the following topics:
 
-* [Pre-requisites](#pre-requisites)
-* [API Documentation](#api-documentation)
-    * [Obtain a JWT token (`login`)](#obtain-a-jwt-token-login)
-    * [Validate and get details from the token (`query`)](#validate-and-get-details-from-the-token-query)
-    * [Invalidate a JWT token (`logout`)](#invalidate-a-jwt-token-logout)
-    * [Obtain a PassTicket (`passTicket`)](#obtain-a-passticket-passticket)
-* [Getting Started (Step by Step Instructions)](#getting-started-step-by-step-instructions)
+- [ZAAS Client](#zaas-client)
+  - [Pre-requisites](#pre-requisites)
+  - [API Documentation](#api-documentation)
+    - [Obtain a JWT token (`login`)](#obtain-a-jwt-token-login)
+    - [Validate and get details from the token (`query`)](#validate-and-get-details-from-the-token-query)
+    - [Validate the OIDC token (`validateOidc`)](#validate-the-oidc-token-validateoidc)
+    - [Invalidate a JWT token (`logout`)](#invalidate-a-jwt-token-logout)
+    - [Obtain a PassTicket (`passTicket`)](#obtain-a-passticket-passticket)
+  - [Getting Started (Step by Step Instructions)](#getting-started-step-by-step-instructions)
 ## Pre-requisites
 
 - Java SDK version 1.8.
@@ -25,7 +27,7 @@ This article contains the following topics:
 
 ## API Documentation
 
-The plain java library provides the `ZaasClient` interface with following public methods:
+The plain Java library provides the `ZaasClient` interface with following public methods:
 
 ```java
 public interface ZaasClient {
@@ -128,7 +130,11 @@ This method has an added layer of security, whereby you do not have to provide a
 In return, this method provides a valid pass ticket as a String to the authorized user.
 
 :::tip
-For additional information about PassTickets in API ML see [Enabling single sign on for extending services via PassTicket configuration](../../user-guide/api-mediation/configuration-extender-passtickets.md).
+Depending on whether you are requesting a PassTicket for core Zowe functions or a custom application, see the following resources for ESM setup instructions:
+
+* For core z/OSMF configuration (required for Zowe v3.4+ installations utilizing the default SAF authentication provider), see [Configuring PassTickets for z/OSMF Authentication](../../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md)
+
+* For third-party downstream services onboarding to API ML, see [Enabling single sign on for extending services via PassTicket configuration](../../user-guide/api-mediation/configuration-extender-passtickets.md).
 :::
 
 ## Getting Started (Step by Step Instructions)

--- a/docs/user-guide/address-authentication-requirements.md
+++ b/docs/user-guide/address-authentication-requirements.md
@@ -2,7 +2,7 @@
 
 The following features are not required, but are recommended with additional prerequisites.
 
-:::info Roles required: security administrator
+:::info Required role: security administrator
 :::
 
 ## Multi-Factor Authentication (MFA)

--- a/docs/user-guide/address-security-requirements.md
+++ b/docs/user-guide/address-security-requirements.md
@@ -1,6 +1,6 @@
 # Addressing security requirements
 
-:::info Roles required: security administrator
+:::info Required role: security administrator
 :::
 
 During configuration of server-side components, it is necessary to configure various system security settings. Your

--- a/docs/user-guide/address-storage-requirements.md
+++ b/docs/user-guide/address-storage-requirements.md
@@ -1,6 +1,6 @@
 # Addressing storage requirements 
 
-:::info Roles required: storage administrator, system programmer
+:::info Required role: storage administrator, system programmer
 :::
 
 Ensure that you have sufficient storage depending on the installation method. Review the storage requirements according 

--- a/docs/user-guide/api-mediation-sso.md
+++ b/docs/user-guide/api-mediation-sso.md
@@ -54,13 +54,21 @@ The REST API of ZAAS can easily be called from a Java application using the [ZAA
 
 ### Existing services that cannot be modified
 
-If you have a service that cannot be changed to adopt the Zowe authentication token, the service can utilize Zowe SSO if the API service is able to handle PassTickets. 
+If an API service cannot be modified to natively validate the Zowe JWT access token, it can still participate in Zowe SSO if authentication is possible via standard z/OS PassTickets. When a client presents a valid Zowe token, the API Gateway automatically generates a one-time PassTicket and passes the PassTicket to the downstream service in the HTTP Basic Authentication header.
 
+Depending on the service you are connecting to, PassTicket configuration falls into one of two categories:
+
+* **Core Subsystems (z/OSMF)**  
+Starting in Zowe v3.4.0, when SAF is configured as your default authentication provider, API ML uses this PassTicket exchange mechanism to route core traffic to z/OSMF (`IZUDFLT`). This is a mandatory configuration requirement for standard Zowe installations.
+For installation steps, see [Configuring PassTickets for z/OSMF Authentication](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+
+* **Extending Services**  
+If you are onboarding an existing, non-Zowe REST interface to API Mediation Layer that relies on PassTickets for mainframe authentication, you must configure a unique APPLID and session key profile. For extension steps, see
 For more information, see [Enabling single sign on for extending services via PassTicket configuration](./api-mediation/configuration-extender-passtickets.md).
 
 ## Further resources
 
 * [Accessing multiple services with SSO](./cli-using-integrating-apiml.md#accessing-multiple-services-with-sso)
-* [Enabling single sign on for clients via JSON Web Token (JWT) configuration](./api-mediation/configuration-jwt.md)
+
 
 

--- a/docs/user-guide/api-mediation-sso.md
+++ b/docs/user-guide/api-mediation-sso.md
@@ -60,7 +60,7 @@ Depending on the service you are connecting to, PassTicket configuration falls i
 
 * **Core Subsystems (z/OSMF)**  
 Starting in Zowe v3.4.0, when SAF is configured as your default authentication provider, API ML uses this PassTicket exchange mechanism to route core traffic to z/OSMF (`IZUDFLT`). This is a mandatory configuration requirement for standard Zowe installations.
-For installation steps, see [Configuring PassTickets for z/OSMF Authentication](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+For installation steps, see [Addressing z/OSMF PassTicket and authentication requirements](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 
 * **Extending Services**  
 If you are onboarding an existing, non-Zowe REST interface to API Mediation Layer that relies on PassTickets for mainframe authentication, you must configure a unique APPLID and session key profile. For extension steps, see

--- a/docs/user-guide/api-mediation-sso.md
+++ b/docs/user-guide/api-mediation-sso.md
@@ -63,7 +63,7 @@ Starting in Zowe v3.4.0, when SAF is configured as your default authentication p
 For installation steps, see [Addressing z/OSMF PassTicket and authentication requirements](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 
 * **Extending Services**  
-If you are onboarding an existing, non-Zowe REST interface to API Mediation Layer that relies on PassTickets for mainframe authentication, you must configure a unique APPLID and session key profile. For extension steps, see
+If you are onboarding an existing, non-Zowe REST interface to API Mediation Layer that relies on PassTickets for mainframe authentication, you must configure a unique APPLID and session key profile. 
 For more information, see [Enabling single sign on for extending services via PassTicket configuration](./api-mediation/configuration-extender-passtickets.md).
 
 ## Further resources

--- a/docs/user-guide/api-mediation-sso.md
+++ b/docs/user-guide/api-mediation-sso.md
@@ -59,8 +59,8 @@ If an API service cannot be modified to natively validate the Zowe JWT access to
 Depending on the service you are connecting to, PassTicket configuration falls into one of two categories:
 
 * **Core Subsystems (z/OSMF)**  
-Starting in Zowe v3.4.0, when SAF is configured as your default authentication provider, API ML uses this PassTicket exchange mechanism to route core traffic to z/OSMF (`IZUDFLT`). This is a mandatory configuration requirement for standard Zowe installations.
-For installation steps, see [Addressing z/OSMF PassTicket and authentication requirements](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`) for all new installations performed via Portable Software Instance (**PSWI**), which is the recommended method for installing Zowe API Mediation Layer (API ML). API ML uses this PassTicket exchange mechanism to route core traffic to z/OSMF (`IZUDFLT`). This is a mandatory configuration requirement for standard Zowe installations. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+
 
 * **Extending Services**  
 If you are onboarding an existing, non-Zowe REST interface to API Mediation Layer that relies on PassTickets for mainframe authentication, you must configure a unique APPLID and session key profile. 

--- a/docs/user-guide/api-mediation/configuration-client-certificates.md
+++ b/docs/user-guide/api-mediation/configuration-client-certificates.md
@@ -33,7 +33,8 @@ The Zowe runtime user must be authorized to perform identity mapping in SAF. For
 * **z/OSMF Access**  
 The Zowe runtime user must be a member of the default `IZUUSER` group to log in to z/OSMF.
 * **PassTicket Generation**  
-The Zowe runtime user must be able to generate PassTickets for the user and for the z/OSMF `APPLID`. For more information, see [Configuring Zowe to use PassTickets](../api-mediation/configuration-extender-passtickets.md#configuring-zowe-to-use-passtickets).
+The Zowe runtime user must be able to generate PassTickets for the user and for the z/OSMF `APPLID`. For more information, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md)
+
 
 :::note
 There is a limitation with respect to performing authentication using Z Secure Services (ZSS) with ACF2 systems. If you are using ACF2, use the recommended Internal API ML Mapper.

--- a/docs/user-guide/api-mediation/configuration-client-certificates.md
+++ b/docs/user-guide/api-mediation/configuration-client-certificates.md
@@ -33,7 +33,7 @@ The Zowe runtime user must be authorized to perform identity mapping in SAF. For
 * **z/OSMF Access**  
 The Zowe runtime user must be a member of the default `IZUUSER` group to log in to z/OSMF.
 * **PassTicket Generation**  
-The Zowe runtime user must be able to generate PassTickets for the user and for the z/OSMF `APPLID`. For more information, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md)
+The Zowe runtime user must be able to generate PassTickets for the user and for the z/OSMF `APPLID`. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../api-mediation/configuring-passtickets-for-zosmf-authentication.md)
 
 
 :::note

--- a/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
+++ b/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
@@ -3,10 +3,24 @@
 :::info Roles: system programmer, API service extender
 :::
 
-Enabling Single Sign On (SSO) in Zowe involves configuring JWT tokens or PassTickets for secure authentication. The JWT token configuration requires setting up a custom HTTP header to store the token, thereby enhancing secure communication with southbound services. 
+Enabling Single Sign On (SSO) in Zowe involves configuring JSON Web Tokens (JWT) or PassTickets for secure authentication. 
 
-For more information, see [Enabling single sign on for extending services via JWT token configuration](./configuration-extender-jwt.md).
+## Configuring JWTs
 
-PassTicket configuration, alternatively, allows services that do not natively support JWT tokens or client certificates to authenticate via the API Gateway. This authentication process requires the activation of PassTicket support, recording the APPLID, and configuring the Zowe started task user ID. Additionally, custom HTTP headers can be set up for PassTickets and user IDs, ensuring secure and streamlined access within the Zowe ecosystem.
+The JWT configuration requires setting up a custom HTTP header to store the token, thereby enhancing secure communication with southbound services. 
 
-For more information, see [Enabling single sign on for extending services via PassTicket configuration](./configuration-extender-passtickets.md).
+For more information, see [Enabling single sign on for extending services via JSON Web Token (JWT) configuration](./configuration-extender-jwt.md).
+
+## Configuring PassTickets
+
+PassTicket configuration serves two distinct purposes within Zowe depending on your authentication architecture:
+
+* **Core Infrastructure (z/OSMF)**  
+Starting in Zowe v3.4.0, when SAF is used as the default authentication provider, the API Gateway relies on PassTickets to communicate with z/OSMF. This is a mandatory core installation step if z/OSMF is present on your system.
+
+To configure PassTickets for core Zowe and z/OSMF functionality, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+
+* **Extending Services**  
+PassTickets can also be used to allow third-party extending services that do not natively support JWT or client certificates to securely authenticate users via the API Gateway. This method requires activating PassTicket support, recording your custom service APPLID, and establishing dedicated application session keys.
+
+To configure PassTickets for a custom downstream service onboarding onto the API Mediation Layer, see [Enabling single sign on for extending services via PassTicket configuration](./configuration-extender-passtickets.md).

--- a/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
+++ b/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
@@ -15,8 +15,8 @@ For more information, see [Enabling single sign on for extending services via JS
 
 PassTicket configuration serves two distinct purposes within Zowe depending on your authentication architecture:
 
-* **Core Infrastructure (z/OSMF)**  
-Starting in Zowe v3.4.0, when SAF is used as the default authentication provider, the API Gateway relies on PassTickets to communicate with z/OSMF. This is a mandatory core installation step if z/OSMF is present on your system.
+* **Core Infrastructure (z/OSMF)**   
+Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`) for all new installations performed via Portable Software Instance (**PSWI**), which is the recommended method for installing Zowe API ML. Under this framework, authentication requests natively utilize SAF directly rather than routing explicitly through z/OSMF for initial validation. This is a mandatory core installation step if z/OSMF is present on your system.
 
 To configure PassTickets for core Zowe and z/OSMF functionality, see [Addressing z/OSMF PassTicket and authentication requirements](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 

--- a/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
+++ b/docs/user-guide/api-mediation/configuration-enable-single-sign-on-extenders.md
@@ -18,7 +18,7 @@ PassTicket configuration serves two distinct purposes within Zowe depending on y
 * **Core Infrastructure (z/OSMF)**  
 Starting in Zowe v3.4.0, when SAF is used as the default authentication provider, the API Gateway relies on PassTickets to communicate with z/OSMF. This is a mandatory core installation step if z/OSMF is present on your system.
 
-To configure PassTickets for core Zowe and z/OSMF functionality, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+To configure PassTickets for core Zowe and z/OSMF functionality, see [Addressing z/OSMF PassTicket and authentication requirements](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 
 * **Extending Services**  
 PassTickets can also be used to allow third-party extending services that do not natively support JWT or client certificates to securely authenticate users via the API Gateway. This method requires activating PassTicket support, recording your custom service APPLID, and establishing dedicated application session keys.

--- a/docs/user-guide/api-mediation/configuration-jwt.md
+++ b/docs/user-guide/api-mediation/configuration-jwt.md
@@ -13,15 +13,14 @@ As a system programmer, you can customize how JSON Web Token (JWT) authenticatio
 
 ## Using SAF as an authentication provider
 
-By default, the API Gateway uses z/OSMF as an authentication provider. It is possible to switch to SAF as the authentication
-provider instead of z/OSMF. The intended usage of SAF as an authentication provider is for systems without z/OSMF.
-If SAF is used and the z/OSMF is available on the system, the created tokens are not accepted by z/OSMF. Use
-the following procedure to switch to SAF. 
+Starting with Zowe v3.4.0, the API Gateway uses SAF as its default authentication provider (`apiml.security.auth.provider: saf`). Under this framework, authentication requests natively utilize SAF directly rather than routing explicitly through z/OSMF for initial validation.
+
+While the SAF provider allows Zowe API Mediation Layer (API ML) to run on systems where z/OSMF is completely absent, many deployments still require communication with z/OSMF for core runtime services. When SAF authentication is active and z/OSMF is available on the system, the API Gateway automatically interacts with z/OSMF using a static service definition configured with the `httpBasicPassticket` authentication scheme. To ensure that generated tokens and requests are accepted by z/OSMF in this configuration, you must authorize the Zowe started task to generate PassTickets for the z/OSMF APPLID. For more information, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
      
 1. Open the `zowe.yaml` configuration file.
-2. Find or add the following property, and set the value to `saf`:
+2. Find or add the following property, and ensure the value is set to `saf` to utilize SAF. Alternatively, you can change this value to `zosmf` if your environment explicitly mandates falling back to legacy z/OSMF direct authentication:
 ```
-components.gateway.apiml.security.auth.provider
+components.gateway.apiml.security.auth.provider: saf
 ```
 3. Restart Zowe.
 
@@ -29,9 +28,10 @@ Authentication requests now utilize SAF as the authentication provider. API ML c
 
 ## Enabling a JWT refresh endpoint
 
-Enable the `/gateway/api/v1/auth/refresh` endpoint to exchange a valid JWT for a new token with a new expiration date. Call the endpoint with a valid JWT and trusted client certificate. When using the z/OSMF authentication provider, enable API Mediation Layer for PassTicket generation and configure the z/OSMF APPLID. 
+Enable the `/gateway/api/v1/auth/refresh` endpoint to exchange a valid JWT for a new token with a new expiration date. Call the endpoint with a valid JWT and trusted client certificate. When utilizing either the SAF or z/OSMF authentication providers, you must ensure the API Mediation Layer is enabled for PassTicket generation and the z/OSMF APPLID is authorized.
 
-For more information, see [Configure PassTickets](configuration-extender-passtickets.md).
+For more information, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+
 
 1. Open the file `zowe.yaml`.
 2. Configure the following properties:

--- a/docs/user-guide/api-mediation/configuration-jwt.md
+++ b/docs/user-guide/api-mediation/configuration-jwt.md
@@ -13,16 +13,16 @@ As a system programmer, you can customize how JSON Web Token (JWT) authenticatio
 
 ## Using SAF as an authentication provider
 
-Starting with Zowe v3.4.0, the API Gateway uses SAF as its default authentication provider (`apiml.security.auth.provider: saf`). Under this framework, authentication requests natively utilize SAF directly rather than routing explicitly through z/OSMF for initial validation.
+Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`) for all new installations performed via Portable Software Instance (**PSWI**), which is the recommended method for installing Zowe API Mediation Layer (API ML). Under this framework, authentication requests natively utilize SAF directly rather than routing explicitly through z/OSMF for initial validation.
 
-While the SAF provider allows Zowe API Mediation Layer (API ML) to run on systems where z/OSMF is completely absent, many deployments still require communication with z/OSMF for core runtime services. When SAF authentication is active and z/OSMF is available on the system, the API Gateway automatically interacts with z/OSMF using a static service definition configured with the `httpBasicPassticket` authentication scheme. To ensure that generated tokens and requests are accepted by z/OSMF in this configuration, you must authorize the Zowe started task to generate PassTickets for the z/OSMF APPLID. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+While the SAF provider allows API ML to run on systems where z/OSMF is completely absent, many deployments still require communication with z/OSMF for core runtime services. When SAF authentication is active and z/OSMF is available on the system, the API Gateway automatically interacts with z/OSMF using a static service definition configured with the `httpBasicPassticket` authentication scheme. To ensure that generated tokens and requests are accepted by z/OSMF in this configuration, you must authorize the Zowe started task to generate PassTickets for the z/OSMF APPLID. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
      
 1. Open the `zowe.yaml` configuration file.
 2. Find or add the following property, and ensure the value is set to `saf` to utilize SAF. Alternatively, you can change this value to `zosmf` if your environment explicitly mandates falling back to legacy z/OSMF direct authentication:
 ```
 components.gateway.apiml.security.auth.provider: saf
 ```
-3. Restart Zowe.
+1. Restart Zowe.
 
 Authentication requests now utilize SAF as the authentication provider. API ML can run without z/OSMF present on the system. 
 
@@ -66,8 +66,8 @@ Authorization is used to set the access rights of an entity.
 
 In the API ML, authorization is performed by any of the following z/OS security managers:
 * [ACF2](https://www.broadcom.com/products/mainframe/identity-access/acf2)
-* [IBM RACF](https://www.ibm.com/support/knowledgecenter/zosbasics/com.ibm.zos.zsecurity/zsecc_042.htm)
 * [Top Secret](https://www.broadcom.com/products/mainframe/security/top-secret). 
+* [IBM RACF](https://www.ibm.com/support/knowledgecenter/zosbasics/com.ibm.zos.zsecurity/zsecc_042.htm)
 
 An authentication token is used as proof of valid authentication. The authorization checks, however, are always performed by the z/OS security manager.
 

--- a/docs/user-guide/api-mediation/configuration-jwt.md
+++ b/docs/user-guide/api-mediation/configuration-jwt.md
@@ -15,7 +15,7 @@ As a system programmer, you can customize how JSON Web Token (JWT) authenticatio
 
 Starting with Zowe v3.4.0, the API Gateway uses SAF as its default authentication provider (`apiml.security.auth.provider: saf`). Under this framework, authentication requests natively utilize SAF directly rather than routing explicitly through z/OSMF for initial validation.
 
-While the SAF provider allows Zowe API Mediation Layer (API ML) to run on systems where z/OSMF is completely absent, many deployments still require communication with z/OSMF for core runtime services. When SAF authentication is active and z/OSMF is available on the system, the API Gateway automatically interacts with z/OSMF using a static service definition configured with the `httpBasicPassticket` authentication scheme. To ensure that generated tokens and requests are accepted by z/OSMF in this configuration, you must authorize the Zowe started task to generate PassTickets for the z/OSMF APPLID. For more information, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+While the SAF provider allows Zowe API Mediation Layer (API ML) to run on systems where z/OSMF is completely absent, many deployments still require communication with z/OSMF for core runtime services. When SAF authentication is active and z/OSMF is available on the system, the API Gateway automatically interacts with z/OSMF using a static service definition configured with the `httpBasicPassticket` authentication scheme. To ensure that generated tokens and requests are accepted by z/OSMF in this configuration, you must authorize the Zowe started task to generate PassTickets for the z/OSMF APPLID. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
      
 1. Open the `zowe.yaml` configuration file.
 2. Find or add the following property, and ensure the value is set to `saf` to utilize SAF. Alternatively, you can change this value to `zosmf` if your environment explicitly mandates falling back to legacy z/OSMF direct authentication:
@@ -28,9 +28,9 @@ Authentication requests now utilize SAF as the authentication provider. API ML c
 
 ## Enabling a JWT refresh endpoint
 
-Enable the `/gateway/api/v1/auth/refresh` endpoint to exchange a valid JWT for a new token with a new expiration date. Call the endpoint with a valid JWT and trusted client certificate. When utilizing either the SAF or z/OSMF authentication providers, you must ensure the API Mediation Layer is enabled for PassTicket generation and the z/OSMF APPLID is authorized.
+Enable the `/gateway/api/v1/auth/refresh` endpoint to exchange a valid JWT for a new token with a new expiration date. Call the endpoint with a valid JWT and trusted client certificate. When utilizing either the SAF or z/OSMF authentication providers, you must ensure that API Mediation Layer is enabled for PassTicket generation and the z/OSMF APPLID is authorized.
 
-For more information, see [Configuring PassTickets for z/OSMF Authentication](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 
 
 1. Open the file `zowe.yaml`.

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -5,15 +5,15 @@ Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default auth
 :::info Required role: Security Administrator
 :::
 
-Use of SAF as the authentication provider requires that PassTicket generation permissions are configured for the z/OSMF application ID (APPLID) if your deployment routes traffic to z/OSMF via the API Gateway. Without this configuration, the API Gateway cannot securely validate requests against z/OSMF, causing core subsystem API requests to fail.
+The use of SAF as the authentication provider requires that PassTicket generation permissions are configured for the z/OSMF application ID (APPLID) if your deployment routes traffic to z/OSMF via the API Gateway. Without this configuration, the API Gateway cannot securely validate requests against z/OSMF, causing core subsystem API requests to fail.
 
 :::info
-This configuration grants the Zowe started task permissions to generate PassTickets specifically for the z/OSMF APPLID (`IZUDFLT`). It does not require generating a new application session key (`SSKEY`), establishing an application profile, or adjusting replay protection settings. Those settings are already managed globally by your operating system's z/OSMF installation.
+This configuration grants the Zowe started task permissions to generate PassTickets specifically for the z/OSMF APPLID (`IZUDFLT`). This configuration does not require generating a new application session key (`SSKEY`), establishing an application profile, or adjusting replay protection settings. Those settings are already managed globally by your operating system's z/OSMF installation.
 :::
 
 ## Prerequisites
 
-Before executing the commands below, ensure that your environment meets these criteria:
+Before executing the commands specified in this article, ensure that your environment meets these criteria:
 
 * **Zowe Version:** v3.4.0 or higher.
 
@@ -33,16 +33,14 @@ The User ID/Accessor ID assigned to the Zowe started task.
 
 ## Configure PassTicket permissions by ESM
 
-Choose the commands that correspond to your system's External Security Manager (ESM)to grant the Zowe runtime permission to generate PassTickets for z/OSMF.
+Choose the commands that correspond to your system's External Security Manager (ESM) to grant the Zowe runtime permission to generate PassTickets for z/OSMF.
 
 **Top Secret (TSS)**
-
-
 
 <details>
 <summary>Click here for command details for Top Secret (TSS).</summary>
 
-Authorize the Zowe started task Accessor ID (ACID) to generate PassTickets for the target z/OSMF instance by adding the following update permit:
+Authorize the Zowe started task Accessor ID (`ACID`) to generate PassTickets for the target z/OSMF instance by adding the following update permit:
 
 ```
 /* Grant update access to the Zowe started task ACID for the specific z/OSMF APPLID */
@@ -59,7 +57,7 @@ TSS REFRESH
 <details>
 <summary>Click here for command details for ACF2.</summary>
 
-Compile the resource rule inside the PassTicket (PTK) to validate and allow generation from the Zowe server user ID:
+Compile the resource rule inside the PassTicket (PTK) to validate, and allow generation from the Zowe server user ID:
 
 ```
 SET RESOURCE(PTK)
@@ -104,7 +102,7 @@ To verify that the permissions were correctly applied and that the Zowe started 
 TSS WHOHAS PTKTDATA(IRRPTAUTH.<zosmf-applid>.)
 ```
 
-Verify that the returned access mask confirms READ,UPDATE visibility for the Zowe ACID.
+Verify that the returned access confirms READ,UPDATE visibility for the Zowe ACID.
 
 </details>
 
@@ -118,7 +116,7 @@ SET RESOURCE(PTK)
 LIST LIKE(IRRPTAUTH-)
 ```
 
-Ensure that the compiled record properly lists the <zosmf-applid> rule containing your Zowe user ID's UID string match.
+Ensure that the compiled record properly lists the `<zosmf-applid>` rule containing your Zowe user ID's UID string match.
 
 </details>
 

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -1,4 +1,4 @@
-# Configuring PassTickets for z/OSMF Authentication
+# Addressing z/OSMF authentication requirements 
 
 Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`). Under this framework, API Mediation Layer (API ML) automatically communicates with z/OSMF using a static routing definition defined with the `httpBasicPassticket` authentication scheme.
 

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -1,0 +1,136 @@
+# Configuring PassTickets for z/OSMF Authentication
+
+Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`). Under this framework, API Mediation Layer (API ML) automatically communicates with z/OSMF using a static routing definition defined with the `httpBasicPassticket` authentication scheme.
+
+:::info Required role: Security Administrator
+:::
+
+Use of SAF as the authentication provider requires that PassTicket generation permissions are configured for the z/OSMF application ID (APPLID) if your deployment routes traffic to z/OSMF via the API Gateway. Without this configuration, the API Gateway cannot securely validate requests against z/OSMF, causing core subsystem API requests to fail.
+
+:::info
+This configuration grants the Zowe started task permissions to generate PassTickets specifically for the z/OSMF APPLID (`IZUDFLT`). It does not require generating a new application session key (`SSKEY`), establishing an application profile, or adjusting replay protection settings. Those settings are already managed globally by your operating system's z/OSMF installation.
+:::
+
+## Prerequisites
+
+Before executing the commands below, ensure that your environment meets these criteria:
+
+* **Zowe Version:** v3.4.0 or higher.
+
+* **Authentication Provider:** Configured for SAF (`apiml.security.auth.provider=saf` in your zowe.yaml).
+
+* **z/OSMF Status:** Installed, running, and active on your system.
+
+## Configuration Variables
+
+* **zosmf-applid**  
+The active APPLID assigned to your z/OSMF instance.  
+**Default:** `IZUDFLT`
+
+* **zowe-user-id**  
+The User ID/Accessor ID assigned to the Zowe started task.  
+**Default:** `ZWESVUSR`
+
+## Configure PassTicket permissions by ESM
+
+Choose the commands that correspond to your system's External Security Manager (ESM)to grant the Zowe runtime permission to generate PassTickets for z/OSMF.
+
+**Top Secret (TSS)**
+
+
+
+<details>
+<summary>Click here for command details for Top Secret (TSS).</summary>
+
+Authorize the Zowe started task Accessor ID (ACID) to generate PassTickets for the target z/OSMF instance by adding the following update permit:
+
+```
+/* Grant update access to the Zowe started task ACID for the specific z/OSMF APPLID */
+TSS PERMIT(<zowe-user-id>) PTKTDATA(IRRPTAUTH.<zosmf-applid>.) ACCESS(READ,UPDATE)
+
+/* Refresh the security environment to apply the update immediately */
+TSS REFRESH
+```
+
+</details>
+
+**ACF2**
+
+<details>
+<summary>Click here for command details for ACF2.</summary>
+
+Compile the resource rule inside the PassTicket (PTK) to validate and allow generation from the Zowe server user ID:
+
+```
+SET RESOURCE(PTK)
+
+/* Add permission for the Zowe started task user ID to use the PassTicket Auth path */
+RECKEY IRRPTAUTH ADD(<zosmf-applid>.- UID(<zowe-user-id>) SERVICE(UPDATE,READ) ALLOW)
+
+/* Rebuild the local active memory structures for PassTickets */
+F ACF2,REBUILD(PTK),CLASS(P)
+```
+</details>
+
+**IBM RACF**
+
+<details>
+<summary>Click here for command details for IBM RACF.</summary>
+
+Execute the following commands to define the `IRRPTAUTH` profile for z/OSMF inside the `PTKTDATA` class and authorize the Zowe started task user:
+
+```
+/* Define the profile for the z/OSMF APPLID within the PassTicket Auth class */
+RDEFINE PTKTDATA IRRPTAUTH.<zosmf-applid>.* UACC(NONE)
+
+/* Permit the Zowe user ID to generate PassTickets for z/OSMF */
+PERMIT IRRPTAUTH.<zosmf-applid>.* CLASS(PTKTDATA) ID(<zowe-user-id>) ACCESS(UPDATE)
+
+/* Refresh the PTKTDATA class storage to apply changes */
+SETROPTS RACLIST(PTKTDATA) REFRESH
+```
+</details>
+
+## Verify the configuration
+
+To verify that the permissions were correctly applied and that the Zowe started task user has the necessary administrative access, issue the command that corresponds to your ESM:
+
+**Top Secret (TSS) verification**
+
+<details>
+<summary>Click here for command verification command details for Top Secret. </summary>
+
+```
+TSS WHOHAS PTKTDATA(IRRPTAUTH.<zosmf-applid>.)
+```
+
+Verify that the returned access mask confirms READ,UPDATE visibility for the Zowe ACID.
+
+</details>
+
+**ACF2 verification**
+
+<details>
+<summary>Click here for command verification command details for ACF2. </summary>
+
+```
+SET RESOURCE(PTK)
+LIST LIKE(IRRPTAUTH-)
+```
+
+Ensure that the compiled record properly lists the <zosmf-applid> rule containing your Zowe user ID's UID string match.
+
+</details>
+
+**IBM RACF verification**
+
+<details>
+<summary>Click here for command verification command details for IBM RACF. </summary>
+
+```
+RLIST PTKTDATA IRRPTAUTH.<zosmf-applid>.* ALL
+```
+
+Verify that the output shows your Zowe started task user listed under USER ACCESS with UPDATE authority.
+
+</details>

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -35,7 +35,7 @@ The User ID/Accessor ID assigned to the Zowe started task.
 
 Choose the commands that correspond to your system's External Security Manager (ESM) to grant the Zowe runtime permission to generate PassTickets for z/OSMF.
 
-**Top Secret (TSS)**
+**Top Secret (TSS)** 
 
 <details>
 <summary>Click here for command details for Top Secret (TSS).</summary>
@@ -51,6 +51,7 @@ TSS REFRESH
 ```
 
 </details>
+</br>
 
 **ACF2**
 
@@ -69,6 +70,7 @@ RECKEY IRRPTAUTH ADD(<zosmf-applid>.- UID(<zowe-user-id>) SERVICE(UPDATE,READ) A
 F ACF2,REBUILD(PTK),CLASS(P)
 ```
 </details>
+</br>
 
 **IBM RACF**
 
@@ -105,6 +107,7 @@ TSS WHOHAS PTKTDATA(IRRPTAUTH.<zosmf-applid>.)
 Verify that the returned access confirms READ,UPDATE visibility for the Zowe ACID.
 
 </details>
+</br>
 
 **ACF2 verification**
 
@@ -119,6 +122,7 @@ LIST LIKE(IRRPTAUTH-)
 Ensure that the compiled record properly lists the `<zosmf-applid>` rule containing your Zowe user ID's UID string match.
 
 </details>
+</br>
 
 **IBM RACF verification**
 
@@ -132,5 +136,6 @@ RLIST PTKTDATA IRRPTAUTH.<zosmf-applid>.* ALL
 Verify that the output shows your Zowe started task user listed under USER ACCESS with UPDATE authority.
 
 </details>
+</br>
 
 Correct verification output indicates you successfully granted the Zowe runtime permission to generate PassTickets for z/OSMF.

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -51,7 +51,7 @@ TSS REFRESH
 ```
 
 </details>
-</br>
+<br />
 
 **ACF2**
 
@@ -70,7 +70,7 @@ RECKEY IRRPTAUTH ADD(<zosmf-applid>.- UID(<zowe-user-id>) SERVICE(UPDATE,READ) A
 F ACF2,REBUILD(PTK),CLASS(P)
 ```
 </details>
-</br>
+<br />
 
 **IBM RACF**
 
@@ -107,7 +107,7 @@ TSS WHOHAS PTKTDATA(IRRPTAUTH.<zosmf-applid>.)
 Verify that the returned access confirms READ,UPDATE visibility for the Zowe ACID.
 
 </details>
-</br>
+<br />
 
 **ACF2 verification**
 
@@ -122,7 +122,7 @@ LIST LIKE(IRRPTAUTH-)
 Ensure that the compiled record properly lists the `<zosmf-applid>` rule containing your Zowe user ID's UID string match.
 
 </details>
-</br>
+<br />
 
 **IBM RACF verification**
 
@@ -136,6 +136,6 @@ RLIST PTKTDATA IRRPTAUTH.<zosmf-applid>.* ALL
 Verify that the output shows your Zowe started task user listed under USER ACCESS with UPDATE authority.
 
 </details>
-</br>
+<br />
 
 Correct verification output indicates you successfully granted the Zowe runtime permission to generate PassTickets for z/OSMF.

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -1,6 +1,6 @@
 # Addressing z/OSMF PassTicket and authentication requirements 
 
-Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`). Under this framework, API Mediation Layer (API ML) automatically communicates with z/OSMF using a static routing definition defined with the `httpBasicPassticket` authentication scheme.
+Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`) for all new installations performed via Portable Software Instance (**PSWI**), which is the recommended method for installing Zowe API Mediation Layer (API ML). Under this framework, API ML automatically communicates with z/OSMF using a static routing definition defined with the `httpBasicPassticket` authentication scheme.
 
 :::info Required role: Security Administrator
 :::

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -1,4 +1,4 @@
-# Addressing z/OSMF authentication requirements 
+# Addressing z/OSMF PassTicket and authentication requirements 
 
 Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`). Under this framework, API Mediation Layer (API ML) automatically communicates with z/OSMF using a static routing definition defined with the `httpBasicPassticket` authentication scheme.
 

--- a/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
+++ b/docs/user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md
@@ -134,3 +134,5 @@ RLIST PTKTDATA IRRPTAUTH.<zosmf-applid>.* ALL
 Verify that the output shows your Zowe started task user listed under USER ACCESS with UPDATE authority.
 
 </details>
+
+Correct verification output indicates you successfully granted the Zowe runtime permission to generate PassTickets for z/OSMF.

--- a/docs/user-guide/authentication-providers-for-apiml.md
+++ b/docs/user-guide/authentication-providers-for-apiml.md
@@ -29,8 +29,8 @@ components.gateway.apiml.security.auth.provider: saf
 :::note
 
 In Zowe v3.4 and later versions, if the API Gateway is configured to use SAF authentication, z/OSMF APIs used by 
-Desktop Explorer apps authenticate using PassTickets instead of a JWT/LTPA token. As such, ensure that 
-PassTickets are configured and enabled for z/OSMF. 
+Desktop Explorer apps authenticate using PassTickets instead of a JWT/LTPA token. Due to this dependency, ensure that 
+PassTickets are configured and enabled for z/OSMF. For more information about how to configure PassTickets for z/OSMF authentication, see [Addressing z/OSMF PassTicket and authentication requirements](./api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 
 :::
 

--- a/docs/user-guide/authentication-providers-for-apiml.md
+++ b/docs/user-guide/authentication-providers-for-apiml.md
@@ -28,8 +28,7 @@ components.gateway.apiml.security.auth.provider: saf
 
 :::note
 
-In Zowe v3.4 and later versions, if the API Gateway is configured to use SAF authentication, z/OSMF APIs used by 
-Desktop Explorer apps authenticate using PassTickets instead of a JWT/LTPA token. Due to this dependency, ensure that 
+Starting in Zowe v3.4.0, System Authorization Facility (SAF) is the default authentication provider (`apiml.security.auth.provider=saf`) for all new installations performed via Portable Software Instance (**PSWI**), which is the recommended method for installing Zowe API Mediation Layer (API ML). Under this framework, authentication requests natively utilize SAF directly rather than routing explicitly through z/OSMF for initial validation. If the API Gateway is configured to use SAF authentication, z/OSMF APIs used by Desktop Explorer apps authenticate using PassTickets instead of a JWT/LTPA token. Due to this dependency, ensure that 
 PassTickets are configured and enabled for z/OSMF. For more information about how to configure PassTickets for z/OSMF authentication, see [Addressing z/OSMF PassTicket and authentication requirements](./api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 
 :::

--- a/docs/user-guide/systemrequirements-zosmf.md
+++ b/docs/user-guide/systemrequirements-zosmf.md
@@ -10,9 +10,8 @@ meta:
 
 Follow these steps described in this article to configure z/OSMF.
 
-:::note
-If you are not using Zowe CLI or Zowe Explorer and you are using API ML's recommended SAF authentication provider, 
-you can skip this pre-requisite.
+:::caution Important
+If you are not using Zowe CLI or Zowe Explorer and you are using API ML's recommended SAF authentication provider, it is necessary to configure PassTickets for z/OSMF authentication. This configuration is required to enable the API Gateway to securely validate requests against z/OSMF. For more information, see [Configuring PassTickets for z/OSMF Authentication](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 :::
 
 :::info Required roles: system programmer, security administrator, domain administrator
@@ -25,7 +24,7 @@ you can skip this pre-requisite.
   **Expected results:**  
   Part of the output contains the release, for example, `RELEASE z/OS 02.02.00`.
 
-2. Configure z/OSMF.
+1. Configure z/OSMF.
 
     z/OSMF is a base element of z/OS, so it is already installed. However, z/OSMF might not be configured and running on every z/OS system.
 

--- a/docs/user-guide/systemrequirements-zosmf.md
+++ b/docs/user-guide/systemrequirements-zosmf.md
@@ -11,7 +11,7 @@ meta:
 Follow these steps described in this article to configure z/OSMF.
 
 :::caution Important
-If you are not using Zowe CLI or Zowe Explorer and you are using API ML's recommended SAF authentication provider, it is necessary to configure PassTickets for z/OSMF authentication. This configuration is required to enable the API Gateway to securely validate requests against z/OSMF. For more information, see [Configuring PassTickets for z/OSMF Authentication](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+If you are not using Zowe CLI or Zowe Explorer and you are using API ML's recommended SAF authentication provider, it is necessary to configure PassTickets for z/OSMF authentication. This configuration is required to enable the API Gateway to securely validate requests against z/OSMF. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
 :::
 
 :::info Required roles: system programmer, security administrator, domain administrator

--- a/docs/user-guide/systemrequirements-zosmf.md
+++ b/docs/user-guide/systemrequirements-zosmf.md
@@ -11,7 +11,8 @@ meta:
 Follow these steps described in this article to configure z/OSMF.
 
 :::caution Important
-If you are not using Zowe CLI or Zowe Explorer and you are using API ML's recommended SAF authentication provider, it is necessary to configure PassTickets for z/OSMF authentication. This configuration is required to enable the API Gateway to securely validate requests against z/OSMF. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+If you are not using Zowe CLI or Zowe Explorer, and you are using API ML's recommended SAF authentication provider, it is necessary to configure PassTickets for z/OSMF authentication. This configuration is required to enable the API Gateway to securely validate requests against z/OSMF. For more information, see [Addressing z/OSMF PassTicket and authentication requirements](../user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication.md).
+
 :::
 
 :::info Required roles: system programmer, security administrator, domain administrator

--- a/sidebars.js
+++ b/sidebars.js
@@ -139,6 +139,7 @@ module.exports = {
             "user-guide/install-nodejs-zos",
             "user-guide/address-security-requirements",
             "user-guide/address-authentication-requirements",
+            "user-guide/api-mediation/configuring-passtickets-for-zosmf-authentication",
             "user-guide/configure-uss",
             "user-guide/address-storage-requirements",
             "user-guide/address-network-requirements",


### PR DESCRIPTION
Describe your pull request here: 
To continue support of zOSMF REST APIs, API ML generates a static definition with httpBasicPassticket authentication scheme. If API ML is not allowed to generate passtickets, these requests will fail.

The documentation in Zowe Docs covers the need to enable passtickets for z/OSMF.

List the file(s) included in this PR: 
configuring-passtickets-for -zosmf-authentication.md
authentication-providers-for-apiml.md
api-mediation-sso-integration-extenders.md
api-mediation-passtickets.md
zaas-client.md
configuration-client-certificates.md
configuration-enable-single-sign-on-extenders.md
configuration-jwt.md
api-mediation-sso.md
systemrequirements-zosmf.md
sidebars.js




After creating the PR, follow the instructions in the comments.
