### PR TITLE
docs: fix V2 artifacts and content issues in routing-requests-to-rest-apis.md

### DIFF
--- a/docs/user-guide/api-mediation/routing-requests-to-rest-apis.md
+++ b/docs/user-guide/api-mediation/routing-requests-to-rest-apis.md
@@ -1,13 +1,13 @@
 # Routing requests to REST APIs
 
-API consumers can access any services onboarded to the API Mediation Layer through a single port. In this context, 'service' refers to one or more instances that share the same API and are onboarded under the same service Id. Some services provide versioned APIs, while other services provide an unversioned API. From the consumer side, the API Mediation Layer takes care of situations in which one instance is down and/or ditributing the load between different instances of a service. 
+API consumers can access any services onboarded to the API Mediation Layer through a single port. In this context, 'service' refers to one or more instances that share the same API and are onboarded under the same service Id. Some services provide versioned APIs, while other services provide an unversioned API. From the consumer side, the API Mediation Layer takes care of situations in which one instance is down and/or distributing the load between different instances of a service.
 
 Types of services include both versioned and nonversioned services:
 
-* **Versioned services**  
+* **Versioned services**
 Routing with service ID and version
 
-* **Nonversioned services**  
+* **Nonversioned services**
 Using only the service ID
 
 Under certain conditions it is possible to route to a specific instance of service.
@@ -16,9 +16,9 @@ Under certain conditions it is possible to route to a specific instance of servi
 
 * **Service**
 
-  * A service provides one or more APIs, and is identified by a service ID. Note that sometimes the term "service name" is used to mean the service ID.  
-  * The default service ID is provided by the service developer in the service configuration file.  
-  * A system administrator can replace the service ID with a deployment environment specific name using additional configuration that is external to the service deployment unit. Most often, configuration is performed in a JAR or WAR file.  
+  * A service provides one or more APIs, and is identified by a service ID. Note that sometimes the term "service name" is used to mean the service ID.
+  * The default service ID is provided by the service developer in the service configuration file.
+  * A system administrator can replace the service ID with a deployment environment specific name using additional configuration that is external to the service deployment unit. Most often, configuration is performed in a JAR or WAR file.
   * Services are deployed using one or more service instances, which share the same service ID and implementation.
 
 * **URI (Uniform Resource Identifier)**
@@ -27,13 +27,13 @@ Under certain conditions it is possible to route to a specific instance of servi
 
 ## Basic Routing
 
-The basic method of routing is based on the service ID. For services that have multiple versions of an API, the secondary parameter is the version of the API that the user wants to reach. 
+The basic method of routing is based on the service ID. For services that have multiple versions of an API, the secondary parameter is the version of the API that the user wants to reach.
 
 ### API ML Routing to the Versioned service
 
 The URI identifies the resource, but does not identify the instance of the service as unique when multiple instances of the same service are provided, such as when a service is running in high-availability (HA) mode. To get to a specific instance, it is necessary to access the instance with a specific API ML configuration and header X-Instance-Id.
 
-In addition to the basic Zuul routing, the Zowe API Gateway supports versioning in which the user can specify a major version. The Gateway routes a request only to an instance that provides the specified major version of the API.
+In addition to basic routing, the Zowe API Gateway supports versioning in which the user can specify a major version. The Gateway routes a request only to an instance that provides the specified major version of the API.
 
 * The `/api/` prefix is used for REST APIs.
 * The prefix `/ui/` applies to web UIs
@@ -49,42 +49,24 @@ The URL expected by the API Gateway has the following format:
 The following address shows the original URL of a resource exposed by a service:
 
 ```
-https://service:10015/enablerv1sampleapp/api/v1/samples
+https://service:7554/enablerv1sampleapp/api/v1/samples
 ```
 
 The following address shows the API Gateway URL of the resource:
 
 ```
-https://gateway:10010/enablerv1sampleapp/api/v1/samples
+https://gateway:7554/enablerv1sampleapp/api/v1/samples
 ```
 
 The following diagram illustrates how basic routing works:
 
 ![Zowe API Mediation basic routing](../../images/api-mediation/Basic-Routing.png)
 
-### Implementation details for routing
+## High availability
 
+The API Gateway can be deployed in a high-availability configuration, such as on Sysplex, where multiple Gateway instances share a port and route requests across LPARs. This routing behavior is separate from the service ID/version routing described above.
 
