### PR TITLE
replace allowEncodedSlashes with enableStrictUrlValidation

### DIFF
--- a/docs/appendix/zowe-yaml-configuration.md
+++ b/docs/appendix/zowe-yaml-configuration.md
@@ -693,8 +693,8 @@ User authorization is required to use the `IRR.RUSERMAP` resource within the `FA
 - **apiml.security.ssl.nonStrictVerifySslCertificatesOfServices**  
  Specifies if API ML is used to verify certificates of services in non-strict mode. Setting the value to `true` enables the `non-strict` mode where API ML validates if the certificate is trusted in the truststore, but ignores the certificate Common Name or Subject Alternate Name (SAN) check. Zowe ignores this configuration when `strict` mode is enabled with `apiml.security.ssl.verifySslCertificatesOfServices`.
 
-- **apiml.service.allowEncodedSlashes**  
- Specifies if the Gateway allows encoded characters to be part of URL requests redirected through the Gateway. Set to `true` to allow encoded characters to be part of URL requests. 
+- **apiml.security.enableStrictUrlValidation**  
+ Specifies whether the Gateway strictly validates request URLs. When set to `true` (default), the Gateway rejects requests containing encoded slashes, backslashes, semicolons, and similar encoded characters. When set to `false`, validation is relaxed for routed traffic, while Gateway-internal endpoints remain strictly validated. 
 
 - **apiml.service.corsEnabled**  
  Specifies if CORS are enabled in the API Gateway for Gateway routes `gateway/api/v1/**`. Set to `true` to enable CORS.

--- a/docs/troubleshoot/troubleshoot-apiml-error-codes.md
+++ b/docs/troubleshoot/troubleshoot-apiml-error-codes.md
@@ -1831,18 +1831,6 @@ Contact your administrator.
 
   Contact the system administrator and request enablement of encoded characters in the service.
 
-### ZWEAG702E
-
-  Gateway does not allow encoded slashes in request: `%s`.
-
-  **Reason:**
-
-  The request that was issued to the Gateway contains an encoded slash in the URL path. Gateway configuration does not allow this encoding in the URL.
-
-  **Action:**
-
-  Contact the system administrator and request enablement of encoded slashes in the Gateway.
-
 ### ZWEAG717E
 
   The service id provided is invalid: `%s`

--- a/docs/user-guide/advanced-apiml-configuration.md
+++ b/docs/user-guide/advanced-apiml-configuration.md
@@ -13,7 +13,7 @@ There are multiple options for customizing Zowe API Mediation Layer according to
 * [Customizing routing behavior](./api-mediation/configuration-routing.md)
     * [Configuring routing in a multi-tenant environment](./api-mediation/configuration-multi-tenancy-routing.md)
     * [Customizing Cross-Origin Resource Sharing (CORS)](./api-mediation/configuration-cors.md)
-    * [Using encoded slashes](./api-mediation/configuration-url-handling.md)
+    * [Using strict URL validation](./api-mediation/configuration-url-handling.md)
     * [Customizing Gateway retry policy](./api-mediation/configuration-gateway-retry-policy.md)
     * [Configuring a unique cookie name for a specific API ML instance](./api-mediation/configuration-unique-cookie-name-for-multiple-zowe-instances.md)
     * [Retrieving a specific service within your environment](./api-mediation/configuration-access-specific-instance-of-service.md)

--- a/docs/user-guide/api-mediation/configuration-routing.md
+++ b/docs/user-guide/api-mediation/configuration-routing.md
@@ -19,7 +19,7 @@ Customizing CORS enables the Gateway to handle Cross-Origin Resource Sharing req
 
 For more information, see [Customizing Cross-Origin Resource Sharing (CORS)](./configuration-cors.md)
 
-To onboard applications which expose endpoints that expect encoded slashes, see [Using encoded slashes](./configuration-url-handling.md)
+To onboard applications which expose endpoints that expect encoded slashes or other encoded characters, see [Using strict URL validation](./configuration-url-handling.md)
 
 The Gateway retry policy, customizable through zowe.yaml, optimizes request handling, which can be especially useful in high availability scenarios.
 

--- a/docs/user-guide/api-mediation/configuration-url-handling.md
+++ b/docs/user-guide/api-mediation/configuration-url-handling.md
@@ -1,14 +1,20 @@
-# Using encoded slashes
+# Using strict URL validation
 
 :::info Role: system programmer
 :::
 
-By default, the API Mediation Layer accepts encoded slashes in the URL path of the request. If you are onboarding applications which expose endpoints that expect encoded slashes, it is necessary to keep the default configuration. We recommend that you change the property to `false` if you do not expect the applications to use the encoded slashes. 
-    
-Use the following procedure to reject encoded slashes.
-    
+By default, the API Mediation Layer strictly validates request URLs and rejects requests whose path contains encoded characters such as encoded slashes (`%2F`), encoded double slashes, backslashes, encoded percent signs, encoded periods, or semicolons.
+
+:::note
+The `components.gateway.apiml.service.allowEncodedSlashes` property was removed in Zowe V3.5 in favor of `components.gateway.apiml.security.enableStrictUrlValidation`. If you previously set `allowEncodedSlashes: true` to permit encoded slashes, set `enableStrictUrlValidation` to `false` instead (note the inverse meaning).
+:::
+
+If you are onboarding applications that expose endpoints which expect any of these characters (for example, encoded slashes) in the URL path, you can relax validation for routed traffic. We recommend that you keep the default strict validation unless you have applications that require these characters.
+
+Use the following procedure to relax URL validation.
+
 1. Open the file `zowe.yaml`.
-2. Find or add the property `components.gateway.apiml.service.allowEncodedSlashes` and set the value to `false`.
-3. Restart Zowe. 
-    
-Requests with encoded slashes are now rejected by the API Mediation Layer.
+2. Find or add the property `components.gateway.apiml.security.enableStrictUrlValidation` and set the value to `false`.
+3. Restart Zowe.
+
+Requests routed through the Gateway that contain these characters are now accepted. Gateway-internal endpoints continue to be strictly validated regardless of this setting.


### PR DESCRIPTION
Describe your pull request here:
Documents API ML PRs zowe/api-layer#4830, zowe/api-layer#4812 which removed `apiml.service.allowEncodedSlashes` in favor of `apiml.security.enableStrictUrlValidation`. It is a security related breaking change.

List the file(s) included in this PR:
- **configuration-url-handling.md** — reworked "Using encoded slashes" into "Using strict URL validation"; added a note that `allowEncodedSlashes` was removed in V3.5 (inverse meaning: set `enableStrictUrlValidation: false` to permit encoded     
  slashes).                                                                                                                                                                                                                                             
- **zowe-yaml-configuration.md** — replaced the `allowEncodedSlashes` property entry with `enableStrictUrlValidation`.                                                                                                                                
- **troubleshoot-apiml-error-codes.md** — removed the retired `ZWEAG702E` error code.                                                                                                                                                                 
- **configuration-routing.md** / **advanced-apiml-configuration.md** — updated cross-links and sidebar label.   

After creating the PR, follow the instructions in the comments.