-## Zowe architecture with high availability enablement on Sysplex
-
-The following diagram illustrates the difference in locations of Zowe components when deploying Zowe into a Sysplex with high availability enabled as opposed to running all components on a single z/OS system.  
-
-![Zowe Architecture Diagram with High Availability Enablement](../../images/common/zowe-architecture-lpar.png)
-
-Zowe has a high availability feature built-in. To enable this feature, you can define the `haInstances` section in your YAML configuration file.
-
-The preceding diagram shows that `ZWESLSTC` started two Zowe instances running on two separate LPARs. These LPARs can be on the same or different sysplexes.  
-
-- Sysplex distributor port sharing enables the API Gateway 7554 ports to be shared, which makes it possible for  incoming requests to be routed to either the Gateway on LPAR A or LPAR B.
-- The discovery servers on each LPAR communicate with each other and share their registered instances, which allows the API Gateway on LPAR A to dispatch APIs to components either on its own LPAR, or alternatively to components on LPAR B. As indicated in the diagram, each component has two input lines: one from the API Gateway on its own LPAR, and one from the Gateway on the other LPAR. When one of the LPARs goes down, the other LPAR remains operating within the sysplex, thereby providing high availability to clients that connect through the shared port irrespective of which Zowe instance is serving the API requests.
-
-The `zowe.yaml` file can be configured to start Zowe instances on more than two LPARS, and also to start more than one Zowe instance on a single LPAR, thereby providing a grid cluster of Zowe components that can meet availability and scalability requirements.  
-
-The configuration entries of each LPAR in the `zowe.yaml` file control which components are started. This configuration mechanism makes it possible to start just the desktop and API Mediation Layer on the first LPAR, and start all of the Zowe components on the second LPAR. Because the desktop on the first LPAR is available to the gateway of the second LPAR, all desktop traffic is routed to the second LPAR.  
-
-The caching services for each Zowe instance, whether on the same LPAR, or distributed across the sysplex, are connected to each other by the same shared VSAM data set. This arrangement allows state sharing so that each instance behaves similarly to the user irrespective of where their request is routed.  
-
-To learn more about Zowe with high availability enablement, see [Configuring Sysplex for high availability](../configure-sysplex.md).
+For details on deploying Zowe with high availability enabled, see [Configuring Sysplex for high availability](../configure-sysplex.md).
 
 ## API Versioning
 
@@ -98,17 +80,17 @@ The API user specifies only the major version in the URI. The API Catalog needs 
 
 - Two last versions are supported.
 
- - **Major version**  
+ - **Major version**
  This version is specified by the user of the API in the URI, and increased only when a backward incompatible change is introduced. This circumstance is rare because the REST APIs should be designed to allow extensibility.
 
- - **Minor version**  
+ - **Minor version**
  This version is not specified in the URI but the user should know what is it. It is important to display the correct level of documentation. The minor version is increased when the API is extended with a new feature (if you use a new resource available in v1.2, the request fails on v1.1). If there are multiple instances of the services that have different minor versions, the service together will state that the lowest minor version is available.
- 
+
  **Example:**
- 
+
  Instance A provide v1.3 and v2.2. Instance B was not yet upgraded and provides v1.2 and v2.1. Subsequently, the service provides v1.2 and v2.1.
 
- - **Patch version**  
+ - **Patch version**
  The Patch version is not specified in the URI and does not indicate a difference in the API. A patch version is used only when the API documentation is patched or a bug was fixed with no change in the API.
 
  ![API Versioning](../../images/api-mediation/API-Versioning.png)


### PR DESCRIPTION
Describe your pull request here:

Fixes V2-era artifacts and content issues in `routing-requests-to-rest-apis.md` so the article accurately reflects the current V3 implementation (Spring Cloud Gateway) and no longer mixes routing concepts with HA deployment architecture.

Changes:
- Replaced "In addition to the basic Zuul routing" with "In addition to basic routing" — Zuul is V2-only and no longer part of the V3 gateway
- Updated example URLs to use the V3 default gateway port (`7554`) instead of the old V2 ports (`10015`/`10010`)
- Fixed typo: "ditributing" → "distributing"
- Removed the empty "Implementation details for routing" heading
- Condensed the "Zowe architecture with high availability enablement on Sysplex" section (Sysplex/LPAR/zowe.yaml/VSAM details) into a brief "High availability" summary with a link to the existing dedicated page, `../configure-sysplex.md`, instead of duplicating that content here

Closes #5077

List the file(s) included in this PR:

- `docs/user-guide/api-mediation/routing-requests-to-rest-apis.md`

After creating the PR, follow the instructions in the comments.